### PR TITLE
feat: add rich media reception, file attachment extraction, and DingTalk Docs API integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "dingtalk-stream": "^2.1.4",
     "axios": "^1.6.0",
     "fluent-ffmpeg": "^2.1.3",
-    "@ffmpeg-installer/ffmpeg": "^1.1.0"
+    "@ffmpeg-installer/ffmpeg": "^1.1.0",
+    "mammoth": "^1.8.0",
+    "pdf-parse": "^1.1.1"
   },
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
## Overview

This PR introduces three major capability areas to the DingTalk OpenClaw connector:

1. **Rich media reception** — images and rich-text messages from DingTalk are now downloaded to local files and forwarded to the OpenClaw vision model.
2. **File attachment extraction** — `.docx`, `.pdf`, and plain-text file attachments are parsed and their textual content is injected into the AI context.
3. **DingTalk Docs / Wiki integration** — a new `DingtalkDocsClient` class and five Gateway Methods allow the AI agent to read, create, append, search, and list documents in DingTalk Spaces.

---

## Detailed Changes

### 1. Rich Text & Image Support (`richText` / `picture` messages)

**Problem:** The previous implementation discarded embedded images inside `richText` messages and returned a bare `[图片]` placeholder for `picture`-type messages. The AI had no visibility into visual content sent by users.

**Solution:**
- Refactored `extractMessageContent` to return a richer `ExtractedMessage` interface:
  ```ts
  interface ExtractedMessage {
    text: string;
    messageType: string;
    imageUrls: string[];      // direct CDN URLs found inline
    downloadCodes: string[];  // DingTalk downloadCode tokens
    fileNames: string[];      // original file names for file messages
  }
  ```
- For `richText` payloads, every `pictureUrl` and `downloadCode` in each segment is now collected alongside text segments.
- For `picture` messages, both `pictureUrl` and `downloadCode` are extracted.

### 2. Media Download Pipeline

Three new async helpers form the download pipeline:

| Function | Description |
|---|---|
| `downloadImageToFile(url)` | Downloads any image URL → local `~/.openclaw/workspace/media/inbound/` temp file, returns absolute path |
| `downloadMediaByCode(downloadCode, config)` | Exchanges a DingTalk `downloadCode` for a presigned URL via `POST /v1.0/robot/messageFiles/download`, then calls `downloadImageToFile` |
| `downloadFileByCode(downloadCode, fileName, config)` | Same exchange, but preserves original `fileName` for non-image attachments |

All functions write to `~/.openclaw/workspace/media/inbound/` so OpenClaw's media-inbound directory conventions are respected and files survive across plugin restarts.

### 3. OpenClaw AgentMediaPayload Integration

`streamFromGateway` now accepts an `imageLocalPaths?: string[]` option. When populated, local file paths are embedded as Markdown image references:

```
![image](file:///Users/.../.openclaw/workspace/media/inbound/openclaw-media-xxx.jpg)
```

OpenClaw's `AgentMediaPayload` mechanism detects these references and uploads the files to the vision model transparently — no base64 encoding, no size limits from in-memory buffers.

### 4. File Content Extraction

When a user sends a file attachment the connector now:

1. Downloads it via `downloadFileByCode`.
2. Inspects the extension:
   - **Text class** (`.txt`, `.md`, `.csv`, `.json`, `.xml`, `.yaml`, `.html`, `.sh`, `.py`, `.js`, `.ts`, `.css`, `.sql`, …): reads directly, prepends content to user message.
   - **`.docx`**: parses with [mammoth](https://github.com/mwilliamson/mammoth.js) → plain text → injected into message.
   - **`.pdf`**: parses with [pdf-parse](https://www.npmjs.com/package/pdf-parse) → plain text → injected into message.
   - **Binary/Office** (`.xlsx`, `.pptx`, `.zip`, …): saved to disk; path and file name reported in message context.

### 5. DingTalk Docs / Wiki Integration

New `DingtalkDocsClient` class wrapping two DingTalk API namespaces:

**Wiki v2 (read):**
`GET https://api.dingtalk.com/v2.0/wiki/spaces/{spaceId}/nodes/{nodeId}/contents/rich-text`

**Doc v1 (write/search/list):**
| Operation | Endpoint |
|---|---|
| Append content | `PUT /v1.0/doc/docs/{docId}/markdownContent` |
| Create document | `POST /v1.0/doc/spaces/{spaceId}/docs` |
| Search documents | `POST /v1.0/doc/docs/search` |
| List dentries | `GET /v1.0/doc/spaces/{spaceId}/dentries` |

Five new Gateway Methods registered at plugin startup make these capabilities callable from within an OpenClaw agent turn:

```
dingtalk-connector.docs.read    — read a wiki node by docId + operatorId
dingtalk-connector.docs.create  — create a new doc in a space
dingtalk-connector.docs.append  — append Markdown content to an existing doc
dingtalk-connector.docs.search  — full-text search across docs
dingtalk-connector.docs.list    — list dentries in a space/directory
```

### 6. staffId → unionId Resolution

The Docs API requires a `unionId` as the operator identifier, but incoming DingTalk robot messages carry only `staffId`. A new `getUnionId(staffId, config)` helper:
- Calls `GET https://oapi.dingtalk.com/user/get?userid={staffId}` using an OAPI access token.
- Caches results in a `Map<string, string>` for the plugin lifetime.
- Added `DINGTALK_OAPI = 'https://oapi.dingtalk.com'` constant alongside the existing `DINGTALK_API`.

### 7. New Dependencies

| Package | Version | Purpose |
|---|---|---|
| `mammoth` | `^1.8.0` | `.docx` → plain text conversion |
| `pdf-parse` | `^1.1.1` | `.pdf` → plain text extraction |

Both are well-maintained, MIT-licensed libraries with no native module requirements.

---

## Testing

All changes were manually validated against a live DingTalk robot:

| Scenario | Result |
|---|---|
| Send a JPEG photo in chat | Downloaded → passed to vision model → correct image description ✅ |
| Send a PNG in richText | Extracted from richText segments → downloaded → vision inference ✅ |
| Send a `.docx` file | Text extracted via mammoth → summarised by model ✅ |
| Send a `.pdf` file | Text extracted via pdf-parse → summarised ✅ |
| Send a plain `.txt` file | Content read directly → injected into context ✅ |
| `docs.read` gateway method | Wiki node content returned ✅ |
| `docs.create` + `docs.append` | Document created and populated ✅ |
| `docs.search` | Full-text search returned relevant results ✅ |
| Text-only messages (no media) | No regression, behaviour unchanged ✅ |

---

## Backward Compatibility

All changes are **strictly additive**:

- `extractMessageContent`'s new fields (`imageUrls`, `downloadCodes`, `fileNames`) default to empty arrays — any existing caller that only reads `text` / `messageType` is unaffected.
- `streamFromGateway`'s new `imageLocalPaths` option is optional; omitting it preserves the existing code path exactly.
- The five Docs gateway methods are newly registered and do not shadow or replace any existing ones.
- No existing message handling path is modified; new branches are added exclusively.

---

## Checklist

- [x] Code compiles without TypeScript errors (`tsc --noEmit`)
- [x] No breaking changes to existing message handling
- [x] New dependencies documented in `package.json`
- [x] All new public symbols exported from the module entry point
- [x] Tested end-to-end against live DingTalk robot