### PR TITLE
fix: don't block session queue on dispatch — allow steer/followup queue to work

### DIFF
--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -1258,15 +1258,22 @@ export async function handleDingTalkMessage(params: HandleMessageParams): Promis
     }
 
     // 创建当前消息的处理任务
+    // Fire-and-forget: 启动 dispatch 但不在队列链中等待完成。
+    // 队列保证同一会话的消息按顺序*启动*，但每个 dispatch 独立在后台执行。
+    // 这允许 SDK 的 steer/followup 队列机制在当前 agent run 进行中时
+    // 接收到下一条消息，从而实现"转向"或"排队跟进"。
+    // 参考：OpenClaw Discord inbound-worker 使用 `void runQueue.enqueue(...)`。
     const currentTask = previousTask
-      .then(async () => {
+      .then(() => {
         log?.info?.(`[队列] 开始处理消息，queueKey=${queueKey}`);
-        await handleDingTalkMessageInternal({ ...params, preCreatedCard, emotionAlreadyAdded: isQueueBusy });
-        log?.info?.(`[队列] 消息处理完成，queueKey=${queueKey}`);
-      })
-      .catch((err: any) => {
-        log?.error?.(`[队列] 消息处理异常，queueKey=${queueKey}, error=${err.message}`);
-        // 不抛出错误，避免阻塞后续消息
+        // 不 await —— dispatch 在后台运行，队列立即释放给下一条消息
+        void handleDingTalkMessageInternal({ ...params, preCreatedCard, emotionAlreadyAdded: isQueueBusy })
+          .then(() => {
+            log?.info?.(`[队列] 消息处理完成，queueKey=${queueKey}`);
+          })
+          .catch((err: any) => {
+            log?.error?.(`[队列] 消息处理异常，queueKey=${queueKey}, error=${err.message}`);
+          });
       })
       .finally(() => {
         // 如果当前任务是队列中的最后一个任务，清理队列


### PR DESCRIPTION
## Summary

- Fix steer/followup queue mode not working when messages arrive during an active agent run
- The per-session serial queue currently `await`s the full `handleDingTalkMessageInternal` call,
  which blocks the next message from reaching the SDK's steer mechanism
- Change to fire-and-forget dispatch within the queue task, matching the pattern used by
  OpenClaw's Discord inbound-worker (`void runQueue.enqueue(...)`)

## Root Cause

The serial queue (`sessionQueues` in `message-handler.ts`) chains tasks via `previousTask.then(async () => { await handleDingTalkMessageInternal(...) })`, where `handleDingTalkMessageInternal` blocks for the entire agent dispatch including LLM inference + reply delivery (tens of seconds to minutes).

This means the second message's task cannot start until the first agent run fully completes:

```
msg1 → previousTask.then() → await handleDingTalkMessageInternal → agent running...
msg2 → currentTask.then()  → waits for msg1's task to resolve    ← BLOCKED HERE
                                                    ↓
                                   msg2 never reaches SDK's steer mechanism
```

The SDK's steer queue action (`resolveActiveRunQueueAction`) correctly returns `"enqueue-followup"` when `isActive === true && queueMode === "steer"`, but the second message never reaches `runReplyAgent` because it's stuck behind the serial queue.

**Note**: The outer function is already fire-and-forget (line 1282: "不等待任务完成，立即返回，不阻塞 WebSocket 消息接收"), so WebSocket message reception is not blocked. The issue is that **within the queue chain**, tasks are strictly serial — message 2's `handleDingTalkMessageInternal` waits for message 1's to complete.

**WeCom (working correctly)**: No per-session serial queue; each message independently calls `dispatchReplyFromConfig`.

**Discord (working correctly)**: Uses `void runQueue.enqueue(...)` — fire-and-forget pattern.

## Fix

Make the dispatch within the queue task fire-and-forget (`void` instead of `await`). The queue still guarantees per-session message ordering (tasks start serially), but individual agent runs execute concurrently in the background.

```diff
 const currentTask = previousTask
-  .then(async () => {
+  .then(() => {
     log?.info?.(`[队列] 开始处理消息，queueKey=${queueKey}`);
-    await handleDingTalkMessageInternal({ ...params, preCreatedCard, emotionAlreadyAdded: isQueueBusy });
-    log?.info?.(`[队列] 消息处理完成，queueKey=${queueKey}`);
-  })
-  .catch((err: any) => {
-    log?.error?.(`[队列] 消息处理异常，queueKey=${queueKey}, error=${err.message}`);
+    void handleDingTalkMessageInternal({ ...params, preCreatedCard, emotionAlreadyAdded: isQueueBusy })
+      .then(() => {
+        log?.info?.(`[队列] 消息处理完成，queueKey=${queueKey}`);
+      })
+      .catch((err: any) => {
+        log?.error?.(`[队列] 消息处理异常，queueKey=${queueKey}, error=${err.message}`);
+      });
   })
   .finally(() => { ... });
```

### Safety analysis

| Concern | Status | Detail |
|---------|--------|--------|
| Reply delivery | ✅ Safe | AI Card streaming + `withReplyDispatcher` run inside `handleDingTalkMessageInternal`, continue in background |
| `onSettled` / typing indicator | ✅ Safe | `markDispatchIdle()` called in `onSettled` callback inside `withReplyDispatcher` |
| Error handling | ✅ Safe | Moved from outer `.catch()` to inner `.catch()` — errors still logged, no unhandled rejections |
| Fallback error message | ✅ Safe | The `catch` block inside `handleDingTalkMessageInternal` (line 1133) sends fallback error to user |
| Emotion recall | ✅ Safe | `recallEmotionReply` runs at the end of `handleDingTalkMessageInternal`, continues in background |
| Concurrent agent runs | ✅ Safe | SDK's steer mechanism injects into current run or enqueues followup — no parallel runs |
| `sessionQueues` cleanup | ✅ Safe | `.finally()` still runs, correctly checks `sessionQueues.get(queueKey) === currentTask` |
| Queue busy ACK card | ⚠️ Note | `isQueueBusy` detection may trigger less often since queue tasks resolve faster. This is expected in steer mode — the second message is injected into the current run rather than truly "queued". |

### What's NOT changed

- **`handleDingTalkMessageInternal`**: No changes — all dispatch, error handling, and lifecycle management remain the same.
- **Queue busy ACK card creation** (lines 1231-1257): Kept as-is. In steer mode the SDK handles the second message seamlessly, so the "排队中" UX hint becomes less relevant.
- **`sessionLastActivity` / TTL cleanup** (lines 100-108): Unchanged, still works correctly.

## Test Plan

- [ ] Send two messages in quick succession in the same chat (steer mode enabled)
- [ ] Verify the second message is processed without waiting for the first to complete
- [ ] Verify the first message's AI Card streaming reply completes normally
- [ ] Verify error handling: simulate a dispatch failure and check error logs
- [ ] Verify non-steer modes (collect, followup) still work correctly
- [ ] Verify async mode dispatch still works correctly
- [ ] Verify emotion reply (贴表情/撤回表情) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)