### PR TITLE
feat: 文件上下文中展示 localPath，便于 AI 引用与调试

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2762,7 +2762,7 @@ async function handleDingTalkMessage(params: {
         const fileContent = fs.readFileSync(localPath, 'utf-8');
         const maxLen = 50_000; // 限制最大读取长度
         const truncated = fileContent.length > maxLen ? fileContent.slice(0, maxLen) + '\n...(内容过长，已截断)' : fileContent;
-        fileContentParts.push(`[文件: ${fileName}]\n\`\`\`\n${truncated}\n\`\`\``);
+        fileContentParts.push(`[文件: ${fileName}]\n[本地路径: ${localPath}]\n\`\`\`\n${truncated}\n\`\`\``);
         log?.info?.(`[DingTalk][File] 文本文件已读取: ${fileName}, size=${fileContent.length}, localPath=${localPath}`);
       } catch (err: any) {
         log?.error?.(`[DingTalk][File] 读取文本文件失败: ${err.message}`);
@@ -2776,7 +2776,7 @@ async function handleDingTalkMessage(params: {
         const fileContent = result.value;
         const maxLen = 50_000;
         const truncated = fileContent.length > maxLen ? fileContent.slice(0, maxLen) + '\n...(内容过长，已截断)' : fileContent;
-        fileContentParts.push(`[文件: ${fileName}]\n\`\`\`\n${truncated}\n\`\`\``);
+        fileContentParts.push(`[文件: ${fileName}]\n[本地路径: ${localPath}]\n\`\`\`\n${truncated}\n\`\`\``);
         log?.info?.(`[DingTalk][File] Word 文档已提取文本: ${fileName}, size=${fileContent.length}, localPath=${localPath}`);
       } catch (err: any) {
         log?.error?.(`[DingTalk][File] Word 文档文本提取失败: ${err.message}`);
@@ -2791,7 +2791,7 @@ async function handleDingTalkMessage(params: {
         const fileContent = pdfData.text;
         const maxLen = 50_000;
         const truncated = fileContent.length > maxLen ? fileContent.slice(0, maxLen) + '\n...(内容过长，已截断)' : fileContent;
-        fileContentParts.push(`[文件: ${fileName}]\n\`\`\`\n${truncated}\n\`\`\``);
+        fileContentParts.push(`[文件: ${fileName}]\n[本地路径: ${localPath}]\n\`\`\`\n${truncated}\n\`\`\``);
         log?.info?.(`[DingTalk][File] PDF 文档已提取文本: ${fileName}, size=${fileContent.length}, localPath=${localPath}`);
       } catch (err: any) {
         log?.error?.(`[DingTalk][File] PDF 文档文本提取失败: ${err.message}`);


### PR DESCRIPTION
## 变更说明
在文本文件、Word 文档、PDF 文档处理时，增加文件本地路径（localPath）的展示：

1. **AI 上下文**：在推送给模型的文件内容中加入 [本地路径] 信息，便于 AI 在回复中引用或提示用户文件保存位置
2. **日志输出**：在处理成功时的日志中增加 localPath，便于运维调试时快速定位文件存储位置

## 修改内容
- 文本文件：内容与日志均增加 localPath
- Word 文档：内容与日志均增加 localPath
- PDF 文档：内容与日志均增加 localPath