### PR TITLE
fix: 群聊场景使用 conversationId 作为 peerId 用于 bindings 匹配

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2806,7 +2806,8 @@ async function handleDingTalkMessage(params: {
 
     // 计算 peerKind 和 peerId 用于 bindings 匹配
     const peerKind: 'direct' | 'group' = isDirect ? 'direct' : 'group';
-    const peerId = senderId;
+    const peerId = peerKind === 'group' ? data.conversationId : senderId;
+    log?.info?.(`[DingTalk][Bindings] peerKind=${peerKind}, peerId=${peerId}, senderId=${senderId}, conversationId=${data.conversationId}`);
 
     let fullResponse = '';
     try {
@@ -2872,7 +2873,8 @@ async function handleDingTalkMessage(params: {
 
   // 计算 peerKind 和 peerId 用于 bindings 匹配（在 asyncMode 外部定义，供所有分支使用）
   const peerKind: 'direct' | 'group' = isDirect ? 'direct' : 'group';
-  const peerId = senderId;
+  const peerId = peerKind === 'group' ? data.conversationId : senderId;
+  log?.info?.(`[DingTalk][Bindings] peerKind=${peerKind}, peerId=${peerId}, senderId=${senderId}, conversationId=${data.conversationId}`);
 
   // 尝试创建 AI Card
   const card = await createAICard(dingtalkConfig, data, log);


### PR DESCRIPTION
- 修改 asyncMode 和 AI Card 模式两处 peerId 计算逻辑
- 群聊时使用 conversationId 而非 senderId，使 bindings 配置正确匹配
- 添加日志输出 peerKind/peerId 便于调试

修复场景：
- 单聊：peerKind=direct, peerId=senderId
- 群聊：peerKind=group, peerId=conversationId