### PR TITLE
feat: group webhook messaging with @ mention support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@
 This document records all significant changes. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [0.8.0] - 2026-03-14
+
+### 新增功能 / Added Features
+- ✅ **群聊 Webhook 消息模式** - 群聊回复通过自定义机器人 Webhook 发送，支持真正的 @ 提醒通知。AI Card 仅作为实时进度指示器，完成后自动替换为摘要（字数 + 耗时）  
+  **Group Webhook Message Mode** - Group replies sent via Custom Robot Webhook with real @ mention notifications. AI Card serves as a real-time progress indicator and is replaced with a summary (word count + time) after completion
+- ✅ **@ 提醒功能** - 通过 `<<AT:name>>` 线索机制让 AI 自主决定 @ 谁，结合文本中 `@Name` 模式的保底扫描，自动转换为钉钉 `atMobiles` 通知  
+  **@ Mention Support** - AI autonomously decides who to @ using `<<AT:name>>` clue mechanism, with fallback scanning for `@Name` patterns in text, automatically converted to DingTalk `atMobiles` notifications
+- ✅ **群聊发送者标识** - 群聊消息自动附加发送者昵称 `[sender]: message`，让共享会话中的 AI 知道谁在说话  
+  **Group Chat Sender Identification** - Group messages automatically prepend sender nickname `[sender]: message` so the AI knows who is speaking in shared sessions
+- ✅ **群聊 @ 系统提示词** - 可配置的系统提示词自动注入，教会 AI 使用 `<<AT:>>` 线索格式并遵循群聊交互规范  
+  **Group AT System Prompt** - Configurable system prompt injection that teaches the AI to use `<<AT:>>` clue format and follow group chat interaction conventions
+- ✅ **oapi Access Token 缓存** - 钉钉 oapi 的 access_token 增加 110 分钟内存缓存，避免每次请求重复获取（原先每次 ~8s 延迟）  
+  **oapi Access Token Caching** - In-memory cache for DingTalk oapi access_token with 110-minute TTL, eliminating redundant token fetches (~8s latency per request)
+
+### 配置 / Configuration
+- 新增 `groupWebhookUrl` — 自定义机器人 Webhook URL，启用后群聊回复通过 Webhook 发送（支持 @ 提醒）  
+  Added `groupWebhookUrl` — Custom robot webhook URL; when set, group replies are sent via webhook (enables @ mentions)
+- 新增 `groupAtMemberMap` — 成员昵称到手机号的映射表，用于 @ 提醒转换  
+  Added `groupAtMemberMap` — Map of member nicknames to mobile numbers for @ mention conversion
+- 新增 `groupAtDefaultMobile` — 错误时默认 @ 的手机号  
+  Added `groupAtDefaultMobile` — Default mobile to @ when errors occur
+- 新增 `groupAtSystemPrompt`（默认：`true`）— 是否自动注入群聊 @ 线索使用说明到系统提示词  
+  Added `groupAtSystemPrompt` (default: `true`) — Whether to auto-inject group AT clue instructions into system prompt
+
 ## [0.7.9] - 2026-03-13
 
 ### 新增 / Added

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 - ✅ **AI Card 流式响应** - 打字机效果，实时显示 AI 回复
 - ✅ **会话持久化** - 同一用户的多轮对话共享上下文
 - ✅ **会话与记忆隔离** - 按单聊/群聊/群区分 session，不同场景下的对话上下文互不干扰，可配置跨会话记忆共享
+- ✅ **群聊 @ 提醒** - 通过自定义机器人 Webhook 发送群聊回复，支持真正的 @ 通知（AI Card 模式下 @ 不生效的解决方案）
+- ✅ **AI Card 进度流** - 群聊 Webhook 模式下，AI Card 作为实时进度指示器，完成后自动替换为摘要
 - ✅ **超时自动新会话** - 默认 30 分钟无活动自动开启新对话
 - ✅ **手动新会话** - 发送 `/new` 或 `新会话` 清空对话历史
 - ✅ **图片自动上传** - 本地图片路径自动上传到钉钉
