### PR TITLE
fix: enforce dmPolicy allowlist check in plugin layer

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2317,6 +2317,16 @@ async function handleDingTalkMessage(params: {
 
   log?.info?.(`[DingTalk] 收到消息: from=${senderName} type=${content.messageType} text="${content.text.slice(0, 50)}..." images=${content.imageUrls.length} downloadCodes=${content.downloadCodes.length}`);
 
+  // ===== DM Policy 检查 =====
+  if (isDirect) {
+    const dmPolicy = dingtalkConfig.dmPolicy || 'open';
+    const allowFrom: string[] = dingtalkConfig.allowFrom || [];
+    if (dmPolicy === 'allowlist' && allowFrom.length > 0 && !allowFrom.includes(senderId)) {
+      log?.warn?.(`[DingTalk] DM 被拦截: senderId=${senderId} 不在 allowFrom 白名单中`);
+      return;
+    }
+  }
+
   // ===== Session 管理 =====
   const sessionTimeout = dingtalkConfig.sessionTimeout ?? 1800000; // 默认 30 分钟
   const forceNewSession = isNewSessionCommand(content.text);


### PR DESCRIPTION
## 问题

`dmPolicy: allowlist` 配置了白名单但没有实际拦截非白名单用户。

## 修复

在消息处理入口加入硬检查：

```typescript
if (isDirect) {
  const dmPolicy = dingtalkConfig.dmPolicy || 'open';
  const allowFrom: string[] = dingtalkConfig.allowFrom || [];
  if (dmPolicy === 'allowlist' && allowFrom.length > 0 && !allowFrom.includes(senderId)) {
    log?.warn?.(`[DingTalk] DM 被拦截: senderId=${senderId} 不在 allowFrom 白名单中`);
    return;
  }
}
```