### PR TITLE
feat: async mode with per-user switching

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2582,7 +2582,6 @@ async function handleDingTalkMessage(params: {
   }
 
   // AI Card 延迟创建：先缓冲响应，确认不是静默回复后再创建卡片
-  // 超时兜底：如果 1.5 秒内没有结论（LLM 在思考），先创建卡片显示 thinking 状态
   {
     let accumulated = '';
     let lastUpdateTime = 0;
@@ -2590,21 +2589,6 @@ async function handleDingTalkMessage(params: {
     let chunkCount = 0;
     let card: AICardInstance | null = null;
     let cardCreationFailed = false;
-    const streamStartTime = Date.now();
-    const SILENT_CHECK_TIMEOUT = 1500; // 1.5 秒内 NO_REPLY 应该已到达
-
-    // 启动超时兜底：1.5s 后如果还没创建卡片且还在缓冲，先创建
-    const cardTimeoutId = setTimeout(async () => {
-      if (!card && !cardCreationFailed && !isSilentReply(accumulated.trim())) {
-        log?.info?.(`[DingTalk] 超时兜底：1.5s 未收到完整静默回复，预创建 AI Card`);
-        card = await createAICard(dingtalkConfig, data, log);
-        if (card) {
-          log?.info?.(`[DingTalk] AI Card 超时预创建成功: ${card.cardInstanceId}`);
-        } else {
-          cardCreationFailed = true;
-        }
-      }
-    }, SILENT_CHECK_TIMEOUT);
 
     try {
       log?.info?.(`[DingTalk] 开始请求 Gateway 流式接口...`);
@@ -2630,7 +2614,6 @@ async function handleDingTalkMessage(params: {
         }
 
         // 确认不是静默，创建 AI Card（如果超时兜底没创建的话）
-        clearTimeout(cardTimeoutId);
         if (!card && !cardCreationFailed) {
           card = await createAICard(dingtalkConfig, data, log);
           if (card) {
@@ -2657,7 +2640,6 @@ async function handleDingTalkMessage(params: {
       }
 
       log?.info?.(`[DingTalk] Gateway 流完成，共 ${chunkCount} chunks, ${accumulated.length} 字符`);
-      clearTimeout(cardTimeoutId);
 
       // 静默回复：不创建卡片，直接返回
       if (isSilentReply(accumulated.trim())) {


### PR DESCRIPTION
## Summary

为钉钉 connector 新增异步模式，支持用户级别的模式切换，并修复 NO_REPLY 泄露和空白卡片问题。

### 功能一：异步模式（Async Mode）
- 收到消息后立即发送回执确认（默认 `🫡 任务已接收，处理中...`，可通过 `ackText` 自定义）
- 后台调用 Gateway 完成处理
- 处理完成后通过主动消息 API 推送最终结果

### 功能二：用户级模式切换
- 默认使用**流式卡片模式**（AI Card Streaming）
- 用户可随时通过命令切换：

| 命令 | 效果 |
|------|------|
| `/async` 或 `异步模式` | 切换到异步模式 |
| `/stream`、`/sync` 或 `流式模式` | 切回流式卡片模式 |

- 模式状态存储在用户 session 中，会话超时或 `/new` 后重置
- 配置项 `asyncMode` 作为新用户的默认值

### Bug 修复：NO_REPLY 泄露与空白卡片
- **问题：** Gateway 识别 `NO_REPLY` 后截断 SSE 流，connector 只收到 `NO` 或 `NO_` 残片，被当作正常内容显示给用户
- **修复：**
  1. `isSilentReply()` 支持前缀匹配（`NO`、`NO_`、`NO_REPLY` 均视为静默），忽略大小写
  2. AI Card 延迟创建：先缓冲响应，确认不是静默回复后才创建卡片
  3. 静默回复时不创建任何卡片，彻底消除空白气泡
  4. 异步模式下静默回复跳过结果推送
  5. 异步模式 `streamFromGateway` 补全 `accountId` 参数，修复 agent 路由错乱

## 配置

```yaml
channels:
  dingtalk-connector:
    asyncMode: false          # 新用户默认模式，默认 false（流式卡片）
    ackText: "🫡 任务已接收，处理中..."  # 异步模式回执文本
```

## 技术细节

- `UserSession` 新增 `asyncMode: boolean` 字段
- `isModeSwitch()` 识别模式切换命令
- `isSilentReply()` / `couldBeSilentReply()` 前缀匹配，大小写不敏感
- AI Card 延迟创建：流式循环内首次确认非静默后才调用 `createAICard()`
- 回滚安全：不设置 `asyncMode` 或设为 `false`，行为与改动前一致