### PR TITLE
fix: enforce dmPolicy allowlist check in plugin layer

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2302,6 +2302,16 @@ async function handleDingTalkMessage(params: {
 
   log?.info?.(`[DingTalk] 收到消息: from=${senderName} type=${content.messageType} text="${content.text.slice(0, 50)}..." images=${content.imageUrls.length} downloadCodes=${content.downloadCodes.length}`);
 
+  // ===== DM Policy 检查 =====
+  if (isDirect) {
+    const dmPolicy = dingtalkConfig.dmPolicy || 'open';
+    const allowFrom: string[] = dingtalkConfig.allowFrom || [];
+    if (dmPolicy === 'allowlist' && allowFrom.length > 0 && !allowFrom.includes(senderId)) {
+      log?.warn?.(`[DingTalk] DM 被拦截: senderId=${senderId} 不在 allowFrom 白名单中`);
+      return;
+    }
+  }
+
   // ===== Session 管理 =====
   const sessionTimeout = dingtalkConfig.sessionTimeout ?? 1800000; // 默认 30 分钟
   const forceNewSession = isNewSessionCommand(content.text);


### PR DESCRIPTION
## 问题

`dmPolicy: allowlist` 和 `allowFrom` 配置了白名单，但实际上没有起作用。非白名单用户发的 DM 仍然会被处理、转发到 Gateway 并得到响应。

## 根本原因

`resolveDmPolicy` 只是向 Gateway 声明策略配置，但 plugin 本身从未真正执行拦截逻辑。消息到达后直接进入 session 管理和 Gateway 调用流程，没有任何 allowlist 检查。

## 修复

在 `handleDingTalkMessage` 的消息处理入口（session 创建之前）加入硬检查：

```typescript
if (isDirect) {
  const dmPolicy = dingtalkConfig.dmPolicy || 'open';
  const allowFrom: string[] = dingtalkConfig.allowFrom || [];
  if (dmPolicy === 'allowlist' && allowFrom.length > 0 && !allowFrom.includes(senderId)) {
    log?.warn?.(`[DingTalk] DM 被拦截: senderId=${senderId} 不在 allowFrom 白名单中`);
    return;
  }
}
```

## 逻辑说明

三个条件同时满足才拦截，保证向后兼容：
- `dmPolicy === 'allowlist'`：只在明确配置 allowlist 时生效
- `allowFrom.length > 0`：白名单为空时不拦截（防止配置失误把所有人锁死）
- `!allowFrom.includes(senderId)`：用 `senderStaffId` 做匹配，与配置字段一致

## 测试

配置 `dmPolicy: allowlist`, `allowFrom: ["398058"]`，非白名单用户发 DM 后日志显示：
`[DingTalk] DM 被拦截: senderId=042117 不在 allowFrom 白名单中`，Gateway 不再收到请求。