### PR TITLE
fix: 修复按会话隔离 Session 与 Memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@
 This document records all significant changes. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [0.7.4] - 2026-03-09
+
+### 新增功能 / Added Features
+- ✅ **按会话区分 Session** - 支持按单聊、群聊、不同群分别维护独立会话，单聊与群聊、不同群之间的对话上下文互不干扰  
+  **Session by conversation** - Support separate sessions for direct chat, group chat, and different groups; conversation context is isolated between DMs, group chats, and different groups
+- ✅ **记忆隔离/共享配置** - 新增 `sharedMemoryAcrossConversations` 配置，控制单 Agent 场景下是否在不同会话间共享记忆；默认 `false` 实现群聊与私聊、不同群之间的记忆隔离  
+  **Memory isolation/sharing config** - Added `sharedMemoryAcrossConversations` option to control whether memory is shared across conversations in single-Agent mode; default `false` isolates memory between DMs, group chats, and different groups
+- ✅ **Gateway Session 格式增强** - Session key 支持 `group:conversationId` 格式，便于 Gateway 识别群聊场景  
+  **Gateway session format enhancement** - Session key supports `group:conversationId` format for Gateway to identify group chat scenarios
+- ✅ **X-OpenClaw-Memory-User 支持** - 向 Gateway 传递记忆归属用户标识，支持 Gateway 侧记忆管理  
+  **X-OpenClaw-Memory-User support** - Pass memory user identifier to Gateway for memory management
+
+### 配置 / Configuration
+- 新增 `separateSessionByConversation`（默认：`true`）- 是否按单聊/群聊/群区分 session  
+  Added `separateSessionByConversation` (default: `true`) - Whether to separate sessions by direct/group/different groups
+- 新增 `sharedMemoryAcrossConversations`（默认：`false`）- 单 Agent 场景下是否在不同会话间共享记忆；`false` 时不同群聊、群聊与私聊记忆隔离  
+  Added `sharedMemoryAcrossConversations` (default: `false`) - Whether to share memory across conversations in single-Agent mode; when `false`, memory is isolated between different groups and between DMs and groups
+
 ## [0.7.3] - 2026-03-09
 
 ### 修复 / Fixes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 以下提供两种方案连接到 [OpenClaw](https://openclaw.ai) Gateway，分别是钉钉机器人和钉钉 DEAP Agent。
 
-> 📝 **版本信息**：当前版本 v0.7.3 | [查看变更日志](CHANGELOG.md) | [发布说明](docs/RELEASE_NOTES_V0.7.3.md) | [发布指南](RELEASE.md)
+> 📝 **版本信息**：当前版本 v0.7.4 | [查看变更日志](CHANGELOG.md) | [发布说明](docs/RELEASE_NOTES_V0.7.4.md) | [发布指南](RELEASE.md)
 
 ## 快速导航
 
@@ -18,6 +18,7 @@
 
 - ✅ **AI Card 流式响应** - 打字机效果，实时显示 AI 回复
 - ✅ **会话持久化** - 同一用户的多轮对话共享上下文
+- ✅ **会话与记忆隔离** - 按单聊/群聊/群区分 session，不同场景下的对话上下文互不干扰，可配置跨会话记忆共享
 - ✅ **超时自动新会话** - 默认 30 分钟无活动自动开启新对话
 - ✅ **手动新会话** - 发送 `/new` 或 `新会话` 清空对话历史
 - ✅ **图片自动上传** - 本地图片路径自动上传到钉钉
@@ -90,6 +91,8 @@ openclaw plugins install -l .
       "gatewayToken": "",                 // 可选：Gateway 认证 token, openclaw.json配置中 gateway.auth.token 的值 
       "gatewayPassword": "",              // 可选：Gateway 认证 password（与 token 二选一）
       "sessionTimeout": 1800000,          // 可选：会话超时(ms)，默认 30 分钟
+      "separateSessionByConversation": true,  // 可选：是否按单聊/群聊/群区分 session（默认：true）
+      "sharedMemoryAcrossConversations": false, // 可选：是否在不同会话间共享记忆；false 时群聊与私聊、不同群记忆隔离（默认：false）
       "asyncMode": false,                 // 可选：异步模式，立即回执用户消息，后台处理并推送结果（默认：false）
       "ackText": "🫡 任务已接收"      // 可选：异步模式下的回执消息文本（默认：'🫡 任务已接收，处理中...'）
     }
