### PR TITLE
fix: 修复 stream 模式 model 参数错误导致 session 路由失败

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2496,6 +2496,7 @@ async function handleDingTalkMessage(params: {
         systemPrompts,
         sessionKey,
         gatewayAuth,
+        imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
         log,
       })) {
         fullResponse += chunk;


### PR DESCRIPTION
## 问题描述

钉钉 connector 使用 stream 模式时，model 参数错误地设为 'default'，导致 gateway 无法正确路由到对应的 agent session。

## 修复内容

将 model 参数从 'default' 改为 'main'，确保消息能正确路由到 agent:main:openai-user:dingtalk-connector:... session。

## 影响范围

- 仅影响 stream 模式（异步消息处理）
- 同步模式不受影响