@@ -96,6 +98,13 @@ openclaw plugins install -l .
       "separateSessionByConversation": true,  // 可选：是否按单聊/群聊/群区分 session（默认：true）
       "groupSessionScope": "group",       // 可选：群聊会话隔离策略，group=群共享，group_sender=群内用户独立（默认：group）
       "sharedMemoryAcrossConversations": false, // 可选：是否在不同会话间共享记忆；false 时群聊与私聊、不同群记忆隔离（默认：false）
+      "groupWebhookUrl": "",               // 可选：自定义机器人 Webhook URL，启用群聊 @ 提醒功能
+      "groupAtMemberMap": {                // 可选：群成员昵称 -> 手机号映射，用于 @ 提醒
+        "张三": "13800138000",
+        "李四": "13900139000"
+      },
+      "groupAtDefaultMobile": "",          // 可选：出错时默认 @ 的手机号
+      "groupAtSystemPrompt": true,         // 可选：是否自动注入群聊 @ 提示词（默认：true）
       "asyncMode": false,                 // 可选：异步模式，立即回执用户消息，后台处理并推送结果（默认：false）
       "ackText": "🫡 任务已接收"      // 可选：异步模式下的回执消息文本（默认：'🫡 任务已接收，处理中...'）
     }
@@ -149,6 +158,10 @@ openclaw plugins list  # 确认 dingtalk-connector 已加载
 | `separateSessionByConversation` | — | 是否按单聊/群聊/群区分 session（默认：true） |
 | `groupSessionScope` | — | 群聊会话隔离策略（仅当 separateSessionByConversation=true 时生效）：`group`=群共享，`group_sender`=群内用户独立（默认：group） |
 | `sharedMemoryAcrossConversations` | — | 是否在不同会话间共享记忆；false 时群聊与私聊、不同群记忆隔离（默认：false） |
+| `groupWebhookUrl` | — | 自定义机器人 Webhook URL，启用后群聊回复通过 Webhook 发送，支持 @ 提醒 |
+| `groupAtMemberMap` | — | 群成员昵称到手机号的映射（JSON 对象），用于 @ 提醒转换。示例：`{"张三": "13800138000"}` |
+| `groupAtDefaultMobile` | — | 出错时默认 @ 的手机号 |
+| `groupAtSystemPrompt` | — | 是否自动注入群聊 @ 线索使用说明到系统提示词（默认：true） |
 | `asyncMode` | — | 异步模式，立即回执用户消息，后台处理并推送结果（默认：false） |
 | `ackText` | — | 异步模式下的回执消息文本（默认：'🫡 任务已接收，处理中...'） |
 
@@ -167,6 +180,44 @@ openclaw plugins list  # 确认 dingtalk-connector 已加载
 
 - **`group`**（默认）：整个群共享一个会话，群内所有用户共用同一个对话上下文
 - **`group_sender`**：群内每个用户独立会话，不同用户的对话上下文互不干扰
