### PR TITLE
fix: 修复修改gateway端口后无法连接的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and version numbers follow [Semantic Versioning](https://semver.org/).
   **Fixed Stream client frequent reconnection issue** - Disabled `DWClient` built-in `autoReconnect`, reconnection is now managed by framework's health-monitor to avoid dual reconnection mechanism conflict
 - 🐛 **修复连接关闭不完整问题** - `stop()` 方法现在正确调用 `client.disconnect()` 关闭 WebSocket 连接  
   **Fixed incomplete connection closure** - `stop()` method now correctly calls `client.disconnect()` to close WebSocket connection
+- 🐛 **Gateway 端口连接修复** - 修复修改 gateway 端口后无法连接的问题
+  **Gateway port connection fix** - Fixed issue where connection fails after modifying gateway port
 
 ### 重构 / Refactoring
 - ✅ **OpenClaw session.dmScope 机制** - 会话管理由 OpenClaw Gateway 统一处理，插件不再内部管理会话超时  

--- a/plugin.ts
+++ b/plugin.ts
@@ -1377,13 +1377,15 @@ interface GatewayOptions {
   peerKind?: 'direct' | 'group';
   /** 发送者 ID，用于 bindings 匹配 */
   peerId?: string;
+  gatewayPort?: number;
   log?: any;
 }
 
 async function* streamFromGateway(options: GatewayOptions, accountId: string): AsyncGenerator<string, void, unknown> {
-  const { userContent, systemPrompts, sessionKey, gatewayAuth, memoryUser, imageLocalPaths, peerKind, peerId, log } = options;
+  const { userContent, systemPrompts, sessionKey, gatewayAuth, memoryUser, imageLocalPaths, peerKind, peerId, gatewayPort, log } = options;
   const rt = getRuntime();
-  const gatewayUrl = `http://127.0.0.1:${rt.gateway?.port || 18789}/v1/chat/completions`;
+  const port = gatewayPort || rt.gateway?.port || 18789;
+  const gatewayUrl = `http://127.0.0.1:${port}/v1/chat/completions`;
 
   const messages: any[] = [];
   for (const prompt of systemPrompts) {
@@ -2717,6 +2719,7 @@ async function handleDingTalkMessage(params: {
         imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
         peerKind,
         peerId,
+        gatewayPort: cfg.gateway?.port,
         log,
       }, accountId)) {
         fullResponse += chunk;
@@ -2793,6 +2796,7 @@ async function handleDingTalkMessage(params: {
         imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
         peerKind,
         peerId,
+        gatewayPort: cfg.gateway?.port,
         log,
       }, accountId)) {
         accumulated += chunk;
@@ -2876,6 +2880,7 @@ async function handleDingTalkMessage(params: {
         imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
         peerKind,
         peerId,
+        gatewayPort: cfg.gateway?.port,
         log,
       }, accountId)) {
         fullResponse += chunk;


### PR DESCRIPTION
## 问题
当修改gateway的监听端口时，钉钉报错 响应中断: fetch failed
Openclaw错误日志：
<img width="2534" height="1168" alt="image" src="https://github.com/user-attachments/assets/5d9c91cf-040b-4fa1-9d56-a4c104d16895" />

## 原因
当前代码中，没有正确获取到配置文件中gateway下的port字段，导致仍然使用18789端口，造成连接断开。
打印rt值如下：{"version":"unknown","config":{},"system":{},"media":{},"tts":{},"stt":{},"tools":{},"channel":{"text":{},"reply":{},"routing":{},"pairing":{},"media":{},"activity":{},"session":{},"mentions":{},"reactions":{},"groups":{},"debounce":{},"commands":{},"discord":{"messageActions":{}},"slack":{},"telegram":{"messageActions":{}},"signal":{"messageActions":{}},"imessage":{},"whatsapp":{},"line":{}},"events":{},"logging":{},"state":{}}

## 修复
从cfg中读取端口。