### PR TITLE
feat: 在消息前注入 [META:senderId,conversationId] 前缀，方便 skill 提取发送者信息

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2615,6 +2615,7 @@ async function handleDingTalkMessage(params: {
   const isDirect = data.conversationType === '1';
   const senderId = data.senderStaffId || data.senderId;
   const senderName = data.senderNick || 'Unknown';
+  const conversationId = data.conversationId || '';
 
   log?.info?.(`[DingTalk] 收到消息: from=${senderName} type=${content.messageType} text="${content.text.slice(0, 50)}..." images=${content.imageUrls.length} downloadCodes=${content.downloadCodes.length}`);
 
@@ -2773,7 +2774,14 @@ async function handleDingTalkMessage(params: {
   // 对于纯图片消息（无文本），添加默认提示
   // 文本部分先经过 normalizeSlashCommand，统一将 /reset /clear 等别名指令转为 /new，再交由 Gateway 解析
   const rawText = content.text || '';
-  let userContent = normalizeSlashCommand(rawText) || (imageLocalPaths.length > 0 ? '请描述这张图片' : '');
+  const normalizedText = normalizeSlashCommand(rawText) || (imageLocalPaths.length > 0 ? '请描述这张图片' : '');
+  // 在消息前注入 META 前缀，供 skill 提取 senderId/conversationId
+  // 格式: [META:senderId=xxx,conversationId=xxx] 原始消息
+  const META_PREFIX = '[META:';
+  const userContent_base = normalizedText.startsWith(META_PREFIX)
+    ? normalizedText
+    : (normalizedText ? `${META_PREFIX}senderId=${senderId},conversationId=${conversationId}] ${normalizedText}` : '');
+  let userContent = userContent_base;
   // 追加文件内容
   if (fileContentParts.length > 0) {
     const fileText = fileContentParts.join('\n\n');


### PR DESCRIPTION
**动机**

当 dingtalk-connector 收到消息后，会调用 Gateway 的 /v1/chat/completions 接口，senderId 和 conversationId 等关键信息随之丢失。下游 skill（如 review-bot、 任何需要回复发送人的 skill）无法获取这两个信息，导致无法 @发送人。

**方案**

在 userContent 前注入 `[META:senderId=xxx,conversationId=xxx]` 前缀， skill 可通过正则提取：

```bash
META_MATCH=$(echo "$USER_MESSAGE" | grep -oP '^\[META:senderId=[^,]+,conversationId=[^\]]+\]')
SENDER_STAFF_ID=$(echo "$META_MATCH" | grep -oP 'senderId=\K[^,]+')
CONVERSATION_ID=$(echo "$META_MATCH" | grep -oP 'conversationId=\K[^\]]+')
```

**实现**

- 在 `handleDingTalkMessage` 中提取 `conversationId`
- 构建 META 前缀并拼接到 userContent 前
- 如果消息本身已包含 `[META:` 前缀（例如转发场景），则不重复注入
- 新会话命令（/new 等）不受影响，normalizeSlashCommand 先于 META 注入执行