+
+## 群聊 @ 提醒（Group Webhook + @ Mentions）
+
+钉钉 Stream Bot 和 AI Card API 不支持 `atMobiles`，导致群聊中无法触发 @ 通知。本功能通过**自定义机器人 Webhook** 解决此问题。
+
+### 工作原理
+
+1. **AI Card 进度流** — 群聊中创建 AI Card 作为实时进度指示器，流式显示 AI 回复内容
+2. **Webhook 最终投递** — AI 回复完成后，通过自定义机器人 Webhook 发送最终消息（支持 `atMobiles`）
+3. **AI Card 摘要覆盖** — Webhook 发送成功后，AI Card 被替换为摘要（如 `✅ 128 字 · 5s`）
+4. **AI 自主 @ 决策** — AI 在回复末尾输出 `<<AT:昵称>>` 线索，系统解析后转换为 `atMobiles`
+
+### 配置步骤
+
+1. 在钉钉群设置中，添加"自定义机器人"，获取 Webhook URL
+2. 在 `openclaw.json` 中配置 `groupWebhookUrl` 和 `groupAtMemberMap`：
+
+```json5
+{
+  "channels": {
+    "dingtalk-connector": {
+      "groupWebhookUrl": "https://oapi.dingtalk.com/robot/send?access_token=YOUR_TOKEN",
+      "groupAtMemberMap": {
+        "张三": "13800138000",
+        "李四": "13900139000"
+      }
+    }
+  }
+}
+```
+
+3. 重启 OpenClaw，群聊中 AI 会自动使用 `<<AT:>>` 格式指定 @ 对象
+
+### 注意事项
+
+- 自定义机器人有频率限制：每分钟最多 20 条消息
+- `groupWebhookUrl` 为空时，行为与原版完全一致（AI Card 直接回复）
+- `groupAtSystemPrompt` 设为 `false` 可禁用自动注入的 @ 提示词（适合自定义 system prompt 的用户）
 
 ### 记忆隔离（sharedMemoryAcrossConversations）
 

--- a/docs/RELEASE_NOTES_V0.8.0.md
+++ b/docs/RELEASE_NOTES_V0.8.0.md
@@ -1,0 +1,49 @@
+# Release Notes - v0.8.0
+
+## 群聊增强版本 / Group Chat Enhancement Release
+
+本次更新解决了钉钉群聊中的三个核心痛点：@ 提醒不生效、AI Card 在群聊中体验不佳、以及 oapi access_token 重复获取导致的延迟。
+
+This release addresses three core pain points in DingTalk group chats: @ mentions not working, poor AI Card experience in groups, and latency from redundant oapi access_token fetches.
+
+## 核心功能 / Core Features
+
+### 群聊 Webhook 消息模式 / Group Webhook Message Mode
+
+**问题 / Problem**: 钉钉 Stream Bot 和 AI Card API 均不支持 `atMobiles` 参数，导致群聊中的 @ 提醒无法触发通知。
+
+**解决方案 / Solution**: 通过自定义机器人 Webhook 发送群聊回复，AI Card 作为实时进度指示器：
+
+```
+用户发消息 → AI Card 创建（进度流）→ Gateway 流式生成 → AI Card 实时更新
+                                                     → 生成完成 → Webhook 发送最终回复（带 @）
+                                                                 → AI Card 覆盖为摘要
+```
+
+### @ 提醒机制 / @ Mention Mechanism
+
+AI 通过 `<<AT:name>>` 线索格式自主决定需要通知的人：
+
+- **线索提取**: 从 AI 回复中解析 `<<AT:Alice,Bob>>` 格式
+- **保底扫描**: 扫描文本中的 `@Alice` 等显式 @ 模式
+- **自动转换**: 通过 `groupAtMemberMap` 配置将昵称转换为手机号
+- **系统提示词**: 自动注入使用说明，教会 AI 何时 @ 、何时不 @
+
+### oapi Access Token 缓存 / oapi Access Token Caching
+
+`getOapiAccessToken` 增加 110 分钟内存缓存（token 有效期 2 小时），消除每次请求 ~8s 的 DNS 解析 + API 调用延迟。
+
+## 配置 / Configuration
+
+| 配置项 | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `groupWebhookUrl` | string | `""` | 自定义机器人 Webhook URL |
+| `groupAtMemberMap` | object | `{}` | 昵称 → 手机号映射 |
+| `groupAtDefaultMobile` | string | `""` | 出错时默认 @ 的手机号 |
+| `groupAtSystemPrompt` | boolean | `true` | 是否自动注入 @ 提示词 |
+
+## 兼容性 / Compatibility
+
+- `groupWebhookUrl` 为空时（默认），行为与 v0.7.x 完全一致
+- 所有新功能通过配置项启用，零破坏性变更
+- 基于 v0.7.9 开发

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,15 +1,20 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "DingTalk (钉钉) messaging channel via Stream mode with AI Card streaming",
   "author": "DingTalk Real Team",
