### PR TITLE
feat: async mode for immediate ack and deferred result push

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -1219,8 +1219,10 @@ async function* streamFromGateway(options: GatewayOptions, accountId: string): A
   if (gatewayAuth) {
     headers['Authorization'] = `Bearer ${gatewayAuth}`;
   }
-  // 使用 HTTP Header 传递 accountId 用于 agent 路由
-  headers['X-OpenClaw-Agent-Id'] = accountId;
+  // 使用 HTTP Header 传递 accountId 用于 agent 路由（'default' 不发，让 gateway 路由到默认 agent）
+  if (accountId && accountId !== 'default') {
+    headers['X-OpenClaw-Agent-Id'] = accountId;
+  }
 
   log?.info?.(`[DingTalk][Gateway] POST ${gatewayUrl}, session=${sessionKey}, accountId=${accountId}, messages=${messages.length}`);
 
@@ -2467,12 +2469,13 @@ async function handleDingTalkMessage(params: {
     let fullResponse = '';
     try {
       for await (const chunk of streamFromGateway({
-        userContent: content.text,
+        userContent,
         systemPrompts,
         sessionKey,
         gatewayAuth,
+        imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
         log,
-      })) {
+      }, accountId)) {
         fullResponse += chunk;
       }
 


### PR DESCRIPTION
## What

Add async mode: immediately acknowledge user messages, process in background, then push the final result as a separate message.

### Changes

Based on the first commit of #83, with critical bug fixes:

1. **Fix agent routing in async mode** — `streamFromGateway` was called without `accountId`, causing sessions to route to `undefined` agent
2. **Fix default agent routing** — Skip `X-OpenClaw-Agent-Id` header when accountId is `default`, letting gateway route to its configured default agent
3. **Fix async mode content** — Use `userContent` (includes file attachments) instead of raw `content.text`
4. **Add image support for async mode** — Pass `imageLocalPaths` to gateway stream

### Config

```yaml
channels:
  dingtalk-connector:
    asyncMode: true          # Enable async mode (default: false)
    ackText: '🫡 任务已接收'  # Custom ack message (optional)
```

Supersedes #83.