### PR TITLE
fix: 更新plugin.ts文件，解决钉钉 channel agent workspace 配置未生效的问题

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -1099,6 +1099,9 @@ async function* streamFromGateway(options: GatewayOptions): AsyncGenerator<strin
   if (gatewayAuth) {
     headers['Authorization'] = `Bearer ${gatewayAuth}`;
   }
+  if (sessionKey) {
+    headers['x-openclaw-session-key'] = sessionKey;
+  }
 
   log?.info?.(`[DingTalk][Gateway] POST ${gatewayUrl}, session=${sessionKey}, messages=${messages.length}`);
 
@@ -1109,7 +1112,6 @@ async function* streamFromGateway(options: GatewayOptions): AsyncGenerator<strin
       model: 'default',
       messages,
       stream: true,
-      user: sessionKey,  // 用于 session 持久化
     }),
   });
 
@@ -2053,10 +2055,13 @@ async function handleDingTalkMessage(params: {
 
     try {
       log?.info?.(`[DingTalk] 开始请求 Gateway 流式接口...`);
+      // 🆕 使用 agentId 指定目标 agent
+      const agentSessionKey = dingtalkConfig.agentId ? `agent:${dingtalkConfig.agentId}:${sessionKey}` : sessionKey;
+      
       for await (const chunk of streamFromGateway({
         userContent: content.text,
         systemPrompts,
-        sessionKey,
+        sessionKey: agentSessionKey,  // 🆕 使用带 agent 的 session key
         gatewayAuth,
         log,
       })) {
@@ -2132,10 +2137,13 @@ async function handleDingTalkMessage(params: {
 
     let fullResponse = '';
     try {
+      // 🆕 使用 agentId 指定目标 agent
+      const agentSessionKey = dingtalkConfig.agentId ? `agent:${dingtalkConfig.agentId}:${sessionKey}` : sessionKey;
+      
       for await (const chunk of streamFromGateway({
         userContent: content.text,
         systemPrompts,
-        sessionKey,
+        sessionKey: agentSessionKey,  // 🆕 使用带 agent 的 session key
         gatewayAuth,
         log,
       })) {


### PR DESCRIPTION
fix：更新plugin.ts，解决如下问题：
当 OpenClaw 配置了多个 agent 并通过 bindings 绑定到不同 channel 时，dingtalk-connector 插件无法正确使用绑定 agent 的 workspace。

---

## 修复方案

### 改动点 1：使用 HTTP Header 传递 Session Key

**文件**: `plugin.ts`  
**函数**: `streamFromGateway`  

```diff
  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
  if (gatewayAuth) {
    headers['Authorization'] = `Bearer ${gatewayAuth}`;
  }
+ if (sessionKey) {
+   headers['x-openclaw-session-key'] = sessionKey;
+ }

  log?.info?.(`[DingTalk][Gateway] POST ${gatewayUrl}, session=${sessionKey}, messages=${messages.length}`);

  const response = await fetch(gatewayUrl, {
    method: 'POST',
    headers,
    body: JSON.stringify({
      model: 'default',
      messages,
      stream: true,
-     user: sessionKey,  // 用于 session 持久化
    }),
  });
```

### 改动点 2：支持从 Channel 配置读取 agentId

**文件**: `plugin.ts`  
**函数**: `handleDingTalkMessage`  
**位置**: （AI Card 模式）和 （降级模式）

```diff
+ // 使用 agentId 指定目标 agent
+ const agentSessionKey = dingtalkConfig.agentId 
+   ? `agent:${dingtalkConfig.agentId}:${sessionKey}` 
+   : sessionKey;

  for await (const chunk of streamFromGateway({
    userContent: content.text,
    systemPrompts,
-   sessionKey,
+   sessionKey: agentSessionKey,  // 使用带 agent 的 session key
    gatewayAuth,
    log,
  })) {
```

---
---

## 影响范围

| 项目 | 说明 |
|------|------|
| **向后兼容** | ✅ 完全兼容，无需修改现有配置 |
| **默认行为** | 未配置 `agentId` 时行为不变，使用 main agent |
| **配置方式** | 支持两种方式指定 agent：bindings 或 channel 配置 |

---

## 使用方式

### 方式 1：通过 Bindings 配置（推荐）

```json
{
  "bindings": [
    {
      "agentId": "dingtalk-main",
      "match": { "channel": "dingtalk-connector" }
    }
  ]
}
```

### 方式 2：通过 Channel 配置

```json
{
  "channels": {
    "dingtalk-connector": {
      "clientId": "your-client-id",
      "clientSecret": "your-client-secret",
      "agentId": "dingtalk-main"
    }
  }
}
```

---