-  "channels": ["dingtalk-connector"],
+  "channels": [
+    "dingtalk-connector"
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
     "properties": {
-      "enabled": { "type": "boolean", "default": true }
+      "enabled": {
+        "type": "boolean",
+        "default": true
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "DingTalk (钉钉) channel connector — Stream mode with AI Card streaming",
   "main": "plugin.ts",
   "type": "module",

--- a/plugin.ts
+++ b/plugin.ts
@@ -203,16 +203,132 @@ function isConfigured(cfg: ClawdbotConfig): boolean {
 
 // ============ 钉钉图片上传 ============
 
+let _oapiTokenCache: { token: string; expiresAt: number } | null = null;
+
 async function getOapiAccessToken(config: any): Promise<string | null> {
+  if (_oapiTokenCache && Date.now() < _oapiTokenCache.expiresAt) {
+    return _oapiTokenCache.token;
+  }
   try {
     const resp = await axios.get('https://oapi.dingtalk.com/gettoken', {
       params: { appkey: config.clientId, appsecret: config.clientSecret },
+      timeout: 10_000,
     });
-    if (resp.data?.errcode === 0) return resp.data.access_token;
+    if (resp.data?.errcode === 0) {
+      _oapiTokenCache = {
+        token: resp.data.access_token,
+        expiresAt: Date.now() + 6600_000,  // cache for 110 min (token valid for 2h)
+      };
+      return resp.data.access_token;
+    }
     return null;
   } catch {
     return null;
   }
+}
+
+
+
+// ============ Group Webhook + @ Mention Support ============
+
+/**
+ * Parse <<AT:name1,name2>> clues from AI response text.
+ * Returns cleaned text and list of mobile numbers to @.
+ */
+function parseAtClue(text: string, memberMap: Record<string, string>): { cleanText: string; mobiles: string[] } {
+  const mobiles = new Set<string>();
+  const cluePattern = /<<AT:([^>]+)>>/g;
+  let cleanText = text;
+  let match;
+  while ((match = cluePattern.exec(text)) !== null) {
+    const names = match[1].split(',').map(n => n.trim()).filter(Boolean);
+    for (const name of names) {
+      const mobile = memberMap[name];
+      if (mobile) { mobiles.add(mobile); continue; }
+      // Case-insensitive fallback
+      for (const [key, val] of Object.entries(memberMap)) {
+        if (key.toLowerCase() === name.toLowerCase()) { mobiles.add(val); break; }
+      }
+    }
+  }
+  cleanText = cleanText.replace(/\s*<<AT:[^>]+>>\s*/g, '').trim();
+  return { cleanText, mobiles: Array.from(mobiles) };
+}
+
+/**
+ * Scan text for explicit @Name patterns (e.g. AI writes "@Chris" in the response).
+ * Fallback for when the AI doesn't use <<AT:>> clue format.
+ */
+function scanExplicitAtMentions(text: string, memberMap: Record<string, string>): string[] {
+  const mobiles = new Set<string>();
+  const atPattern = /@([\u4e00-\u9fa5a-zA-Z\s]{1,20})/g;
+  let match;
+  while ((match = atPattern.exec(text)) !== null) {
+    const mentioned = match[1].trim();
+    for (const [name, mobile] of Object.entries(memberMap)) {
+      if (mentioned.toLowerCase().startsWith(name.toLowerCase())) {
+        mobiles.add(mobile);
+      }
+    }
+  }
+  return Array.from(mobiles);
+}
+
+/**
+ * Send a message via DingTalk custom robot webhook.
+ * This is the only way to trigger real @ notifications in group chats,
+ * since Stream Bot and AI Card APIs do not support atMobiles.
+ */
+async function sendViaGroupWebhook(
+  webhookUrl: string,
+  text: string,
+  options: { atMobiles?: string[]; isAtAll?: boolean; useMarkdown?: boolean; title?: string; log?: any } = {},
+): Promise<boolean> {
+  const { atMobiles, isAtAll, useMarkdown, title, log } = options;
+  try {
+    const at: any = isAtAll
+      ? { isAtAll: true }
+      : (atMobiles && atMobiles.length > 0 ? { atMobiles, isAtAll: false } : {});
+    let fullText = text;
+    if (atMobiles && atMobiles.length > 0) {
+      fullText = `${text}\n\n${atMobiles.map(m => '@' + m).join(' ')}`;
+    }
+    let body: any;
+    if (useMarkdown) {
+      const t = title || fullText.split('\n')[0].replace(/^[#*\s\->]+/, '').slice(0, 20) || 'Message';
+      body = { msgtype: 'markdown', markdown: { title: t, text: fullText }, at };
+    } else {
+      body = { msgtype: 'text', text: { content: fullText }, at };
+    }
+    log?.info?.(`[DingTalk][GroupWebhook] Sending: type=${body.msgtype} len=${text.length} at=${JSON.stringify(at)}`);
+    const resp = await axios.post(webhookUrl, body, { headers: { 'Content-Type': 'application/json' }, timeout: 10_000 });
+    if (resp.data?.errcode === 0) { log?.info?.('[DingTalk][GroupWebhook] OK'); return true; }
+    log?.warn?.(`[DingTalk][GroupWebhook] Failed: ${JSON.stringify(resp.data)}`);
+    return false;
+  } catch (err: any) {
+    log?.error?.(`[DingTalk][GroupWebhook] Error: ${err.message}`);
+    return false;
+  }
+}
+
+/**
+ * Build dynamic group AT system prompt based on configured member map.
+ */
+function buildGroupAtSystemPrompt(memberMap: Record<string, string>): string {
+  const nameList = Object.keys(memberMap).join('、');
+  return (
+    '【Group Chat Rules / 群聊规则】\n' +
+    '1. Reply naturally; match response length to question complexity.\n' +
+    '2. This is a shared group conversation. Remember what everyone said.\n' +
+    '3. If context is too long, prioritize recent messages and important decisions.\n' +
+    '4. 【@ Mention Mechanism】Only when you need to notify a specific person, ' +
+    'append <<AT:nickname>> at the very end of your reply. Rules:\n' +
+    '   (a) Only @ someone when asked to relay a message to them.\n' +
+    '   (b) Do NOT @ the person who asked the question (they can already see your reply).\n' +
+    '   (c) To @ multiple people: <<AT:Alice,Bob>>.\n' +
+    '   (d) Default: do NOT @ anyone unless there is a clear reason.\n' +
+    (nameList ? `   Available nicknames: ${nameList}.` : '')
+  );
 }
 
 /** staffId → unionId 缓存 */
@@ -2676,6 +2792,14 @@ async function handleDingTalkMessage(params: {
     systemPrompts.push(dingtalkConfig.systemPrompt);
   }
 
+  // Group webhook mode: inject AT clue instructions into system prompt
+  const groupWebhookUrl = dingtalkConfig.groupWebhookUrl as string | undefined;
+  const groupAtMemberMap = (dingtalkConfig.groupAtMemberMap || {}) as Record<string, string>;
+  const groupWebhookEnabled = !isDirect && !!groupWebhookUrl;
+  if (groupWebhookEnabled && dingtalkConfig.groupAtSystemPrompt !== false) {
+    systemPrompts.push(buildGroupAtSystemPrompt(groupAtMemberMap));
+  }
+
   // ===== 图片下载到本地文件（用于 OpenClaw AgentMediaPayload） =====
   const imageLocalPaths: string[] = [];
 
@@ -2774,6 +2898,11 @@ async function handleDingTalkMessage(params: {
   // 文本部分先经过 normalizeSlashCommand，统一将 /reset /clear 等别名指令转为 /new，再交由 Gateway 解析
   const rawText = content.text || '';
   let userContent = normalizeSlashCommand(rawText) || (imageLocalPaths.length > 0 ? '请描述这张图片' : '');
+
+  // Group chats: prepend sender name so the shared session knows who's talking
+  if (!isDirect && senderName && userContent) {
+    userContent = `[${senderName}]: ${userContent}`;
+  }
   // 追加文件内容
   if (fileContentParts.length > 0) {
     const fileText = fileContentParts.join('\n\n');
@@ -2875,11 +3004,14 @@ async function handleDingTalkMessage(params: {
   const peerId = senderId;
 
   // 尝试创建 AI Card
-  const card = await createAICard(dingtalkConfig, data, log);
+  // Group webhook mode: AI Card is used as a progress indicator only
+  const card = groupWebhookEnabled ? null : await createAICard(dingtalkConfig, data, log);
+  const progressCard = groupWebhookEnabled ? await createAICard(dingtalkConfig, data, log) : null;
 
-  if (card) {
+  if (card || progressCard) {
     // ===== AI Card 流式模式 =====
-    log?.info?.(`[DingTalk] AI Card 创建成功: ${card.cardInstanceId}`);
+    const activeCard = card || progressCard!;
+    log?.info?.(`[DingTalk] AI Card 创建成功: ${activeCard.cardInstanceId}${progressCard ? ' (progress mode)' : ''}`);
 
     let accumulated = '';
     let lastUpdateTime = 0;
@@ -2917,7 +3049,7 @@ async function handleDingTalkMessage(params: {
             .replace(VIDEO_MARKER_PATTERN, '')
             .replace(AUDIO_MARKER_PATTERN, '')
             .trim();
-          await streamAICard(card, displayContent, false, log);
+          await streamAICard(activeCard, displayContent, false, log);
           lastUpdateTime = now;
         }
       }
@@ -2950,9 +3082,29 @@ async function handleDingTalkMessage(params: {
       const finalContent = accumulated.trim();
       if (finalContent.length === 0) {
         log?.info?.(`[DingTalk][AICard] 内容为空（纯媒体消息），使用默认提示`);
-        await finishAICard(card, '✅ 媒体已发送', log);
+        await finishAICard(activeCard, '✅ 媒体已发送', log);
       } else {
-        await finishAICard(card, finalContent, log);
+        if (groupWebhookEnabled) {
+          // Group webhook mode: send final reply via webhook with @ support, overwrite AI Card with summary
+          const { cleanText, mobiles: clueMobiles } = parseAtClue(finalContent, groupAtMemberMap);
+          const textAtMobiles = scanExplicitAtMentions(cleanText || '', groupAtMemberMap);
+          const finalMobiles = [...new Set([...clueMobiles, ...textAtMobiles])];
+          log?.info?.(`[DingTalk][AT] clue=${JSON.stringify(clueMobiles)} textAt=${JSON.stringify(textAtMobiles)} final=${JSON.stringify(finalMobiles)}`);
+          await sendViaGroupWebhook(groupWebhookUrl!, cleanText || '(no response)', {
+            atMobiles: finalMobiles,
+            useMarkdown: true,
+            log,
+          });
+          const totalTime = Math.round((Date.now() - (lastUpdateTime - updateInterval * chunkCount)) / 1000);
+          const summary = `✅ ${cleanText.length} 字 · ${totalTime}s`;
+          try {
+            await finishAICard(activeCard, summary, log);
+          } catch (e: any) {
+            log?.warn?.(`[DingTalk][GroupWebhook] Summary overwrite failed: ${e.message}`);
+          }
+        } else {
+          await finishAICard(activeCard, finalContent, log);
+        }
       }
       log?.info?.(`[DingTalk] 流式响应完成，共 ${finalContent.length} 字符`);
 
@@ -2961,7 +3113,7 @@ async function handleDingTalkMessage(params: {
       log?.error?.(`[DingTalk] 错误详情: ${err.stack}`);
       accumulated += `\n\n⚠️ 响应中断: ${err.message}`;
       try {
-        await finishAICard(card, accumulated, log);
+        await finishAICard(activeCard, accumulated, log);
       } catch (finishErr: any) {
         log?.error?.(`[DingTalk] 错误恢复 finish 也失败: ${finishErr.message}`);
       }
@@ -3005,17 +3157,38 @@ async function handleDingTalkMessage(params: {
       log?.info?.(`[DingTalk][File] (降级模式) 开始文件后处理`);
       fullResponse = await processFileMarkers(fullResponse, sessionWebhook, dingtalkConfig, oapiToken, log);
 
-      await sendMessage(dingtalkConfig, sessionWebhook, fullResponse || '（无响应）', {
-        atUserId: !isDirect ? senderId : null,
-        useMarkdown: true,
-      });
-      log?.info?.(`[DingTalk] 普通消息回复完成，共 ${fullResponse.length} 字符`);
+      if (groupWebhookEnabled) {
+        // Group webhook mode: send via webhook with @ support
+        const { cleanText, mobiles: clueMobiles } = parseAtClue(fullResponse || '', groupAtMemberMap);
+        const textAtMobiles = scanExplicitAtMentions(cleanText || '', groupAtMemberMap);
+        const finalMobiles = [...new Set([...clueMobiles, ...textAtMobiles])];
+        log?.info?.(`[DingTalk][AT] clue=${JSON.stringify(clueMobiles)} textAt=${JSON.stringify(textAtMobiles)} final=${JSON.stringify(finalMobiles)}`);
+        await sendViaGroupWebhook(groupWebhookUrl!, cleanText || '(no response)', {
+          atMobiles: finalMobiles,
+          useMarkdown: true,
+          log,
+        });
+      } else {
+        await sendMessage(dingtalkConfig, sessionWebhook, fullResponse || '（无响应）', {
+          atUserId: !isDirect ? senderId : null,
+          useMarkdown: true,
+        });
+      }
+      log?.info?.(`[DingTalk] 回复完成，共 ${fullResponse.length} 字符`);
 
     } catch (err: any) {
       log?.error?.(`[DingTalk] Gateway 调用失败: ${err.message}`);
-      await sendMessage(dingtalkConfig, sessionWebhook, `抱歉，处理请求时出错: ${err.message}`, {
-        atUserId: !isDirect ? senderId : null,
-      });
+      if (groupWebhookEnabled) {
+        const defaultMobile = dingtalkConfig.groupAtDefaultMobile as string | undefined;
+        await sendViaGroupWebhook(groupWebhookUrl!, `Error: ${err.message}`, {
+          atMobiles: defaultMobile ? [defaultMobile] : [],
+          log,
+        });
+      } else {
+        await sendMessage(dingtalkConfig, sessionWebhook, `抱歉，处理请求时出错: ${err.message}`, {
+          atUserId: !isDirect ? senderId : null,
+        });
+      }
     }
   }
   } finally {
@@ -3372,6 +3545,11 @@ const dingtalkPlugin = {
         sharedMemoryAcrossConversations: { type: 'boolean', default: false, description: '单 agent 场景下是否共享记忆；false 时不同群聊、群聊与私聊记忆隔离' },
         asyncMode: { type: 'boolean', default: false, description: 'Send immediate ack and push final result as a second message' },
         ackText: { type: 'string', default: '🫡 任务已接收，处理中...', description: 'Ack text when asyncMode is enabled' },
+        groupWebhookUrl: { type: 'string', default: '', description: 'Custom robot webhook URL for group messages. When set, group replies use this webhook (supports @ mentions via atMobiles). Get this URL from DingTalk group settings > Smart Group Assistant > Add Robot > Custom Robot.' },
+        groupAtMemberMap: { type: 'object', default: {}, description: 'Map of member name/nickname to mobile number for @ mentions. Example: {"Alice": "13800138000", "Bob": "13900139000"}. The AI uses <<AT:Alice>> clue in its response, which is then converted to a real @ notification.' },
+        groupAtDefaultMobile: { type: 'string', default: '', description: 'Default mobile number to @ when error occurs and sender cannot be identified' },
+        groupAtSystemPrompt: { type: 'boolean', default: true, description: 'Auto-inject group chat AT clue instructions into system prompt. Set to false if you want to handle @ logic in your own system prompt.' },
+        groupSessionScope: { type: 'string', enum: ['group', 'group_sender'], default: 'group', description: 'Group session isolation: "group" = shared session for entire group (recommended), "group_sender" = separate session per user in group' },
         debug: { type: 'boolean', default: false },
       },
       required: ['clientId', 'clientSecret'],
@@ -4061,6 +4239,10 @@ export {
   dingtalkPlugin,
   // 回复消息（需要 sessionWebhook）
   sendMessage,
+  sendViaGroupWebhook,
+  parseAtClue,
+  scanExplicitAtMentions,
+  buildGroupAtSystemPrompt,
   sendTextMessage,
   sendMarkdownMessage,
   // 主动发送消息（无需 sessionWebhook）


### PR DESCRIPTION
Add group chat enhancements:
- Group replies sent via custom robot webhook (supports atMobiles)
- AI Card serves as real-time progress indicator, replaced with summary
- AI autonomously decides @ targets using <<AT:name>> clue mechanism
- Fallback scanning for @Name patterns in text
- Auto-inject group AT clue instructions into system prompt
- Prepend sender name in group messages for shared session context
- Cache oapi access_token for 110 min to reduce latency

All features are opt-in via configuration (groupWebhookUrl, groupAtMemberMap). When groupWebhookUrl is empty (default), behavior is identical to v0.7.x.


## Summary / 概要

解决钉钉群聊中三个核心痛点 / Addresses three core pain points in DingTalk group chats:

- **@ 提醒不生效** — Stream Bot 和 AI Card API 均不支持 `atMobiles`，群聊中无法触发 @ 通知
- **AI Card 群聊体验差** — 群聊中 AI Card 无法 @ 人，且样式笨重
- **oapi access_token 重复获取** — 每次请求重新获取 token 导致 ~8s 延迟

## Changes / 改动

### Group Webhook Message Mode / 群聊 Webhook 消息模式
- 群聊回复通过自定义机器人 Webhook 发送，支持 `atMobiles` 真正的 @ 通知
- AI Card 作为实时进度指示器，完成后自动替换为摘要（`✅ 128 字 · 5s`）
- 通过 `groupWebhookUrl` 配置项启用，为空时行为与原版一致

### @ Mention Support / @ 提醒功能
- AI 通过 `<<AT:name>>` 线索格式自主决定 @ 谁
- 保底扫描文本中的 `@Name` 显式 @ 模式
- 通过 `groupAtMemberMap` 配置昵称到手机号的映射
- 可配置的系统提示词自动注入（`groupAtSystemPrompt`）

### Group Chat Sender Identification / 群聊发送者标识
- 群聊消息自动附加 `[sender]: message`，让共享会话中的 AI 知道谁在说话

### oapi Access Token Caching / Access Token 缓存
- `getOapiAccessToken` 增加 110 分钟内存缓存（token 有效期 2h），消除重复获取延迟

## Configuration / 配置

| 配置项 | 类型 | 默认值 | 说明 |
|--------|------|--------|------|
| `groupWebhookUrl` | string | `""` | 自定义机器人 Webhook URL |
| `groupAtMemberMap` | object | `{}` | 昵称 → 手机号映射 |
| `groupAtDefaultMobile` | string | `""` | 出错时默认 @ 的手机号 |
| `groupAtSystemPrompt` | boolean | `true` | 是否自动注入 @ 提示词 |

## Compatibility / 兼容性

- 所有新功能通过配置项 opt-in，`groupWebhookUrl` 为空时行为与 v0.7.x 完全一致
- 零破坏性变更
- 基于 v0.7.9 开发