### PR TITLE
feat: 富文本/图片/文件附件/知识库文档支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "dingtalk-stream": "^2.1.4",
     "axios": "^1.6.0",
     "fluent-ffmpeg": "^2.1.3",
-    "@ffmpeg-installer/ffmpeg": "^1.1.0"
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
+    "mammoth": "^1.8.0",
+    "pdf-parse": "^1.1.1"
   },
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## 概述

本 PR 为 dingtalk-openclaw-connector 插件新增三项核心能力，使机器人能够理解用户发送的富媒体内容：图片、文件附件（.docx/.pdf 等），以及对钉钉知识库文档的读取支持。

## 变更内容

### 1. 富文本消息解析（Rich Text）
- 正确处理 `msgtype=richText` 类型消息
- 提取富文本中的文字段落和图片 downloadCode，分别处理

### 2. 图片分析支持
- 新增 `downloadImageToFile()` 函数：通过 `/v1.0/robot/messageFiles/download` 下载图片到本地
- 图片保存至 `~/.openclaw/workspace/media/inbound/`（OpenClaw workspace 安全目录）
- 消息内容嵌入 `![image](file:///path)` 格式，OpenClaw 自动识别并传给 Claude 视觉分析
- **修复**：原实现使用 base64 image_url，OpenClaw 不支持此格式

### 3. 文件附件支持
- 新增 `downloadFileByCode()` 函数：通过 `/v1.0/robot/messageFiles/download` 下载文件
- 文本类（.txt / .md / .csv / .json / .xml 等）：直接读取内容追加到对话
- Word 文档（.docx）：使用 mammoth 库提取纯文本
- PDF 文档（.pdf）：使用 pdf-parse 库提取文本
- 其他格式：提示文件已保存的本地路径

### 4. 钉钉知识库文档读取（DingtalkDocsClient）
- 使用正确的 `GET /v2.0/wiki/nodes/{nodeId}` API 获取节点信息
- 通过 oapi 接口将 staffId 转换为 unionId（知识库 API 必要参数）
- 新增 `registerGatewayMethod('dingtalk-connector.docs.read')` 供外部调用

## 关键修复

| 问题 | 修复方式 |
|------|----------|
| 图片通过 base64 image_url 传递，OpenClaw 不透传 | 改为保存本地文件，用 file:// 路径 |
| mammoth 依赖缺失导致 docx 解析失败 | npm install 完整依赖并同步 |
| 知识库 API 使用旧版 /v1.0/doc/workspaces | 切换至正确的 /v2.0/wiki/workspaces 和 /v2.0/wiki/nodes |

## 依赖变更

新增：
- `mammoth`：Word 文档文本提取
- `pdf-parse`：PDF 文本提取

## 测试验证

- [x] 图片消息 → Claude 成功识别图片内容
- [x] .md 文件 → 内容直接读取并传入对话
- [x] .docx 文件 → mammoth 提取文本正常
- [x] 知识库节点信息读取（GET /v2.0/wiki/nodes）

## Commits

- `3c6f44e` feat: add rich text, image/attachment, and docs support
- `585e528` fix: use local file path for image passing instead of base64 image_url
- `42260d0` fix: save inbound media to workspace dir for OpenClaw access
- `796a2e5` feat: support file attachment download and content extraction
- `c56c3d6` fix: use v2.0/wiki API for docs, add unionId resolution
- `422bad3` fix: use correct file download API and add docx/pdf text extraction
