### PR TITLE
fix:修复sendFileProactive调用参数使用错误问题,修复无法发送文件的问题

### DIFF
--- a/src/services/media.ts
+++ b/src/services/media.ts
@@ -667,7 +667,7 @@ export async function processFileMarkers(
 
       // 发送文件消息
       if (useProactiveApi && target) {
-        await sendFileProactive(config, target, fileInfo, uploadResult.downloadUrl, log);
+        await sendFileProactive(config, target, fileInfo, uploadResult.cleanMediaId, log);
       } else {
         await sendFileMessage(config, sessionWebhook, fileInfo, uploadResult.downloadUrl, log);
       }
@@ -1108,7 +1108,7 @@ export async function processRawMediaPaths(
         
         if (target) {
           // 文件消息使用下载链接
-          await sendFileProactive(config, target, fileInfo, uploadResult.downloadUrl, log);
+          await sendFileProactive(config, target, fileInfo, uploadResult.cleanMediaId, log);
         }
         statusMessages.push(`✅ 文件已发送: ${fileName}`);
       }


### PR DESCRIPTION
PR 描述
🐛 问题描述
在 src/services/media.ts 中，sendFileProactive 函数被调用时使用了错误的参数：

错误地传递了 uploadResult.downloadUrl 作为第4个参数
应该传递 uploadResult.cleanMediaId（媒体文件ID）

📝 修改内容
修复了两处调用点：
processFileMarkers 函数 (第670行)
processRawMediaPaths 函数 (第1111行)

- await sendFileProactive(config, target, fileInfo, uploadResult.downloadUrl, log);
+ await sendFileProactive(config, target, fileInfo, uploadResult.cleanMediaId, log);

✅ 影响范围
修复了使用主动 API 模式发送文件失败的问题
确保文件消息能够正确通过钉钉 API 发送