### PR TITLE
fix: 统一新会话命令并修复未真正清理会话的问题

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -73,9 +73,13 @@ function markMessageProcessed(messageId: string): void {
 const NEW_SESSION_COMMANDS = ['/new', '/reset', '/clear', '新会话', '重新开始', '清空对话'];
 
 /** 检查消息是否是新会话命令 */
-function isNewSessionCommand(text: string): boolean {
-  const trimmed = text.trim().toLowerCase();
-  return NEW_SESSION_COMMANDS.some(cmd => trimmed === cmd.toLowerCase());
+function normalizeSlashCommand(text: string): string {
+  const trimmed = text.trim();
+  const lower = trimmed.toLowerCase();
+  if (NEW_SESSION_COMMANDS.some(cmd => lower === cmd.toLowerCase())) {
+    return '/new';
+  }
+  return text;
 }
 
 /**
@@ -2522,18 +2526,6 @@ async function handleDingTalkMessage(params: {
     }
   }
 
-  // ===== Session 管理 =====
-  const forceNewSession = isNewSessionCommand(content.text);
-
-  // 如果是新会话命令，直接回复确认消息
-  if (forceNewSession) {
-    await sendMessage(dingtalkConfig, sessionWebhook, '✨ 已开启新会话，之前的对话已清空。', {
-      atUserId: !isDirect ? senderId : null,
-    });
-    log?.info?.(`[DingTalk] 用户请求新会话: ${senderId}`);
-    return;
-  }
-
   // 构建 OpenClaw 标准会话上下文
   // 兼容旧配置：sessionTimeout 已废弃，打印警告
   if (dingtalkConfig.sessionTimeout !== undefined) {
@@ -2677,7 +2669,9 @@ async function handleDingTalkMessage(params: {
   }
 
   // 对于纯图片消息（无文本），添加默认提示
-  let userContent = content.text || (imageLocalPaths.length > 0 ? '请描述这张图片' : '');
+  // 文本部分先经过 normalizeSlashCommand，统一将 /reset /clear 等别名指令转为 /new，再交由 Gateway 解析
+  const rawText = content.text || '';
+  let userContent = normalizeSlashCommand(rawText) || (imageLocalPaths.length > 0 ? '请描述这张图片' : '');
   // 追加文件内容
   if (fileContentParts.length > 0) {
     const fileText = fileContentParts.join('\n\n');


### PR DESCRIPTION
问题背景：
- 钉钉 Connector 之前在本地通过 isNewSessionCommand 拦截 /new、/reset、/clear、「新会话」等指令。
- 命中后由插件直接回复「✨ 已开启新会话，之前的对话已清空。」这条固定文案，并提前 return，不再往 Gateway 发送消息。
- 实际上 Connector 本身并没有真正清理会话上下文，也没有触发 Gateway 的 session.reset，导致用户以为会话已清空，但后续对话仍然带着旧上下文继续。

本次改动：
- 新增 normalizeSlashCommand 工具方法，将 /new、/reset、/clear、「新会话」「重新开始」「清空对话」等别名统一归一为标准指令 `/new`。
- 在构造 userContent 时，先对文本部分调用 normalizeSlashCommand，再将结果连同图片、本地文件内容一并发送给 Gateway。
- 删除 handleDingTalkMessage 中原有的“本地拦截 + 假提示”逻辑（forceNewSession 判断 + 直接回复「已开启新会话」并提前 return），不再在 Connector 层吞掉命令。

行为变化：
- 用户发送新会话类命令时，消息会以 `/new` 的形式完整透传到 Gateway，由 Gateway 统一决定是否重置会话以及返回何种提示文案，从而真正清理会话。