@@ -143,8 +146,30 @@ openclaw plugins list  # 确认 dingtalk-connector 已加载
 | `gatewayToken` | `OPENCLAW_GATEWAY_TOKEN` | Gateway 认证 token（可选） |
 | `gatewayPassword` | — | Gateway 认证 password（可选，与 token 二选一） |
 | `sessionTimeout` | — | 会话超时时间，单位毫秒（默认 1800000 = 30分钟） |
+| `separateSessionByConversation` | — | 是否按单聊/群聊/群区分 session（默认：true） |
+| `sharedMemoryAcrossConversations` | — | 是否在不同会话间共享记忆；false 时群聊与私聊、不同群记忆隔离（默认：false） |
 | `asyncMode` | — | 异步模式，立即回执用户消息，后台处理并推送结果（默认：false） |
 | `ackText` | — | 异步模式下的回执消息文本（默认：'🫡 任务已接收，处理中...'） |
+
+## 会话与记忆隔离
+
+连接器支持按单聊、群聊、不同群分别维护独立会话和记忆，确保同一用户在不同场景下的对话上下文互不干扰。
+
+### 会话隔离（separateSessionByConversation）
+
+- **默认开启**（`true`）：单聊、群聊、不同群各自拥有独立的 session
+- **关闭**（`false`）：按用户维度维护 session，不区分单聊/群聊（兼容旧行为）
+
+### 记忆隔离（sharedMemoryAcrossConversations）
+
+- **默认关闭**（`false`）：不同群聊、群聊与私聊之间的记忆隔离，AI 不会混淆不同场景下的对话历史
+- **开启**（`true`）：单 Agent 场景下，同一用户在不同会话间共享记忆
+
+### 适用场景
+
+- ✅ 同一机器人在多个群中服务，希望每个群的对话互不干扰
+- ✅ 用户既在私聊也在群聊中使用机器人，希望私聊与群聊上下文分离
+- ✅ 需要跨会话共享记忆时，可设置 `sharedMemoryAcrossConversations: true`
 
 ## 异步模式
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "DingTalk (钉钉) messaging channel via Stream mode with AI Card streaming",
   "author": "DingTalk Real Team",
   "channels": ["dingtalk-connector"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "DingTalk (钉钉) channel connector — Stream mode with AI Card streaming",
   "main": "plugin.ts",
   "type": "module",

--- a/plugin.ts
+++ b/plugin.ts
@@ -78,6 +78,43 @@ function isNewSessionCommand(text: string): boolean {
   return NEW_SESSION_COMMANDS.some(cmd => trimmed === cmd.toLowerCase());
 }
 
+/** 计算 scope：单聊 direct，群聊 group:conversationId，无效 legacy */
+function getSessionScope(convCtx?: { conversationType: string; conversationId?: string }): string {
+  if (!convCtx) return 'legacy';
+  if (convCtx.conversationType === '1') return 'direct';
+  if (convCtx.conversationType === '2') {
+    const cid = convCtx.conversationId?.trim();
+    return cid ? `group:${cid}` : 'group:unknown';
+  }
+  return 'legacy';
+}
+
+/**
+ * 构建 Gateway 可识别的 session key 格式。
+ * Gateway 通过检查 :group: 或 :channel: 识别群聊。
+ * - 单聊: dingtalk-connector:accountId:senderId
+ * - 群聊: dingtalk-connector:accountId:group:conversationId:senderId
+ */
+function buildSessionIdForGateway(
+  accountId: string,
+  senderId: string,
+  scope: string,
+  forceNew: boolean,
+): string {
+  const base = `dingtalk-connector:${accountId}`;
+  const now = Date.now();
+  if (scope === 'direct') {
+    return forceNew ? `${base}:${senderId}:${now}` : `${base}:${senderId}`;
+  }
+  if (scope.startsWith('group:')) {
+    const conversationId = scope.slice(6);
+    const sessionId = `${base}:group:${conversationId}:${senderId}`;
+    return forceNew ? `${sessionId}:${now}` : sessionId;
+  }
+  // legacy
+  return forceNew ? `${base}:${senderId}:${now}` : `${base}:${senderId}`;
+}
+
 /** 获取或创建用户 session key */
 function getSessionKey(
   senderId: string,
@@ -85,15 +122,17 @@ function getSessionKey(
   forceNew: boolean,
   sessionTimeout: number,
   log?: any,
+  /** 可选：区分单聊/群聊。conversationType: '1'=单聊, '2'=群聊；群聊时需传 conversationId */
+  conversationContext?: { conversationType: string; conversationId?: string },
 ): { sessionKey: string; isNew: boolean } {
   const now = Date.now();
-  const sessionKeyPrefix = `dingtalk-connector:${accountId}`;  // 使用 accountId 作为前缀
-  const cacheKey = `${accountId}:${senderId}`;  // 使用 accountId:senderId 作为缓存键
+  const scope = getSessionScope(conversationContext);
+  const cacheKey = `${accountId}:${senderId}:${scope}`;
   const existing = userSessions.get(cacheKey);
 
   // 强制新会话
   if (forceNew) {
-    const sessionId = `${sessionKeyPrefix}:${senderId}:${now}`;
+    const sessionId = buildSessionIdForGateway(accountId, senderId, scope, true);
     userSessions.set(cacheKey, { lastActivity: now, sessionId });
     log?.info?.(`[DingTalk][Session] 账号[${accountId}] 用户主动开启新会话: ${senderId}`);
     return { sessionKey: sessionId, isNew: true };
@@ -103,7 +142,7 @@ function getSessionKey(
   if (existing) {
     const elapsed = now - existing.lastActivity;
     if (elapsed > sessionTimeout) {
-      const sessionId = `${sessionKeyPrefix}:${senderId}:${now}`;
+      const sessionId = buildSessionIdForGateway(accountId, senderId, scope, true);
       userSessions.set(cacheKey, { lastActivity: now, sessionId });
       log?.info?.(`[DingTalk][Session] 账号[${accountId}] 会话超时(${Math.round(elapsed / 60000)}分钟)，自动开启新会话: ${senderId}`);
       return { sessionKey: sessionId, isNew: true };
@@ -114,7 +153,7 @@ function getSessionKey(
   }
 
   // 首次会话
-  const sessionId = `${sessionKeyPrefix}:${senderId}`;
+  const sessionId = buildSessionIdForGateway(accountId, senderId, scope, false);
   userSessions.set(cacheKey, { lastActivity: now, sessionId });
   log?.info?.(`[DingTalk][Session] 账号[${accountId}] 新用户首次会话: ${senderId}`);
   return { sessionKey: sessionId, isNew: false };
@@ -1194,13 +1233,15 @@ interface GatewayOptions {
   systemPrompts: string[];
   sessionKey: string;
   gatewayAuth?: string;  // token 或 password，都用 Bearer 格式
+  /** 记忆归属用户标识，用于 Gateway 区分记忆；sharedMemoryAcrossConversations=true 时传 accountId，false 时传 sessionKey */
+  memoryUser?: string;
   /** 本地图片文件路径列表，用于 OpenClaw AgentMediaPayload */
   imageLocalPaths?: string[];
   log?: any;
 }
 
 async function* streamFromGateway(options: GatewayOptions, accountId: string): AsyncGenerator<string, void, unknown> {
-  const { userContent, systemPrompts, sessionKey, gatewayAuth, imageLocalPaths, log } = options;
+  const { userContent, systemPrompts, sessionKey, gatewayAuth, memoryUser, imageLocalPaths, log } = options;
   const rt = getRuntime();
   const gatewayUrl = `http://127.0.0.1:${rt.gateway?.port || 18789}/v1/chat/completions`;
 
@@ -1226,6 +1267,9 @@ async function* streamFromGateway(options: GatewayOptions, accountId: string): A
   // DEFAULT_ACCOUNT_ID 映射到 'main' agent
   const agentId = accountId === DEFAULT_ACCOUNT_ID ? 'main' : accountId;
   headers['X-OpenClaw-Agent-Id'] = agentId;
+  if (memoryUser) {
+    headers['X-OpenClaw-Memory-User'] = memoryUser;
+  }
 
   log?.info?.(`[DingTalk][Gateway] POST ${gatewayUrl}, session=${sessionKey}, accountId=${accountId}, messages=${messages.length}`);
 
@@ -2335,10 +2379,13 @@ async function handleDingTalkMessage(params: {
   // ===== Session 管理 =====
   const sessionTimeout = dingtalkConfig.sessionTimeout ?? 1800000; // 默认 30 分钟
   const forceNewSession = isNewSessionCommand(content.text);
+  const convCtx = dingtalkConfig.separateSessionByConversation !== false
+    ? { conversationType: data.conversationType, conversationId: data.conversationId }
+    : undefined;
 
   // 如果是新会话命令，直接回复确认消息
   if (forceNewSession) {
-    const { sessionKey } = getSessionKey(senderId, accountId, true, sessionTimeout, log);
+    const { sessionKey } = getSessionKey(senderId, accountId, true, sessionTimeout, log, convCtx);
     await sendMessage(dingtalkConfig, sessionWebhook, '✨ 已开启新会话，之前的对话已清空。', {
       atUserId: !isDirect ? senderId : null,
     });
@@ -2347,8 +2394,10 @@ async function handleDingTalkMessage(params: {
   }
 
   // 获取或创建 session
-  const { sessionKey, isNew } = getSessionKey(senderId, accountId, false, sessionTimeout, log);
+  const { sessionKey, isNew } = getSessionKey(senderId, accountId, false, sessionTimeout, log, convCtx);
   log?.info?.(`[DingTalk][Session] key=${sessionKey}, isNew=${isNew}`);
+
+  const memoryUser = dingtalkConfig.sharedMemoryAcrossConversations === true ? accountId : sessionKey;
 
   // Gateway 认证：优先使用 token，其次 password
   const gatewayAuth = dingtalkConfig.gatewayToken || dingtalkConfig.gatewayPassword || '';
@@ -2501,6 +2550,7 @@ async function handleDingTalkMessage(params: {
         systemPrompts,
         sessionKey,
         gatewayAuth,
+        memoryUser,
         imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
         log,
       }, accountId)) {
@@ -2570,6 +2620,7 @@ async function handleDingTalkMessage(params: {
         systemPrompts,
         sessionKey,
         gatewayAuth,
+        memoryUser,
         imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
         log,
       }, accountId)) {
@@ -2650,6 +2701,7 @@ async function handleDingTalkMessage(params: {
         systemPrompts,
         sessionKey,
         gatewayAuth,
+        memoryUser,
         imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
         log,
       }, accountId)) {
@@ -3030,6 +3082,8 @@ const dingtalkPlugin = {
         gatewayToken: { type: 'string', default: '', description: 'Gateway auth token (Bearer)' },
         gatewayPassword: { type: 'string', default: '', description: 'Gateway auth password (alternative to token)' },
         sessionTimeout: { type: 'number', default: 1800000, description: 'Session timeout in ms (default 30min)' },
+        separateSessionByConversation: { type: 'boolean', default: true, description: '是否按单聊/群聊/群区分 session' },
+        sharedMemoryAcrossConversations: { type: 'boolean', default: false, description: '单 agent 场景下是否共享记忆；false 时不同群聊、群聊与私聊记忆隔离' },
         asyncMode: { type: 'boolean', default: false, description: 'Send immediate ack and push final result as a second message' },
         ackText: { type: 'string', default: '🫡 任务已接收，处理中...', description: 'Ack text when asyncMode is enabled' },
         debug: { type: 'boolean', default: false },


### PR DESCRIPTION
背景：

原先 session key 为 dingtalk-connector:accountId:senderId，同一用户在不同群聊、私聊共享同一 session 群 A 和群 B、私聊和群聊的对话上下文混在一起 无法实现按会话的上下文和记忆隔离

变更：

新增 separateSessionByConversation（默认 true）：按单聊/群聊区分 session

单聊：dingtalk-connector:accountId:senderId
群聊：dingtalk-connector:accountId:group:conversationId:senderId 新增 sharedMemoryAcrossConversations（默认 false）：按 session 共享 memory false：每个 session 独立记忆，群聊之间、群聊与私聊不共享
true：所有会话共享 memory（归属到 accountId） 通过 X-OpenClaw-Memory-User 请求头将 memoryUser 传给 Gateway false 时 memoryUser = sessionKey，true 时 memoryUser = accountId 影响范围：

separateSessionByConversation 默认 true，新部署即按会话隔离 session sharedMemoryAcrossConversations 默认 false，记忆按 session 隔离 旧配置未显式设置时行为与上述默认值一致

说明：

如果用户的描述中存在“记住”“保存”等字样，模型会绕过gateway，直接存到本地文件系统，因此设置不生效（此行为需要设置模型层面，而非插件）。