### PR TITLE
fix: enforce dmPolicy allowlist check in plugin layer

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2302,6 +2302,16 @@ async function handleDingTalkMessage(params: {
 
   log?.info?.(`[DingTalk] 收到消息: from=${senderName} type=${content.messageType} text="${content.text.slice(0, 50)}..." images=${content.imageUrls.length} downloadCodes=${content.downloadCodes.length}`);
 
+  // ===== DM Policy 检查 =====
+  if (isDirect) {
+    const dmPolicy = dingtalkConfig.dmPolicy || 'open';
+    const allowFrom: string[] = dingtalkConfig.allowFrom || [];
+    if (dmPolicy === 'allowlist' && allowFrom.length > 0 && !allowFrom.includes(senderId)) {
+      log?.warn?.(`[DingTalk] DM 被拦截: senderId=${senderId} 不在 allowFrom 白名单中`);
+      return;
+    }
+  }
+
   // ===== Session 管理 =====
   const sessionTimeout = dingtalkConfig.sessionTimeout ?? 1800000; // 默认 30 分钟
   const forceNewSession = isNewSessionCommand(content.text);


### PR DESCRIPTION
## 问题

`dmPolicy: allowlist` 和 `allowFrom` 配置了白名单，但实际上没有起作用。非白名单用户发的 DM 仍然会被处理。

## 修复

在消息处理入口加入硬检查：

```typescript
if (isDirect) {
  const dmPolicy = dingtalkConfig.dmPolicy || 'open';
  const allowFrom: string[] = dingtalkConfig.allowFrom || [];
  if (dmPolicy === 'allowlist' && allowFrom.length > 0 && !allowFrom.includes(senderId)) {
    log?.warn?.(`[DingTalk] DM 被拦截: senderId=${senderId} 不在 allowFrom 白名单中`);
    return;
  }
}
```

## 测试

配置 `dmPolicy: allowlist`, `allowFrom: ["398058"]`，非白名单用户发 DM 后日志显示被拦截，Gateway 不再收到请求。