### PR TITLE
fix: allow ackText="" to disable async acknowledgment

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2792,16 +2792,21 @@ async function handleDingTalkMessage(params: {
     : { openConversationId: data.conversationId };
 
   if (asyncMode) {
-    const ackText = dingtalkConfig.ackText || '🫡 任务已接收，处理中...';
-    try {
-      await sendProactive(dingtalkConfig, proactiveTarget, ackText, {
-        msgType: 'text',
-        useAICard: false,
-        fallbackToNormal: true,
-        log,
-      });
-    } catch (ackErr: any) {
-      log?.warn?.(`[DingTalk][Async] 回执发送失败: ${ackErr?.message || ackErr}`);
+    // 允许通过 ackText: '' 显式关闭异步回执；仅在未配置（null/undefined）时回退到默认文案
+    const ackText = dingtalkConfig.ackText ?? '🫡 任务已接收，处理中...';
+    if (typeof ackText === 'string' && ackText.trim().length > 0) {
+      try {
+        await sendProactive(dingtalkConfig, proactiveTarget, ackText, {
+          msgType: 'text',
+          useAICard: false,
+          fallbackToNormal: true,
+          log,
+        });
+      } catch (ackErr: any) {
+        log?.warn?.(`[DingTalk][Async] 回执发送失败: ${ackErr?.message || ackErr}`);
+      }
+    } else {
+      log?.info?.('[DingTalk][Async] ackText 为空，跳过异步回执发送');
     }
 
     // 计算 peerKind 和 peerId 用于 bindings 匹配


### PR DESCRIPTION
# DingTalk Connector: `ackText: ""` cannot disable async acknowledgment

## Summary

When `asyncMode: true` is enabled, setting:

```json
{
  "channels": {
    "dingtalk-connector": {
      "asyncMode": true,
      "ackText": ""
    }
  }
}
```

is expected to disable the immediate async acknowledgment message.

However, the connector still sends the default acknowledgment:

- `🫡 任务已接收，处理中...`

## Root cause

Current implementation uses `||` fallback:

```ts
const ackText = dingtalkConfig.ackText || '🫡 任务已接收，处理中...';
```

This treats an empty string (`""`) as falsy and silently restores the default text.

## Expected behavior

- `ackText: undefined` / not configured → use default acknowledgment text
- `ackText: "custom text"` → use custom acknowledgment text
- `ackText: ""` → disable acknowledgment entirely

## Suggested fix

Use nullish coalescing and skip sending when the resolved value is blank:

```ts
const ackText = dingtalkConfig.ackText ?? '🫡 任务已接收，处理中...';
if (typeof ackText === 'string' && ackText.trim().length > 0) {
  await sendProactive(...ackText...);
}
```

## Verified locally

I reproduced this with:

- OpenClaw: `2026.3.13`
- `@dingtalk-real-ai/dingtalk-connector`: `0.7.8`

Observed behavior before fix:
- Config contained `ackText: ""`
- Connector still sent `🫡 任务已接收，处理中...`

Observed code path:

```ts
const ackText = dingtalkConfig.ackText || '🫡 任务已接收，处理中...';
```

Local patch that fixes it:

```ts
const ackText = dingtalkConfig.ackText ?? '🫡 任务已接收，处理中...';
if (typeof ackText === 'string' && ackText.trim().length > 0) {
  await sendProactive(...ackText...);
} else {
  log?.info?.('[DingTalk][Async] ackText 为空，跳过异步回执发送');
}
```

## Why this matters

The README / config behavior implies `ackText` is configurable, but there is currently no supported way to disable the acknowledgment while keeping `asyncMode` enabled.

This is especially relevant for users who want:
- async processing
- final response push
- no intermediate “任务已接收” message

## Optional PR title

```text
fix: allow ackText="" to disable async acknowledgment
```

## Optional PR description

This change makes `ackText: ""` a valid way to disable the async acknowledgment message while preserving `asyncMode` behavior.

### Before
- `ackText: ""` still sends the default ack text because `||` treats empty string as falsy.

### After
- `undefined` → fallback to default ack text
- non-empty string → send configured ack text
- empty string / whitespace-only string → skip ack send entirely

### Compatibility
This is backward-compatible for all existing users who rely on default or custom ack text.
Only the previously broken “disable via empty string” case changes behavior.
