### PR TITLE
支持bingings.match.peer配置，实现agent动态路由规则

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,74 @@ openclaw plugins list  # 确认 dingtalk-connector 已加载
 }
 ```
 
+### 基于单聊/群聊的路由（peer.kind）
+
+连接器支持根据会话类型（单聊/群聊）将消息路由到不同的 Agent。这对于以下场景非常有用：
+
+- **安全隔离**：群聊使用受限功能的 Agent，单聊使用完整功能的 Agent
+- **多角色支持**：不同用户或会话类型分配不同的 Agent
+- **成本优化**：普通用户路由到低成本模型，VIP 用户使用高端模型
+
+#### 配置示例
+
+```json5
+{
+  "bindings": [
+    // 场景1：特定用户的单聊 → main agent（完整功能）
+    {
+      "agentId": "main",
+      "match": {
+        "channel": "dingtalk-connector",
+        "peer": {
+          "kind": "direct",
+          "id": "YOUR_VIP_USER_ID"
+        }
+      }
+    },
+    // 场景2：所有群聊 → guest agent（受限功能）
+    {
+      "agentId": "guest",
+      "match": {
+        "channel": "dingtalk-connector",
+        "peer": {
+          "kind": "group",
+          "id": "*"
+        }
+      }
+    },
+    // 场景3：其他单聊 → guest agent（受限功能）
+    {
+      "agentId": "guest",
+      "match": {
+        "channel": "dingtalk-connector",
+        "peer": {
+          "kind": "direct",
+          "id": "*"
+        }
+      }
+    }
+  ]
+}
+```
+
+#### peer.kind 配置说明
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `peer.kind` | `'direct'` \| `'group'` | 会话类型：`direct` 表示单聊，`group` 表示群聊 |
+| `peer.id` | `string` | 发送者 ID（单聊）或 `*` 通配符匹配所有 |
+
+#### 匹配优先级
+
+bindings 按以下优先级匹配（从高到低）：
+
+1. **peer.kind + peer.id 精确匹配**：指定会话类型和具体用户 ID
+2. **peer.kind + peer.id='*' 通配匹配**：指定会话类型，匹配所有用户
+3. **仅 peer.kind 匹配**：只指定会话类型（无 peer.id）
+4. **accountId 匹配**：按钉钉账号路由
+5. **channel 匹配**：仅指定 channel
+6. **默认 fallback**：使用 `main` agent
+
 ### 官方文档
 
 详细的配置指南和架构说明，请参考 OpenClaw 官方文档：

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "DingTalk (钉钉) channel connector — Stream mode with AI Card streaming",
   "main": "plugin.ts",
   "type": "module",

--- a/plugin.ts
+++ b/plugin.ts
@@ -1228,6 +1228,136 @@ async function finishAICard(
 
 // ============ Gateway SSE Streaming ============
 
+// ============ Bindings 匹配逻辑 ============
+
+interface BindingMatch {
+  channel?: string;
+  accountId?: string;
+  peer?: {
+    kind?: 'direct' | 'group';
+    id?: string;
+  };
+}
+
+interface Binding {
+  agentId: string;
+  match?: BindingMatch;
+}
+
+/**
+ * 根据 OpenClaw bindings 配置解析 agentId
+ * 
+ * 匹配优先级（从高到低）：
+ * 1. peer.kind + peer.id 精确匹配（非 '*'）
+ * 2. peer.kind + peer.id='*' 通配匹配
+ * 3. peer.kind 匹配（无 peer.id）
+ * 4. accountId 匹配
+ * 5. channel 匹配
+ * 6. 默认 fallback
+ * 
+ * @param accountId 账号 ID
+ * @param peerKind 会话类型：'direct'（单聊）或 'group'（群聊）
+ * @param peerId 发送者 ID（单聊）或会话 ID（群聊）
+ * @param log 日志对象
+ * @returns 匹配到的 agentId
+ */
+function resolveAgentIdByBindings(
+  accountId: string,
+  peerKind: 'direct' | 'group',
+  peerId: string,
+  log?: any,
+): string {
+  const rt = getRuntime();
+  const defaultAgentId = accountId === DEFAULT_ACCOUNT_ID ? 'main' : accountId;
+  
+  // 读取 OpenClaw 配置
+  let bindings: Binding[] = [];
+  try {
+    const configPath = path.join(os.homedir(), '.openclaw', 'openclaw.json');
+    if (fs.existsSync(configPath)) {
+      const configContent = fs.readFileSync(configPath, 'utf-8');
+      const config = JSON.parse(configContent);
+      bindings = config.bindings || [];
+    }
+  } catch (err: any) {
+    log?.warn?.(`[DingTalk][Bindings] 读取 OpenClaw 配置失败: ${err.message}`);
+    return defaultAgentId;
+  }
+
+  if (bindings.length === 0) {
+    log?.info?.(`[DingTalk][Bindings] 无 bindings 配置，使用默认 agentId=${defaultAgentId}`);
+    return defaultAgentId;
+  }
+
+  // 筛选 channel='dingtalk-connector' 的 bindings
+  const channelBindings = bindings.filter(b => 
+    !b.match?.channel || b.match.channel === 'dingtalk-connector'
+  );
+
+  if (channelBindings.length === 0) {
+    log?.info?.(`[DingTalk][Bindings] 无匹配 channel 的 bindings，使用默认 agentId=${defaultAgentId}`);
+    return defaultAgentId;
+  }
+
+  log?.info?.(`[DingTalk][Bindings] 开始匹配: accountId=${accountId}, peerKind=${peerKind}, peerId=${peerId}, bindings数量=${channelBindings.length}`);
+
+  // 按优先级匹配
+  // 优先级1: peer.kind + peer.id 精确匹配
+  for (const binding of channelBindings) {
+    const match = binding.match || {};
+    if (match.peer?.kind === peerKind && 
+        match.peer?.id && 
+        match.peer.id !== '*' && 
+        match.peer.id === peerId) {
+      // 还需检查 accountId 是否匹配（如果指定了）
+      if (match.accountId && match.accountId !== accountId) continue;
+      log?.info?.(`[DingTalk][Bindings] 精确匹配 peer.id: agentId=${binding.agentId}`);
+      return binding.agentId || defaultAgentId;
+    }
+  }
+
+  // 优先级2: peer.kind + peer.id='*' 通配匹配
+  for (const binding of channelBindings) {
+    const match = binding.match || {};
+    if (match.peer?.kind === peerKind && match.peer?.id === '*') {
+      if (match.accountId && match.accountId !== accountId) continue;
+      log?.info?.(`[DingTalk][Bindings] 通配匹配 peer.kind=${peerKind}, peer.id=*: agentId=${binding.agentId}`);
+      return binding.agentId || defaultAgentId;
+    }
+  }
+
+  // 优先级3: 仅 peer.kind 匹配（无 peer.id）
+  for (const binding of channelBindings) {
+    const match = binding.match || {};
+    if (match.peer?.kind === peerKind && !match.peer?.id) {
+      if (match.accountId && match.accountId !== accountId) continue;
+      log?.info?.(`[DingTalk][Bindings] 匹配 peer.kind=${peerKind}: agentId=${binding.agentId}`);
+      return binding.agentId || defaultAgentId;
+    }
+  }
+
+  // 优先级4: accountId 匹配（无 peer 配置）
+  for (const binding of channelBindings) {
+    const match = binding.match || {};
+    if (!match.peer && match.accountId === accountId) {
+      log?.info?.(`[DingTalk][Bindings] 匹配 accountId=${accountId}: agentId=${binding.agentId}`);
+      return binding.agentId || defaultAgentId;
+    }
+  }
+
+  // 优先级5: 仅 channel 匹配（无 peer 和 accountId）
+  for (const binding of channelBindings) {
+    const match = binding.match || {};
+    if (!match.peer && !match.accountId) {
+      log?.info?.(`[DingTalk][Bindings] 匹配 channel=dingtalk-connector: agentId=${binding.agentId}`);
+      return binding.agentId || defaultAgentId;
+    }
+  }
+
+  log?.info?.(`[DingTalk][Bindings] 无匹配，使用默认 agentId=${defaultAgentId}`);
+  return defaultAgentId;
+}
+
 interface GatewayOptions {
   userContent: string;
   systemPrompts: string[];
@@ -1237,11 +1367,15 @@ interface GatewayOptions {
   memoryUser?: string;
   /** 本地图片文件路径列表，用于 OpenClaw AgentMediaPayload */
   imageLocalPaths?: string[];
+  /** 会话类型：'direct'（单聊）或 'group'（群聊），用于 bindings 匹配 */
+  peerKind?: 'direct' | 'group';
+  /** 发送者 ID，用于 bindings 匹配 */
+  peerId?: string;
   log?: any;
 }
 
 async function* streamFromGateway(options: GatewayOptions, accountId: string): AsyncGenerator<string, void, unknown> {
-  const { userContent, systemPrompts, sessionKey, gatewayAuth, memoryUser, imageLocalPaths, log } = options;
+  const { userContent, systemPrompts, sessionKey, gatewayAuth, memoryUser, imageLocalPaths, peerKind, peerId, log } = options;
   const rt = getRuntime();
   const gatewayUrl = `http://127.0.0.1:${rt.gateway?.port || 18789}/v1/chat/completions`;
 
