### PR TITLE
fix: add robotCode to imRobotOpenDeliverModel for private chat routing

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -1508,7 +1508,7 @@ function buildDeliverBody(
   return {
     ...base,
     openSpaceId: `dtv1.card//IM_ROBOT.${target.userId}`,
-    imRobotOpenDeliverModel: { spaceType: 'IM_ROBOT' },
+    imRobotOpenDeliverModel: { spaceType: 'IM_ROBOT', robotCode },
   };
 }
 


### PR DESCRIPTION
When multiple DingTalk bots are configured, all private chat replies were being sent from the wrong bot because imRobotOpenDeliverModel was missing the robotCode parameter.

This fix adds robotCode to imRobotOpenDeliverModel, consistent with imGroupOpenDeliverModel which already had robotCode.

Fixes: private chat messages now correctly route to the intended bot.