### PR TITLE
chore: 迁移 npm 包名至 @dingtalk-real-ai/dingtalk-connector

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,13 +1,4 @@
 .git/
-.venv/
-__pycache__/
-*.py[cod]
-*.egg-info/
-dist/
-build/
-src/
-examples/
-pyproject.toml
-*.egg
+.claude/
 .env
 .gitignore

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ graph LR
 ### 1. 安装插件
 
 ```bash
-# 远程安装
+# 通过 npm 安装（推荐）
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector
+
+# 或通过 Git 安装
 openclaw plugins install https://github.com/DingTalk-Real-AI/dingtalk-moltbot-connector.git
 
 # 升级插件
@@ -197,7 +200,7 @@ dingtalk-moltbot-connector/
 rm -rf ~/.clawdbot/extensions/dingtalk-connector
 rm -rf ~/.moltbot/extensions/dingtalk-connector
 rm -rf ~/.openclaw/extensions/dingtalk-connector
-openclaw plugins install https://github.com/DingTalk-Real-AI/dingtalk-moltbot-connector.git
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector
 ```
 
 ### Q: 图片不显示

--- a/package.json
+++ b/package.json
@@ -1,15 +1,30 @@
 {
-  "name": "@openclaw/dingtalk-connector",
+  "name": "@dingtalk-real-ai/dingtalk-connector",
   "version": "0.6.0",
-  "description": "DingTalk (钉钉) channel plugin for OpenClaw — Stream mode with AI Card streaming",
+  "description": "DingTalk (钉钉) channel connector — Stream mode with AI Card streaming",
   "main": "plugin.ts",
   "type": "module",
   "scripts": {
     "build": "echo 'No build needed - jiti loads TS at runtime'"
   },
-  "keywords": ["openclaw", "dingtalk", "channel", "stream", "ai-card"],
+  "keywords": [
+    "dingtalk",
+    "channel",
+    "stream",
+    "ai-card",
+    "connector"
+  ],
   "author": "DingTalk Real Team",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DingTalk-Real-AI/dingtalk-moltbot-connector.git"
+  },
+  "homepage": "https://github.com/DingTalk-Real-AI/dingtalk-moltbot-connector#readme",
+  "bugs": "https://github.com/DingTalk-Real-AI/dingtalk-moltbot-connector/issues",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "dingtalk-stream": "^2.1.4",
     "axios": "^1.6.0",
@@ -17,8 +32,12 @@
     "@ffmpeg-installer/ffmpeg": "^1.1.0"
   },
   "openclaw": {
-    "extensions": ["./plugin.ts"],
-    "channels": ["dingtalk-connector"],
+    "extensions": [
+      "./plugin.ts"
+    ],
+    "channels": [
+      "dingtalk-connector"
+    ],
     "installDependencies": true
   }
 }


### PR DESCRIPTION
## 变更内容

将 npm 包从 `@openclaw/dingtalk-connector` 迁移至 `@dingtalk-real-ai/dingtalk-connector`，已发布 v0.6.0 到 npm。

### 改动
- **package.json**: 更新包名、描述、keywords，添加 repository/homepage/bugs/publishConfig 字段
- **.npmignore**: 清理无关的 Python 条目
- **README.md**: 安装方式优先使用 `openclaw plugins install @dingtalk-real-ai/dingtalk-connector`

### 验证
```bash
openclaw plugins install @dingtalk-real-ai/dingtalk-connector
```