### PR TITLE
fix: clear heartbeat interval on socket close to prevent reconnect storm

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -3603,6 +3603,30 @@ const dingtalkPlugin = {
         }
       });
 
+      // Workaround for dingtalk-stream SDK bug (v2.1.4):
+      // DWClient._connect() starts a heartbeat setInterval on every 'open' event but never
+      // clears it on 'close', so each autoReconnect cycle leaks one interval.
+      // After a few hours the accumulated timers fire against a dead socket and produce
+      // "TERMINATE SOCKET: Ping Pong does not transfer heartbeat within heartbeat intervall"
+      // errors, causing a restart storm.  Patch connect() to clear the stale interval
+      // whenever the socket closes.
+      // TODO: Remove once https://github.com/open-dingtalk/dingtalk-stream-sdk-nodejs/issues/13
+      //       is fixed in a released version of dingtalk-stream.
+      const _origConnect = (client as any).connect.bind(client);
+      (client as any).connect = async function (this: any) {
+        await _origConnect();
+        const sock = this.socket;
+        if (sock && !(sock as any).__heartbeatPatched) {
+          (sock as any).__heartbeatPatched = true;
+          sock.on('close', () => {
+            if (this.heartbeatIntervallId !== undefined) {
+              clearInterval(this.heartbeatIntervallId);
+              this.heartbeatIntervallId = undefined;
+            }
+          });
+        }
+      };
+
       await client.connect();
       ctx.log?.info(`[${account.accountId}] 钉钉 Stream 客户端已连接`);
 


### PR DESCRIPTION
dingtalk-stream SDK (v2.1.4) starts a setInterval for heartbeat ping on every WebSocket 'open' event but never clears it on 'close'.  Each autoReconnect cycle therefore leaks one interval; after a few hours the accumulated timers all fire against a dead socket and emit:

  TERMINATE SOCKET: Ping Pong does not transfer heartbeat within heartbeat intervall

This triggers health-monitor restarts in rapid succession, making the bot unresponsive to group @-mentions and direct messages.

Patch DWClient.connect() at startup to register a 'close' handler that calls clearInterval(heartbeatIntervallId).  A __heartbeatPatched guard prevents double-patching if connect() is called multiple times.

Upstream issue: https://github.com/open-dingtalk/dingtalk-stream-sdk-nodejs/issues/13
Related: #185

## Problem

`dingtalk-stream` SDK (v2.1.4) starts a `setInterval` for heartbeat ping on every WebSocket `open` event but **never clears it on `close`**. Each `autoReconnect` cycle therefore leaks one interval timer.

After a few hours of uptime, the accumulated timers all fire against a dead/new socket and produce:

ERMINATE SOCKET: Ping Pong does not transfer heartbeat within heartbeat intervall


This causes `health-monitor` to restart the connector in rapid succession, making the bot **unresponsive to group @-mentions and direct messages**.

Upstream SDK issue: https://github.com/open-dingtalk/dingtalk-stream-sdk-nodejs/issues/13
Related: #185

## Fix

Patch `DWClient.connect()` at startup to register a `close` handler that calls `clearInterval(heartbeatIntervallId)`. A `__heartbeatPatched` guard prevents double-patching if `connect()` is called multiple times.

```typescript
const _origConnect = (client as any).connect.bind(client);
(client as any).connect = async function (this: any) {
  await _origConnect();
  const sock = this.socket;
  if (sock && !(sock as any).__heartbeatPatched) {
    (sock as any).__heartbeatPatched = true;
    sock.on("close", () => {
      if (this.heartbeatIntervallId !== undefined) {
        clearInterval(this.heartbeatIntervallId);
        this.heartbeatIntervallId = undefined;
      }
    });
  }
};
``` 
Verification
Applied this patch locally on a production instance. Before the fix, TERMINATE SOCKET errors appeared every few minutes and the count kept growing. After the patch, the counter stopped and has not increased since. Bot is now stable and responds reliably to group @-mentions.

Note
This is a workaround until the upstream dingtalk-stream SDK fixes the root cause. The TODO comment references the upstream issue so it can be removed once a fixed SDK version is released.