@@ -1263,15 +1397,17 @@ async function* streamFromGateway(options: GatewayOptions, accountId: string): A
   if (gatewayAuth) {
     headers['Authorization'] = `Bearer ${gatewayAuth}`;
   }
-  // 使用 HTTP Header 传递 accountId 用于 agent 路由
-  // DEFAULT_ACCOUNT_ID 映射到 'main' agent
-  const agentId = accountId === DEFAULT_ACCOUNT_ID ? 'main' : accountId;
+  // 使用 bindings 配置解析 agentId，支持基于 peer.kind（单聊/群聊）的路由
+  // 如果没有提供 peerKind/peerId，则回退到原有逻辑
+  const agentId = (peerKind && peerId)
+    ? resolveAgentIdByBindings(accountId, peerKind, peerId, log)
+    : (accountId === DEFAULT_ACCOUNT_ID ? 'main' : accountId);
   headers['X-OpenClaw-Agent-Id'] = agentId;
   if (memoryUser) {
     headers['X-OpenClaw-Memory-User'] = memoryUser;
   }
 
-  log?.info?.(`[DingTalk][Gateway] POST ${gatewayUrl}, session=${sessionKey}, accountId=${accountId}, messages=${messages.length}`);
+  log?.info?.(`[DingTalk][Gateway] POST ${gatewayUrl}, session=${sessionKey}, accountId=${accountId}, agentId=${agentId}, peerKind=${peerKind}, messages=${messages.length}`);
 
   const response = await fetch(gatewayUrl, {
     method: 'POST',
@@ -2543,6 +2679,10 @@ async function handleDingTalkMessage(params: {
       log?.warn?.(`[DingTalk][Async] 回执发送失败: ${ackErr?.message || ackErr}`);
     }
 
+    // 计算 peerKind 和 peerId 用于 bindings 匹配
+    const peerKind: 'direct' | 'group' = isDirect ? 'direct' : 'group';
+    const peerId = senderId;
+
     let fullResponse = '';
     try {
       for await (const chunk of streamFromGateway({
@@ -2552,6 +2692,8 @@ async function handleDingTalkMessage(params: {
         gatewayAuth,
         memoryUser,
         imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
+        peerKind,
+        peerId,
         log,
       }, accountId)) {
         fullResponse += chunk;
@@ -2601,6 +2743,10 @@ async function handleDingTalkMessage(params: {
     return;
   }
 
+  // 计算 peerKind 和 peerId 用于 bindings 匹配（在 asyncMode 外部定义，供所有分支使用）
+  const peerKind: 'direct' | 'group' = isDirect ? 'direct' : 'group';
+  const peerId = senderId;
+
   // 尝试创建 AI Card
   const card = await createAICard(dingtalkConfig, data, log);
 
@@ -2622,6 +2768,8 @@ async function handleDingTalkMessage(params: {
         gatewayAuth,
         memoryUser,
         imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
+        peerKind,
+        peerId,
         log,
       }, accountId)) {
         accumulated += chunk;
@@ -2703,6 +2851,8 @@ async function handleDingTalkMessage(params: {
         gatewayAuth,
         memoryUser,
         imageLocalPaths: imageLocalPaths.length > 0 ? imageLocalPaths : undefined,
+        peerKind,
+        peerId,
         log,
       }, accountId)) {
         fullResponse += chunk;


### PR DESCRIPTION
同：https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/144
问题：

没有读取 openclaw.json 中的 bindings 配置
没有基于 peer.kind 或 conversationType 的路由逻辑
仅通过 accountId 映射到 agentId，导致单账号模式下所有消息都路由到 main
这导致 bindings.peer.kind 配置完全无效，OpenClaw Gateway 无法根据会话类型进行 agent 路由。

改进方案：
添加基于 binding 配置的 agent 路由逻辑。
<img width="1270" height="808" alt="image" src="https://github.com/user-attachments/assets/f2f274d8-e87f-4a01-a1d0-add137fc718e" />
