### PR TITLE
fix: /new command not creating new session (#254)

### DIFF
--- a/plugin.ts
+++ b/plugin.ts
@@ -2679,8 +2679,6 @@ async function handleDingTalkMessage(params: {
     separateSessionByConversation,
     groupSessionScope,
   });
-  const sessionContextJson = JSON.stringify(sessionContext);
-  log?.info?.(`[DingTalk][Session] context=${sessionContextJson}`);
 
   // memoryUser 用于 Gateway 区分记忆归属
   // 使用 peerId（不包含中文）作为标识符，避免 HTTP Header 编码问题
@@ -2805,15 +2803,29 @@ async function handleDingTalkMessage(params: {
   }
 
   // 对于纯图片消息（无文本），添加默认提示
-  // 文本部分先经过 normalizeSlashCommand，统一将 /reset /clear 等别名指令转为 /new，再交由 Gateway 解析
+  // 文本部分先经过 normalizeSlashCommand，统一将 /reset /clear 等别名指令转为 /new
   const rawText = content.text || '';
-  let userContent = normalizeSlashCommand(rawText) || (imageLocalPaths.length > 0 ? '请描述这张图片' : '');
+  const normalizedText = normalizeSlashCommand(rawText);
+  const isNewSessionCommand = normalizedText === '/new';
+
+  // 检测新会话命令，在 sessionKey 中注入时间戳强制创建新会话
+  const finalSessionContext = isNewSessionCommand
+    ? { ...sessionContext, timestamp: Date.now() }
+    : sessionContext;
+  const sessionKey = JSON.stringify(finalSessionContext);
+
+  log?.info?.(`[DingTalk][Session] context=${sessionKey}${isNewSessionCommand ? ' (新会话)' : ''}`);
+
+  let userContent = isNewSessionCommand
+    ? '' // 新会话时使用空内容，让 AI 自然开场
+    : (normalizedText || (imageLocalPaths.length > 0 ? '请描述这张图片' : ''));
   // 追加文件内容
   if (fileContentParts.length > 0) {
     const fileText = fileContentParts.join('\n\n');
     userContent = userContent ? `${userContent}\n\n${fileText}` : fileText;
   }
-  if (!userContent && imageLocalPaths.length === 0) return;
+  // 新会话命令必须有内容（即使是空的）才能触发 Gateway 创建新会话
+  if (!userContent && !isNewSessionCommand && imageLocalPaths.length === 0) return;
 
   // ===== 贴处理中表情 =====
   await addEmotionReply(dingtalkConfig, data, log);
@@ -2847,7 +2859,7 @@ async function handleDingTalkMessage(params: {
       for await (const chunk of streamFromGateway({
         userContent,
         systemPrompts,
-        sessionKey: sessionContextJson,
+        sessionKey: sessionKey,
         gatewayAuth,
         gatewayBaseUrl: dingtalkConfig.gatewayBaseUrl,
         memoryUser,
@@ -2925,7 +2937,7 @@ async function handleDingTalkMessage(params: {
       for await (const chunk of streamFromGateway({
         userContent,
         systemPrompts,
-        sessionKey: sessionContextJson,
+        sessionKey: sessionKey,
         gatewayAuth,
         gatewayBaseUrl: dingtalkConfig.gatewayBaseUrl,
         memoryUser,
@@ -3010,7 +3022,7 @@ async function handleDingTalkMessage(params: {
       for await (const chunk of streamFromGateway({
         userContent,
         systemPrompts,
-        sessionKey: sessionContextJson,
+        sessionKey: sessionKey,
         gatewayAuth,
         gatewayBaseUrl: dingtalkConfig.gatewayBaseUrl,
         memoryUser,

--- a/tests/core/core.test.ts
+++ b/tests/core/core.test.ts
@@ -48,11 +48,17 @@ describe('core functionality', () => {
       const { __testables } = await import('../../plugin');
       const { normalizeSlashCommand } = __testables as any;
 
+      // 覆盖所有新会话命令
       expect(normalizeSlashCommand('/new')).toBe('/new');
       expect(normalizeSlashCommand('/reset')).toBe('/new');
       expect(normalizeSlashCommand('/clear')).toBe('/new');
       expect(normalizeSlashCommand('新会话')).toBe('/new');
       expect(normalizeSlashCommand('重新开始')).toBe('/new');
+      expect(normalizeSlashCommand('清空对话')).toBe('/new');
+
+      // 测试大小写不敏感
+      expect(normalizeSlashCommand('/NEW')).toBe('/new');
+      expect(normalizeSlashCommand('/Reset')).toBe('/new');
     });
 
     it('should return original text for non-command text', async () => {


### PR DESCRIPTION
  ## Problem Summary

  When users send new session commands (`/new`, `/reset`, `/clear`, `新会话`, `重新开始`, `清空对话`):
  - ❌ New session is not created
  - ❌ Conversation context is not cleared
  - ❌ Chat history persists unexpectedly

  ### Root Cause

  The current implementation sends `/new` as `userContent` to Gateway, but `sessionKey` remains unchanged for the same conversation. Gateway cannot identify that a new session is requested when `sessionKey` is identical.

  **Code flow:**
  ```typescript
  // Before: sessionKey is static
  const sessionContext = buildSessionContext({...});
  const sessionKey = JSON.stringify(sessionContext); // Always same for same conversation!

  // Gateway receives:
  // - sessionKey: {"channel":"dingtalk-connector",...} (unchanged)
  // - userContent: "/new"
  // → Gateway treats this as normal message in existing session
```
  Solution

  Approach: Inject timestamp into sessionKey for new session commands

  When a new session command is detected:
  1. Inject timestamp: Date.now() into SessionContext
  2. Generate unique sessionKey to force Gateway creating new session
  3. Convert /new command to empty content, let AI start naturally
  4. Fix early return logic to ensure command reaches Gateway

 Fixes #254

 