### PR TITLE
Avoid per-chunk AI Card streaming updates and finalize once at completion

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2882,8 +2882,6 @@ async function handleDingTalkMessage(params: {
     log?.info?.(`[DingTalk] AI Card 创建成功: ${card.cardInstanceId}`);
 
     let accumulated = '';
-    let lastUpdateTime = 0;
-    const updateInterval = 300; // 最小更新间隔 ms
     let chunkCount = 0;
 
     try {
@@ -2906,19 +2904,6 @@ async function handleDingTalkMessage(params: {
 
         if (chunkCount <= 3) {
           log?.info?.(`[DingTalk] Gateway chunk #${chunkCount}: "${chunk.slice(0, 50)}..." (accumulated=${accumulated.length})`);
-        }
-
-        // 节流更新，避免过于频繁
-        const now = Date.now();
-        if (now - lastUpdateTime >= updateInterval) {
-          // 实时清理文件、视频、音频标记（避免用户在流式过程中看到标记）
-          const displayContent = accumulated
-            .replace(FILE_MARKER_PATTERN, '')
-            .replace(VIDEO_MARKER_PATTERN, '')
-            .replace(AUDIO_MARKER_PATTERN, '')
-            .trim();
-          await streamAICard(card, displayContent, false, log);
-          lastUpdateTime = now;
         }
       }
 


### PR DESCRIPTION
## Summary

This PR changes the DingTalk AI Card update strategy in synchronous mode:

- keep creating AI Card normally
- keep reading the full gateway stream
- stop sending intermediate `PUT /v1.0/card/streaming` updates for every small chunk
- only finalize the card once at the end with the complete content

## Problem

When the gateway returns very small chunks, the current implementation updates the AI Card too frequently.

This causes:

- poor UX in DingTalk, where only a few characters appear every few seconds
- extra API overhead from repeated `card/streaming` calls
- slower perceived response even when the model is already generating

## Change

Inside the AI Card branch of `handleDingTalkMessage(...)`:

- remove the throttled per-chunk `streamAICard(card, displayContent, false, log)`
- keep accumulating streamed text in memory
- continue using `finishAICard(card, finalContent, log)` after the stream completes

## Result

The user still gets an AI Card, but instead of fragmented streaming updates, the card is completed once with the final response.

## Scope

This PR does not change:

- gateway request format
- final card content
- media/file/audio/video post-processing
- async mode behavior

It only changes the AI Card update behavior during synchronous streaming mode.

## Motivation

In real usage, final-only AI Card updates provide a better DingTalk experience than very frequent small streaming updates.
