### PR TITLE
fix: 修复语音消息时长始终显示 1:00 的问题

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -842,6 +842,71 @@ async function sendFileMessage(
 }
 
 /**
+ * 获取 ffprobe 可执行文件路径
+ * 优先级: @ffprobe-installer/ffprobe > FFPROBE_PATH 环境变量 > 系统 PATH
+ */
+function getFfprobePath(): string {
+  // 1. 尝试 @ffprobe-installer/ffprobe 包
+  try {
+    const ffprobePath = require('@ffprobe-installer/ffprobe').path;
+    if (ffprobePath) return ffprobePath;
+  } catch { /* 未安装，跳过 */ }
+
+  // 2. 尝试环境变量
+  if (process.env.FFPROBE_PATH) return process.env.FFPROBE_PATH;
+
+  // 3. fallback 到系统 PATH
+  return 'ffprobe';
+}
+
+/**
+ * 提取音频文件时长（毫秒）
+ * 使用 ffprobe CLI 直接获取，避免 fluent-ffmpeg 在部分运行环境中回调不触发的问题
+ */
+async function extractAudioDuration(
+  filePath: string,
+  log?: any,
+): Promise<number | null> {
+  try {
+    const { execFile } = require('child_process');
+    const ffprobeBin = getFfprobePath();
+
+    return new Promise((resolve) => {
+      execFile(ffprobeBin, [
+        '-v', 'quiet',
+        '-print_format', 'json',
+        '-show_format',
+        filePath,
+      ], { timeout: 10_000 }, (err: any, stdout: string, stderr: string) => {
+        if (err) {
+          log?.error?.(`[DingTalk][Audio] ffprobe 执行失败 (${ffprobeBin}): ${err.message}`);
+          return resolve(null);
+        }
+
+        try {
+          const parsed = JSON.parse(stdout);
+          const durationSec = parseFloat(parsed?.format?.duration);
+          if (isNaN(durationSec)) {
+            log?.warn?.(`[DingTalk][Audio] 无法解析音频时长，ffprobe 输出: ${stdout.slice(0, 200)}`);
+            return resolve(null);
+          }
+
+          const durationMs = Math.floor(durationSec * 1000);
+          log?.info?.(`[DingTalk][Audio] 音频时长: ${durationMs}ms (${durationSec}s)`);
+          resolve(durationMs);
+        } catch (parseErr: any) {
+          log?.error?.(`[DingTalk][Audio] ffprobe 输出解析失败: ${parseErr.message}`);
+          resolve(null);
+        }
+      });
+    });
+  } catch (err: any) {
+    log?.error?.(`[DingTalk][Audio] extractAudioDuration 异常: ${err.message}`);
+    return null;
+  }
+}
+
+/**
  * 发送音频消息到钉钉（被动回复场景）
  */
 async function sendAudioMessage(
@@ -851,14 +916,16 @@ async function sendAudioMessage(
   mediaId: string,
   oapiToken: string,
   log?: any,
+  durationMs?: number,
 ): Promise<void> {
   try {
     // 钉钉语音消息格式
+    const actualDuration = (durationMs && durationMs > 0) ? durationMs.toString() : '60000';
     const audioMessage = {
       msgtype: 'voice',
       voice: {
         mediaId: mediaId,
-        duration: '60000',  // 默认时长，单位毫秒
+        duration: actualDuration,
       },
     };
 
@@ -936,12 +1003,14 @@ async function processFileMarkers(
       // 音频文件使用 voice 类型上传
       const mediaId = await uploadMediaToDingTalk(fileInfo.path, 'voice', oapiToken, MAX_FILE_SIZE, log);
       if (mediaId) {
+        // 提取音频实际时长
+        const audioDurationMs = await extractAudioDuration(fileInfo.path, log);
         if (useProactiveApi && target) {
           // 使用主动消息 API（适用于 AI Card 场景）
-          await sendAudioProactive(config, target, fileInfo, mediaId, log);
+          await sendAudioProactive(config, target, fileInfo, mediaId, log, audioDurationMs ?? undefined);
         } else {
           // 使用 sessionWebhook（传统被动回复场景）
-          await sendAudioMessage(config, sessionWebhook, fileInfo, mediaId, oapiToken, log);
+          await sendAudioMessage(config, sessionWebhook, fileInfo, mediaId, oapiToken, log, audioDurationMs ?? undefined);
         }
         statusMessages.push(`✅ 音频已发送: ${fileInfo.fileName}`);
       } else {
@@ -1626,14 +1695,16 @@ async function sendAudioProactive(
   fileInfo: FileInfo,
   mediaId: string,
   log?: any,
+  durationMs?: number,
 ): Promise<void> {
   try {
     const token = await getAccessToken(config);
 
     // 钉钉普通消息 API 的音频消息格式
+    const actualDuration = (durationMs && durationMs > 0) ? durationMs.toString() : '60000';
     const msgParam = {
       mediaId: mediaId,
-      duration: '60000',  // 默认时长，单位毫秒
+      duration: actualDuration,
     };
 
     const body: any = {
@@ -1806,11 +1877,14 @@ async function processAudioMarkers(
         continue;
       }
 
+      // 提取音频实际时长
+      const audioDurationMs = await extractAudioDuration(audioInfo.path, log);
+
       // 发送音频消息
       if (useProactiveApi && target) {
-        await sendAudioProactive(config, target, fileInfo, mediaId, log);
+        await sendAudioProactive(config, target, fileInfo, mediaId, log, audioDurationMs ?? undefined);
       } else {
-        await sendAudioMessage(config, sessionWebhook, fileInfo, mediaId, oapiToken, log);
+        await sendAudioMessage(config, sessionWebhook, fileInfo, mediaId, oapiToken, log, audioDurationMs ?? undefined);
       }
       statusMessages.push(`✅ 音频已发送: ${fileName}`);
       log?.info?.(`${logPrefix} 音频处理完成: ${fileName}`);


### PR DESCRIPTION
## 问题

发送语音消息时，钉钉客户端始终显示时长为 **1:00**，而非音频的实际时长。

## 原因

`sendAudioMessage` 和 `sendAudioProactive` 中 `duration` 字段硬编码为 `'60000'`（60000ms = 60s = 1:00），没有提取音频文件的实际时长。

## 修复

- 新增 `extractAudioDuration()` 函数，使用 `ffprobe` CLI 提取音频实际时长（毫秒）
- 新增 `getFfprobePath()` 支持多种 ffprobe 查找方式：
  1. `@ffprobe-installer/ffprobe` 包（如果安装了）
  2. `FFPROBE_PATH` 环境变量
  3. 系统 PATH 中的 `ffprobe`
- `sendAudioMessage` / `sendAudioProactive` 新增可选参数 `durationMs`
- `processFileMarkers` / `processAudioMarkers` 在发送前提取时长并传入

## 兼容性

- **无 breaking change**：`durationMs` 为可选参数，不传时 fallback 到原有的 `60000` 默认值
- **无新依赖**：使用 Node.js 内置的 `child_process.execFile` 调用系统 ffprobe
- **graceful degradation**：ffprobe 不可用时静默 fallback，不影响消息发送

## 测试

已在 macOS (arm64) + OpenClaw gateway 环境中验证，修复后钉钉客户端正确显示音频实际时长。