### PR TITLE
chore: release v0.8.13-beta.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -30,9 +30,17 @@ tests/
 # Development
 .aone_copilot/
 AGENTS.md
+CLAUDE.md
+.qoder/
+.claude/
 .github/
 .git/
 .gitignore
+install-beta.sh
+install-npm.sh
+
+# Large images
+docs/images/
 
 # Documentation (keep only essential docs)
 docs/RELEASE_NOTES_*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.13-beta.0] - 2026-04-06
+
+### 修复 / Fixes
+- 🐛 **修复多账号场景下凭据未解析** - `sendText`/`sendMedia` 在多账号模式下 `clientId`/`clientSecret` 可能为 `SecretInput` 对象，导致 API 请求携带无效凭据。现已用 `resolveDingtalkAccount` 返回的已解析值覆盖原始 config  
+  **Fix unresolved credentials in sendText/sendMedia** - In multi-account mode, credentials could be `SecretInput` objects; now resolved values are used
+
+- 🐛 **修复连接错误在 async 回调中无法传播** - `connection.ts` 错误处理使用 `throw` 抛出，但在 async 回调内无法被外层 Promise 捕获。改为 `reject(new Error(...))` 确保 400/401 等错误正确传播  
+  **Fix connection errors not propagating in async callback** - Changed `throw` to `reject()` inside async error handlers
+
+- 🐛 **修复 QPS 限流后立即重试触发再次限流** - 收到 403 QpsLimit 后未更新 `lastUpdateTime`，导致节流检查立即放行。现已同步更新节流时间  
+  **Fix QPS rate limit immediate retry** - `lastUpdateTime` is now synced when skipping a QPS-limited update
+
+- 🐛 **修复 `resolveAllowFrom` 全局过滤误拦截群消息** - `allowFrom` 仅用于私聊白名单，群消息由 `groupAllowFrom` 在内部处理。将 `resolveAllowFrom` 改为返回空列表，禁用框架层全局过滤  
+  **Fix resolveAllowFrom global filter blocking group messages** - Returns `[]` to disable framework-level filtering; internal policy checks handle DM and group separately
+
+### 新增 / Added
+- ✨ **消息路由支持 `group:`/`user:` 前缀** - `sendTextToDingTalk` 和 `sendMediaToDingTalk` 新增 `group:<id>` 和 `user:<id>` 格式解析，与 `gateway-methods.ts` 保持一致，兼容旧版裸 `cid` 前缀  
+  **Message routing supports `group:`/`user:` prefix targets** - Consistent with `gateway-methods.ts`, backward compatible with bare `cid` prefix
+
+### 改进 / Improvements
+- ✅ **兼容 pdf-parse v1 和 v2 API** - `parsePdfFile` 自动检测 pdf-parse 导出格式，v2.x 使用 `PDFParse` 类，v1.x 使用 `default` 函数  
+  **Support both pdf-parse v1 and v2 API** - Auto-detects export format: v2.x class API or v1.x function API
+
+- ✅ **`enableMediaUpload`/`systemPrompt` 移至共享配置** - 这两个字段现在支持多账号模式下每个账号独立配置  
+  **Move `enableMediaUpload`/`systemPrompt` to shared config** - Now configurable per-account in multi-account mode
+
+### 文档 / Documentation
+- 📝 **优化 README 安装验证说明** - 移除版本号硬编码，新增插件未加载时的警示提示  
+  **Improve README plugin verification instructions** - Removed hardcoded version, added warning when plugin is not loaded
+
 ## [0.8.12] - 2026-04-01
 
 ### 修复 / Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,35 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.13-beta.0] - 2026-04-06
+## [0.8.13] - 2026-04-08
 
 ### 修复 / Fixes
-- 🐛 **修复多账号场景下凭据未解析** - `sendText`/`sendMedia` 在多账号模式下 `clientId`/`clientSecret` 可能为 `SecretInput` 对象，导致 API 请求携带无效凭据。现已用 `resolveDingtalkAccount` 返回的已解析值覆盖原始 config  
-  **Fix unresolved credentials in sendText/sendMedia** - In multi-account mode, credentials could be `SecretInput` objects; now resolved values are used
+- 🐛 **修复文件发送 mediaId 格式不一致导致静默失败** - `sendFileProactive` 在不同调用点传入 `cleanMediaId`（不带 `@`）和 `mediaId`（带 `@`），经实测钉钉 API 统一要求带 `@` 前缀。同时修复 catch 块吞掉异常导致外层误报成功  
+  **Fix inconsistent mediaId format causing silent file send failure** - Unified to `@`-prefixed `mediaId`; fixed catch blocks swallowing errors
 
-- 🐛 **修复连接错误在 async 回调中无法传播** - `connection.ts` 错误处理使用 `throw` 抛出，但在 async 回调内无法被外层 Promise 捕获。改为 `reject(new Error(...))` 确保 400/401 等错误正确传播  
-  **Fix connection errors not propagating in async callback** - Changed `throw` to `reject()` inside async error handlers
+- 🐛 **修复多账号场景下凭据未解析** - `sendText`/`sendMedia` 在多账号模式下 `clientId`/`clientSecret` 可能为 `SecretInput` 对象，现已用已解析值覆盖  
+  **Fix unresolved credentials in multi-account mode** - Resolved values now override raw config
 
-- 🐛 **修复 QPS 限流后立即重试触发再次限流** - 收到 403 QpsLimit 后未更新 `lastUpdateTime`，导致节流检查立即放行。现已同步更新节流时间  
-  **Fix QPS rate limit immediate retry** - `lastUpdateTime` is now synced when skipping a QPS-limited update
+- 🐛 **修复连接错误在 async 回调中无法传播** - 改为 `reject(new Error(...))` 确保 400/401 等错误正确传播  
+  **Fix connection errors not propagating** - Changed `throw` to `reject()` inside async error handlers
 
-- 🐛 **修复 `resolveAllowFrom` 全局过滤误拦截群消息** - `allowFrom` 仅用于私聊白名单，群消息由 `groupAllowFrom` 在内部处理。将 `resolveAllowFrom` 改为返回空列表，禁用框架层全局过滤  
-  **Fix resolveAllowFrom global filter blocking group messages** - Returns `[]` to disable framework-level filtering; internal policy checks handle DM and group separately
+- 🐛 **修复 QPS 限流后立即重试** - 收到 403 QpsLimit 后同步更新 `lastUpdateTime`  
+  **Fix QPS rate limit immediate retry** - `lastUpdateTime` is now synced when skipping
+
+- 🐛 **修复 `resolveAllowFrom` 全局过滤误拦截群消息** - 返回空列表禁用框架层全局过滤，群消息由内部 `groupAllowFrom` 处理  
+  **Fix resolveAllowFrom blocking group messages** - Returns `[]` to disable framework-level filtering
 
 ### 新增 / Added
-- ✨ **消息路由支持 `group:`/`user:` 前缀** - `sendTextToDingTalk` 和 `sendMediaToDingTalk` 新增 `group:<id>` 和 `user:<id>` 格式解析，与 `gateway-methods.ts` 保持一致，兼容旧版裸 `cid` 前缀  
-  **Message routing supports `group:`/`user:` prefix targets** - Consistent with `gateway-methods.ts`, backward compatible with bare `cid` prefix
+- ✨ **消息路由支持 `group:`/`user:` 前缀** - `sendTextToDingTalk` 和 `sendMediaToDingTalk` 新增前缀格式解析，兼容旧版裸 `cid` 前缀  
+  **Message routing supports `group:`/`user:` prefix targets** - Backward compatible with bare `cid` prefix
 
 ### 改进 / Improvements
-- ✅ **兼容 pdf-parse v1 和 v2 API** - `parsePdfFile` 自动检测 pdf-parse 导出格式，v2.x 使用 `PDFParse` 类，v1.x 使用 `default` 函数  
-  **Support both pdf-parse v1 and v2 API** - Auto-detects export format: v2.x class API or v1.x function API
+- ✅ **兼容 pdf-parse v1/v2 API** - 自动检测导出格式，v2.x 使用 class API，v1.x 使用函数 API  
+  **Support both pdf-parse v1 and v2 API** - Auto-detects export format
 
-- ✅ **`enableMediaUpload`/`systemPrompt` 移至共享配置** - 这两个字段现在支持多账号模式下每个账号独立配置  
-  **Move `enableMediaUpload`/`systemPrompt` to shared config** - Now configurable per-account in multi-account mode
+- ✅ **`enableMediaUpload`/`systemPrompt` 移至共享配置** - 支持多账号独立配置  
+  **Move `enableMediaUpload`/`systemPrompt` to shared config** - Per-account configurable
+
+- ✅ **新增出站路由测试** - 覆盖 `group:`/`user:` 前缀解析和消息路由场景  
+  **Add outbound routing tests** - Covers prefix parsing and routing scenarios
 
 ### 文档 / Documentation
 - 📝 **优化 README 安装验证说明** - 移除版本号硬编码，新增插件未加载时的警示提示  
-  **Improve README plugin verification instructions** - Removed hardcoded version, added warning when plugin is not loaded
+  **Improve README plugin verification instructions** - Removed hardcoded version, added warning
 
 ## [0.8.12] - 2026-04-01
 

--- a/README.en.md
+++ b/README.en.md
@@ -122,7 +122,9 @@ registry=https://registry.npmmirror.com
 ```bash
 openclaw plugins list
 ```
-You should see `✓ DingTalk Channel (v0.8.6) - loaded`
+You should see output similar to `✓ DingTalk Channel (vX.X.X) - loaded`.
+
+> ⚠️ **If you don't see `loaded`**, resolve the plugin loading issue before proceeding to Step 3. Otherwise, DingTalk will not appear in `openclaw channels add`.
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img alt="DingTalk" src="docs/images/dingtalk.svg" width="72" height="72" />
+  <img alt="DingTalk" src="https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-openclaw-connector/main/docs/images/dingtalk.svg" width="72" height="72" />
   <h1>Official DingTalk OpenClaw Connector</h1>
   <p>Connect DingTalk bots to OpenClaw Gateway with AI Card streaming and session management</p>
   
@@ -135,13 +135,13 @@ You should see output similar to `✓ DingTalk Channel (vX.X.X) - loaded`.
 1. Go to [DingTalk Open Platform](https://open-dev.dingtalk.com/)
 2. Click **"Application Development"**
 
-![Create Application](docs/images/image-1.png)
+![Create Application](https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-openclaw-connector/main/docs/images/image-1.png)
 
 #### 2.2 Add Bot Capability
 
 1. On the application details page, use the “one-click OpenClaw bot app” flow
 
-![Create OpenClaw bot app](docs/images/image-2.png)
+![Create OpenClaw bot app](https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-openclaw-connector/main/docs/images/image-2.png)
 
 #### 2.3 Get Credentials
 
@@ -149,9 +149,9 @@ You should see output similar to `✓ DingTalk Channel (vX.X.X) - loaded`.
 2. Copy your **AppKey** (Client ID)
 3. Copy your **AppSecret** (Client Secret)
 
-![Finish creation](docs/images/image-3.png)
+![Finish creation](https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-openclaw-connector/main/docs/images/image-3.png)
 
-![Get credentials](docs/images/image-4.png)
+![Get credentials](https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-openclaw-connector/main/docs/images/image-4.png)
 
 > ⚠️ **Important**: Client ID and Client Secret are your bot’s unique credentials. Store them safely.
 

--- a/README.en.md
+++ b/README.en.md
@@ -281,6 +281,29 @@ Both session routing/message policy options (including `pmpolicy` and `groupPoli
 
 ---
 
+### Invalid Config: additional properties
+
+**Symptoms**:
+
+```
+Problem:
+  - channels.dingtalk-connector: invalid config: must NOT have additional properties
+```
+
+**Cause**: Your config file contains deprecated or renamed fields that are no longer recognized.
+
+**Solution**: Open `openclaw.config.yaml` and remove any unsupported fields under `channels.dingtalk-connector`. Known fields to remove:
+
+| Old Field | Notes |
+|-----------|-------|
+| `gatewayPassword` | Deprecated legacy field |
+| `gatewayToken` | Deprecated legacy field |
+| `dmHistoryLimit` | Removed in v0.8.9 (never implemented) |
+
+The error message will indicate the exact field name. Remove it and restart.
+
+---
+
 ### HTTP 401 Error
 
 **Symptoms**: Error message shows "401 Unauthorized"

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ registry=https://registry.npmmirror.com
 ```bash
 openclaw plugins list
 ```
-你应该看到 `✓ DingTalk Channel (v0.8.6) - loaded`
+你应该看到类似 `✓ DingTalk Channel (vX.X.X) - loaded` 的输出。
+
+> ⚠️ **如果没看到 `loaded`**，请先解决插件加载问题，再进行步骤 3 的配置。否则 `openclaw channels add` 中不会出现钉钉选项。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,29 @@ openclaw logs --follow
 
 ---
 
+### 配置字段不合法（additional properties）
+
+**症状**：
+
+```
+Problem:
+  - channels.dingtalk-connector: invalid config: must NOT have additional properties
+```
+
+**原因**：配置文件中包含已废弃或已重命名的字段，连接器不再识别。
+
+**解决方案**：打开 `openclaw.config.yaml`，删除 `channels.dingtalk-connector` 下不再支持的字段。已知需要删除的旧字段：
+
+| 旧字段 | 说明 |
+|--------|------|
+| `gatewayPassword` | 早期版本字段，已废弃 |
+| `gatewayToken` | 早期版本字段，已废弃 |
+| `dmHistoryLimit` | v0.8.9 移除（未实现） |
+
+错误信息会指出具体的字段名，删除后重启即可。
+
+---
+
 ### HTTP 401 错误
 
 **症状**：错误信息显示 "401 Unauthorized"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img alt="DingTalk" src="docs/images/dingtalk.svg" width="72" height="72" />
+  <img alt="DingTalk" src="https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-openclaw-connector/main/docs/images/dingtalk.svg" width="72" height="72" />
   <h1>钉钉 OpenClaw 官方连接器</h1>
   <p>将钉钉机器人连接到 OpenClaw Gateway，支持 AI Card 流式响应和会话管理</p>
   
@@ -167,13 +167,13 @@ openclaw plugins list
 1. 访问 [钉钉开放平台](https://open-dev.dingtalk.com/)
 2. 点击 **"应用开发"**
 
-![创建应用](docs/images/image-1.png)
+![创建应用](https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-openclaw-connector/main/docs/images/image-1.png)
 
 #### 3.2 添加机器人能力
 
 1. 在应用详情页，点击 一键创建OpenClaw机器人应用
 
-![创建OpenClaw机器人应用](docs/images/image-2.png)
+![创建OpenClaw机器人应用](https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-openclaw-connector/main/docs/images/image-2.png)
 
 #### 3.3 获取凭证
 
@@ -181,9 +181,9 @@ openclaw plugins list
 2. 复制你的 **AppKey**（Client ID）
 3. 复制你的 **AppSecret**（Client Secret）
 
-![完成创建](docs/images/image-3.png)
+![完成创建](https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-openclaw-connector/main/docs/images/image-3.png)
 
-![获取凭证](docs/images/image-4.png)
+![获取凭证](https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-openclaw-connector/main/docs/images/image-4.png)
 
 > ⚠️ **重要**：Client ID和 Client Secret是机器人的唯一凭证。请合理保存。
 

--- a/docs/RELEASE_NOTES_V0.8.13-beta.0.md
+++ b/docs/RELEASE_NOTES_V0.8.13-beta.0.md
@@ -1,0 +1,69 @@
+# Release Notes - v0.8.13-beta.0
+
+## 🎉 新版本亮点 / Highlights
+
+本次更新修复了**多账号凭据解析错误**（SecretInput 对象未展开导致发送失败）、**连接错误无法被正确捕获**（async 回调中 throw 无效），以及**消息路由支持 `group:`/`user:` 前缀**，同时兼容 pdf-parse v1/v2 双版本 API，并修复了 QPS 限流后立即重试的问题。
+
+This release fixes **multi-account credential resolution** (SecretInput objects not unwrapped before sending), **connection errors not propagating correctly** (throw inside async callbacks replaced with reject), and adds **`group:`/`user:` prefix support in message routing**, along with pdf-parse v1/v2 compatibility and a QPS throttle retry fix.
+
+## 🐛 修复 / Fixes
+
+- **修复多账号场景下发送消息时凭据未解析 / Fix unresolved credentials in sendText/sendMedia**  
+  `sendText` 和 `sendMedia` 在多账号模式下，`clientId`/`clientSecret` 可能为 `SecretInput` 对象或 `undefined`，导致 API 请求携带无效凭据。现已在调用前用 `resolveDingtalkAccount` 返回的已解析值覆盖原始 config。  
+  In multi-account mode, `clientId`/`clientSecret` could be `SecretInput` objects or `undefined`, causing API requests with invalid credentials. Now the resolved values from `resolveDingtalkAccount` are used to override the raw config.
+
+- **修复连接错误在 async 回调中无法传播 / Fix connection errors not propagating in async callback**  
+  `connection.ts` 的错误处理在 async 回调内使用 `throw` 抛出错误，但错误无法被外层 Promise 捕获，导致 400/401 等连接失败被静默忽略。已改为 `reject(new Error(...))` 确保错误正确传播。  
+  Error handlers in `connection.ts` used `throw` inside async callbacks, making errors uncatchable by the outer Promise. Changed to `reject(new Error(...))` to ensure proper error propagation for 400/401 and other connection failures.
+
+- **修复 QPS 限流后立即重试导致再次触发限流 / Fix QPS rate limit immediate retry**  
+  收到 403 QpsLimit 响应后，`lastUpdateTime` 未更新，导致下一次节流检查立即放行并再次触发限流。现已在跳过更新时同步 `lastUpdateTime`。  
+  After receiving a 403 QpsLimit response, `lastUpdateTime` was not updated, causing the throttle check to immediately allow the next attempt. Now `lastUpdateTime` is synced when skipping an update.
+
+- **修复 `resolveAllowFrom` 全局过滤误拦截群消息 / Fix resolveAllowFrom global filter incorrectly blocking group messages**  
+  框架层使用 `resolveAllowFrom` 对所有消息（含群消息）做全局发送者过滤，但 `allowFrom` 原意只用于私聊白名单。群消息有独立的 `groupAllowFrom` 字段控制，由 `message-handler.ts` 内部处理。现已将 `resolveAllowFrom` 改为返回空列表，禁用框架层全局过滤。  
+  The framework used `resolveAllowFrom` to filter all incoming messages (including group messages), but `allowFrom` was intended only for DM whitelisting. Group messages have a separate `groupAllowFrom` field handled internally by `message-handler.ts`. Now returns `[]` to disable framework-level global filtering.
+
+## ✨ 功能改进 / Improvements
+
+- **消息路由支持 `group:`/`user:` 前缀 / Message routing supports `group:`/`user:` prefix targets**  
+  `sendTextToDingTalk` 和 `sendMediaToDingTalk` 新增对 `group:<openConversationId>` 和 `user:<userId>` 格式的目标解析，与 `gateway-methods.ts` 中的逻辑保持一致，兼容旧版裸 `cid` 前缀格式。  
+  `sendTextToDingTalk` and `sendMediaToDingTalk` now support `group:<openConversationId>` and `user:<userId>` prefixed targets, consistent with `gateway-methods.ts` logic, while maintaining backward compatibility with bare `cid`-prefixed targets.
+
+- **兼容 pdf-parse v1 和 v2 API / Support both pdf-parse v1 and v2 API**  
+  `parsePdfFile` 现在自动检测 pdf-parse 模块导出格式：v2.x 使用 `PDFParse` 类（class API），v1.x 使用 `default` 函数，均可正确解析 PDF 文件。  
+  `parsePdfFile` now auto-detects the pdf-parse export format: v2.x uses the `PDFParse` class API, v1.x uses the `default` function — both are handled correctly.
+
+- **将 `enableMediaUpload`/`systemPrompt` 移至共享配置 / Move `enableMediaUpload`/`systemPrompt` to shared config shape**  
+  这两个字段现在位于 `DingtalkSharedConfigShape`，在多账号模式下每个账号可独立配置，而不是只能在顶层配置。  
+  These fields are now in `DingtalkSharedConfigShape`, allowing per-account configuration in multi-account mode instead of only top-level.
+
+## 📝 文档 / Documentation
+
+- **优化 README 安装验证说明 / Improve README plugin verification instructions**  
+  移除了版本号硬编码（`v0.8.6`），改为通用版本占位符，并新增"如果没看到 `loaded`"的警示提示，避免用户在插件未正确加载时继续配置步骤。  
+  Removed hardcoded version number (`v0.8.6`), replaced with generic version placeholder, and added a warning for when `loaded` is not shown to prevent users from proceeding with configuration before the plugin is properly loaded.
+
+## 📥 安装升级 / Installation & Upgrade
+
+```bash
+# 安装 beta 版本 / Install beta version
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.13-beta.0
+
+# 或升级现有版本 / Or upgrade existing version
+openclaw plugins update dingtalk-connector
+
+# 通过 Git 安装 / Install via Git
+openclaw plugins install https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector.git#v0.8.13
+```
+
+## 🔗 相关链接 / Related Links
+
+- [完整变更日志 / Full Changelog](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/CHANGELOG.md)
+- [使用文档 / Documentation](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/README.md)
+
+---
+
+**发布日期 / Release Date**：2026-04-06  
+**版本号 / Version**：v0.8.13-beta.0  
+**兼容性 / Compatibility**：OpenClaw Gateway 0.4.0+

--- a/docs/RELEASE_NOTES_V0.8.13.md
+++ b/docs/RELEASE_NOTES_V0.8.13.md
@@ -1,0 +1,62 @@
+# Release Notes - v0.8.13
+
+## 🎉 新版本亮点 / Highlights
+
+本次更新聚焦**媒体发送可靠性**和**多账号稳定性**：修复了文件发送时 mediaId 格式不一致导致静默失败的问题，修复了多账号凭据解析错误、连接错误无法传播、QPS 限流重试等多个关键 Bug，同时新增 `group:`/`user:` 前缀路由支持。
+
+This release focuses on **media sending reliability** and **multi-account stability**: fixes silent file sending failures caused by inconsistent mediaId format, resolves multi-account credential resolution errors, connection error propagation, QPS throttle retry issues, and adds `group:`/`user:` prefix routing support.
+
+## 🐛 修复 / Fixes
+
+- **修复文件发送时 mediaId 格式不一致导致静默失败 / Fix inconsistent mediaId format causing silent file send failure**  
+  `sendFileProactive` 在不同调用点传入了 `cleanMediaId`（不带 `@`）和 `mediaId`（带 `@`），经实测钉钉 API 统一要求带 `@` 前缀的 `mediaId`。同时修复了 `sendFileMessage`/`sendFileProactive` 的 catch 块吞掉异常导致外层误报成功的问题。  
+  `sendFileProactive` was called with `cleanMediaId` (without `@`) in some places and `mediaId` (with `@`) in others. Testing confirmed DingTalk API requires the `@`-prefixed `mediaId`. Also fixed catch blocks swallowing errors, causing false success reports.
+
+- **修复多账号场景下凭据未解析 / Fix unresolved credentials in multi-account mode**  
+  `sendText`/`sendMedia` 在多账号模式下 `clientId`/`clientSecret` 可能为 `SecretInput` 对象，导致 API 请求携带无效凭据。现已用 `resolveDingtalkAccount` 返回的已解析值覆盖。  
+  In multi-account mode, credentials could be `SecretInput` objects; now resolved values are used.
+
+- **修复连接错误在 async 回调中无法传播 / Fix connection errors not propagating**  
+  `connection.ts` 错误处理使用 `throw` 抛出，但在 async 回调内无法被外层 Promise 捕获。改为 `reject(new Error(...))` 确保 400/401 等错误正确传播。  
+  Changed `throw` to `reject()` inside async error handlers for proper error propagation.
+
+- **修复 QPS 限流后立即重试 / Fix QPS rate limit immediate retry**  
+  收到 403 QpsLimit 后未更新 `lastUpdateTime`，导致节流检查立即放行。现已同步更新。  
+  `lastUpdateTime` is now synced when skipping a QPS-limited update.
+
+- **修复 `resolveAllowFrom` 全局过滤误拦截群消息 / Fix resolveAllowFrom blocking group messages**  
+  `allowFrom` 仅用于私聊白名单，群消息由 `groupAllowFrom` 在内部处理。将 `resolveAllowFrom` 改为返回空列表，禁用框架层全局过滤。  
+  Returns `[]` to disable framework-level filtering; internal policy checks handle DM and group separately.
+
+## ✨ 功能改进 / Improvements
+
+- **消息路由支持 `group:`/`user:` 前缀 / Message routing supports `group:`/`user:` prefix targets**  
+  `sendTextToDingTalk` 和 `sendMediaToDingTalk` 新增 `group:<id>` 和 `user:<id>` 格式解析，兼容旧版裸 `cid` 前缀。  
+  Now supports `group:<id>` and `user:<id>` prefixed targets, backward compatible with bare `cid` prefix.
+
+- **兼容 pdf-parse v1/v2 API、共享配置字段扩展 / pdf-parse v1/v2 compatibility & shared config fields**  
+  `parsePdfFile` 自动检测 pdf-parse 导出格式；`enableMediaUpload`/`systemPrompt` 移至共享配置，支持多账号独立配置。  
+  Auto-detects pdf-parse export format; `enableMediaUpload`/`systemPrompt` now configurable per-account.
+
+- **新增出站路由测试 / Add outbound routing tests**  
+  新增 `outbound-routing.test.ts`，覆盖 `group:`/`user:` 前缀解析和消息路由场景。  
+  Added `outbound-routing.test.ts` covering prefix parsing and message routing scenarios.
+
+## 📥 安装升级 / Installation & Upgrade
+
+```bash
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector
+openclaw plugins update dingtalk-connector
+openclaw plugins install https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector.git
+```
+
+## 🔗 相关链接 / Related Links
+
+- [完整变更日志 / Full Changelog](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/CHANGELOG.md)
+- [使用文档 / Documentation](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/README.md)
+
+---
+
+**发布日期 / Release Date**：2026-04-08  
+**版本号 / Version**：v0.8.13  
+**兼容性 / Compatibility**：OpenClaw Gateway 0.4.0+

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.8.12",
+  "version": "0.8.13-beta.0",
   "description": "DingTalk (钉钉) messaging channel via Stream mode with AI Card streaming",
   "author": "DingTalk Real Team",
   "main": "index.ts",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.8.13-beta.0",
+  "version": "0.8.13",
   "description": "DingTalk (钉钉) messaging channel via Stream mode with AI Card streaming",
   "author": "DingTalk Real Team",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.8.12",
+  "version": "0.8.13-beta.0",
   "description": "DingTalk (钉钉) channel connector — Stream mode with AI Card streaming",
   "main": "index.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,17 @@
   },
   "homepage": "https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector#readme",
   "bugs": "https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues",
+  "files": [
+    "index.ts",
+    "src/",
+    "docs/*.md",
+    "openclaw.plugin.json",
+    "tsconfig.json",
+    "LICENSE",
+    "README.md",
+    "README.en.md",
+    "CHANGELOG.md"
+  ],
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.8.13-beta.0",
+  "version": "0.8.13",
   "description": "DingTalk (钉钉) channel connector — Stream mode with AI Card streaming",
   "main": "index.ts",
   "type": "module",
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "dependencies": {
-    "axios": "1.6.0",
+    "axios": "1.14.0",
     "dingtalk-stream": "2.1.4",
     "form-data": "^4.0.0",
     "zod": "^4.3.6"

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -162,10 +162,10 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingtalkAccount> = {
       name: account.name,
       clientId: account.clientId,
     }),
-    resolveAllowFrom: ({ cfg, accountId }) => {
-      const account = resolveDingtalkAccount({ cfg, accountId });
-      return (account.config?.allowFrom ?? []).map((entry) => String(entry));
-    },
+    // 返回空列表，禁止框架层对发送者做全局过滤。
+    // 连接器内部（message-handler.ts）已按 dmPolicy/groupPolicy 各自独立检查，
+    // allowFrom 仅用于私聊，groupAllowFrom 仅用于群聊，不应被框架层全局应用。
+    resolveAllowFrom: () => [],
     formatAllowFrom: ({ allowFrom }) =>
       allowFrom
         .map((entry) => String(entry).trim())
@@ -289,8 +289,14 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingtalkAccount> = {
     textChunkLimit: 2000,
     sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) => {
       const account = resolveDingtalkAccount({ cfg, accountId });
+      // 使用已解析的凭据覆盖原始 config，防止 clientId/clientSecret 为 SecretInput 对象或 undefined
+      const resolvedConfig: DingtalkConfig = {
+        ...account.config,
+        ...(account.clientId != null ? { clientId: account.clientId } : {}),
+        ...(account.clientSecret != null ? { clientSecret: account.clientSecret } : {}),
+      };
       const result = await sendTextToDingTalk({
-        config: account.config,
+        config: resolvedConfig,
         target: to,
         text,
         replyToId,
@@ -303,6 +309,12 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingtalkAccount> = {
     },
     sendMedia: async ({ cfg, to, text, mediaUrl, accountId, mediaLocalRoots, replyToId, threadId }) => {
       const account = resolveDingtalkAccount({ cfg, accountId });
+      // 使用已解析的凭据覆盖原始 config，防止 clientId/clientSecret 为 SecretInput 对象或 undefined
+      const resolvedConfig: DingtalkConfig = {
+        ...account.config,
+        ...(account.clientId != null ? { clientId: account.clientId } : {}),
+        ...(account.clientSecret != null ? { clientSecret: account.clientSecret } : {}),
+      };
       const logger = createLogger(account.config?.debug ?? false, 'DingTalk:SendMedia');
       
       logger.info('开始处理，参数:', JSON.stringify({
@@ -326,7 +338,7 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingtalkAccount> = {
       }
 
       const result = await sendMediaToDingTalk({
-        config: account.config,
+        config: resolvedConfig,
         target: to,
         text,
         mediaUrl,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -66,6 +66,8 @@ const DingtalkSharedConfigShape = {
   ackText: z.string().optional(),
   endpoint: z.string().optional(), // DWClient gateway endpoint
   debug: z.boolean().optional(), // DWClient debug mode
+  enableMediaUpload: z.boolean().optional(),
+  systemPrompt: z.string().optional(),
 };
 
 /**
@@ -93,8 +95,6 @@ export const DingtalkConfigBaseSchema = z
     // Top-level credentials (backward compatible for single-account mode)
     clientId: z.union([z.string(), z.number()]).optional(),
     clientSecret: buildSecretInputSchema().optional(),
-    enableMediaUpload: z.boolean().optional(),
-    systemPrompt: z.string().optional(),
     ...DingtalkSharedConfigShape,
     dmPolicy: DmPolicySchema.optional().default("open"),
     groupPolicy: GroupPolicySchema.optional().default("open"),

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -664,7 +664,7 @@ export async function monitorSingleAccount(
 
       // 处理 400 错误（请求参数错误）
       if (error.response?.status === 400 || error.message?.includes("status code 400") || error.message?.includes("400")) {
-        throw new Error(
+        reject(new Error(
           `[DingTalk][${accountId}] Bad Request (400):\n` +
             `  - clientId or clientSecret format is invalid\n` +
             `  - clientId: ${clientIdStr} (type: ${typeof account.clientId}, length: ${clientIdStr.length})\n` +
@@ -676,24 +676,27 @@ export async function monitorSingleAccount(
             `    4. Check if clientId starts with 'ding' prefix\n` +
             `  - Error details: ${error.message}\n` +
             `  - Response data: ${JSON.stringify(error.response?.data || {})}`,
-        );
+        ));
+        return;
       }
 
       // 处理 401 认证错误
       if (error.response?.status === 401 || error.message?.includes("401")) {
-        throw new Error(
+        reject(new Error(
           `[DingTalk][${accountId}] Authentication failed (401 Unauthorized):\n` +
             `  - Your clientId or clientSecret is invalid, expired, or revoked\n` +
             `  - clientId: ${clientIdStr.substring(0, 8)}...\n` +
             `  - Please verify your credentials at DingTalk Developer Console\n` +
             `  - Error details: ${error.message}`,
-        );
+        ));
+        return;
       }
 
       // 处理其他连接错误
-      throw new Error(
+      reject(new Error(
         `[DingTalk][${accountId}] Failed to connect to DingTalk Stream: ${error.message}`,
-      );
+      ));
+      return;
     }
 
     // Handle disconnection（已被自定义 close 监听器替代）

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -857,20 +857,40 @@ async function parsePdfFile(filePath: string, log?: any): Promise<string | null>
   try {
     log?.info?.(`开始解析 PDF 文档: ${filePath}`);
 
-    let pdfParse: any;
+    let pdfParseV1: any;
+    let pdfParseV2: any;
     try {
-      pdfParse = (await import('pdf-parse')).default;
+      const mod = await import('pdf-parse');
+      if (mod.PDFParse) {
+        pdfParseV2 = mod.PDFParse; // v2.x API
+      } else if (mod.default) {
+        pdfParseV1 = mod.default; // v1.x API
+      } else {
+        throw new Error('pdf-parse module format not recognized');
+      }
     } catch {
       log?.warn?.('pdf-parse 库未安装，无法解析 .pdf 文件。请运行: npm install pdf-parse');
       return null;
     }
 
     const buffer = fs.readFileSync(filePath);
-    const data = await pdfParse(buffer);
-    const text = data.text.trim();
-    
+    let text: string;
+    let numPages: number | undefined;
+
+    if (pdfParseV2) {
+      const parser = new pdfParseV2({ data: buffer });
+      const result = await parser.getText();
+      text = (result.text ?? '').trim();
+      numPages = result.total;
+      parser.destroy?.();
+    } else {
+      const data = await pdfParseV1(buffer);
+      text = (data.text ?? '').trim();
+      numPages = data.numpages;
+    }
+
     if (text) {
-      log?.info?.(`PDF 文档解析成功: ${filePath}, 文本长度=${text.length}, 页数=${data.numpages}`);
+      log?.info?.(`PDF 文档解析成功: ${filePath}, 文本长度=${text.length}, 页数=${numPages}`);
       return text;
     } else {
       log?.warn?.(`PDF 文档解析结果为空: ${filePath}`);

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -49,7 +49,7 @@ import {
   processLocalImages, 
   processVideoMarkers, 
   processAudioMarkers, 
-  processFileMarkers
+  uploadAndReplaceFileMarkers
 } from "../services/media/index.ts";
 import { sendProactive, type AICardTarget } from "../services/messaging/index.ts";
 import { createAICardForTarget, streamAICard, type AICardInstance } from "../services/messaging/card.ts";
@@ -701,7 +701,7 @@ export async function downloadMediaByCode(
 
     const resp = await dingtalkHttp.post(
       `${DINGTALK_API}/v1.0/robot/messageFiles/download`,
-      { downloadCode, robotCode: config.clientId },
+      { downloadCode, robotCode: String(config.clientId) },
       {
         headers: { 'x-acs-dingtalk-access-token': token, 'Content-Type': 'application/json' },
         timeout: 30_000,
@@ -733,7 +733,7 @@ export async function getFileDownloadUrl(
 
     const resp = await dingtalkHttp.post(
       `${DINGTALK_API}/v1.0/robot/messageFiles/download`,
-      { downloadCode, robotCode: config.clientId },
+      { downloadCode, robotCode: String(config.clientId) },
       {
         headers: { 'x-acs-dingtalk-access-token': token, 'Content-Type': 'application/json' },
         timeout: 30_000,
@@ -1513,7 +1513,7 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
             true,  // ✅ 使用主动 API 模式
             mediaTarget
           );
-          finalText = await processFileMarkers(
+          finalText = await uploadAndReplaceFileMarkers(
             finalText,
             '',
             config,

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -607,7 +607,8 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
               // 安全检查：确保 code 存在且为字符串
               const errorCode = err.response?.data?.code;
               if (err.response?.status === 403 && typeof errorCode === 'string' && errorCode.includes('QpsLimit')) {
-                // QPS 限流，跳过本次更新
+                // QPS 限流，跳过本次更新；同步更新节流时间，防止立即重试再次触发限流
+                lastUpdateTime = now;
                 log.warn(`[DingTalk][AICard] QPS 限流，跳过本次更新`);
               } else {
                 log.error(`[DingTalk][onPartialReply] ❌ AI Card 更新失败：${err.message}`);

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -43,7 +43,7 @@ import {
   processLocalImages,
   processVideoMarkers,
   processAudioMarkers,
-  processFileMarkers,
+  uploadAndReplaceFileMarkers,
 } from "./services/media/index.ts";
 
 
@@ -314,7 +314,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
           true,  // ✅ 使用主动 API 模式
           target
         );
-        finalText = await processFileMarkers(
+        finalText = await uploadAndReplaceFileMarkers(
           finalText,
           '',
           account.config as DingtalkConfig,

--- a/src/services/media.ts
+++ b/src/services/media.ts
@@ -607,7 +607,12 @@ export interface FileInfo {
 }
 
 /**
- * 提取文件标记并发送文件消息
+ * 提取文件标记，上传文件到钉钉，并发送独立的文件消息（webhook 或 proactive API）。
+ * 
+ * 注意：此函数既做「上传」也做「发送」，是完整版的文件处理流程。
+ * 与 media/file.ts 中的 uploadAndReplaceFileMarkers 不同，后者只做上传+文本替换。
+ * 
+ * 调用方：messaging.ts（直接 import media.ts）
  */
 export async function processFileMarkers(
   content: string,
@@ -672,11 +677,11 @@ export async function processFileMarkers(
         continue;
       }
 
-      // 发送文件消息
+      // 发送文件消息（钉钉 API 统一要求带 @ 前缀的 mediaId）
       if (useProactiveApi && target) {
-        await sendFileProactive(config, target, fileInfo, uploadResult.cleanMediaId, log);
+        await sendFileProactive(config, target, fileInfo, uploadResult.mediaId, log);
       } else {
-        await sendFileMessage(config, sessionWebhook, fileInfo, uploadResult.downloadUrl, log);
+        await sendFileMessage(config, sessionWebhook, fileInfo, uploadResult.mediaId, log);
       }
       statusMessages.push(`✅ 文件已发送: ${fileName}`);
       log?.info?.(`${logPrefix} 文件处理完成: ${fileName}`);
@@ -771,7 +776,7 @@ export async function sendVideoProactive(
     };
 
     const body: any = {
-      robotCode: config.clientId,
+      robotCode: String(config.clientId),
       msgKey: 'sampleVideo',
       msgParam: JSON.stringify(msgParam),
     };
@@ -873,7 +878,7 @@ export async function sendAudioProactive(
     };
 
     const body: any = {
-      robotCode: config.clientId,
+      robotCode: String(config.clientId),
       msgKey: 'sampleAudio',
       msgParam: JSON.stringify(msgParam),
     };
@@ -942,6 +947,7 @@ async function sendFileMessage(
     }
   } catch (err: any) {
     log?.error?.(`发送文件消息异常: ${fileInfo.fileName}, 错误: ${err.message}`);
+    throw err;
   }
 }
 
@@ -960,14 +966,16 @@ export async function sendFileProactive(
     const { DINGTALK_API } = await import('../utils/index.ts');
 
     // 钉钉普通消息 API 的文件消息格式
+    const resolvedFileName = fileInfo.fileName || path.basename(fileInfo.path);
+    const resolvedFileType = fileInfo.fileType || resolvedFileName.split('.').pop() || 'file';
     const msgParam = {
       mediaId: mediaId,
-      fileName: fileInfo.fileName,
-      fileType: fileInfo.fileType,
+      fileName: resolvedFileName,
+      fileType: resolvedFileType,
     };
 
     const body: any = {
-      robotCode: config.clientId,
+      robotCode: String(config.clientId),
       msgKey: 'sampleFile',
       msgParam: JSON.stringify(msgParam),
     };
@@ -994,6 +1002,7 @@ export async function sendFileProactive(
     }
   } catch (err: any) {
     log?.error?.(`File[Proactive] 发送文件消息失败: ${fileInfo.fileName}, 错误: ${err.message}`);
+    throw err;
   }
 }
 
@@ -1109,9 +1118,7 @@ export async function processRawMediaPaths(
         };
         
         if (target) {
-          // 文件消息使用下载链接
-          // 文件消息使用媒体文件ID（cleanMediaId）通过主动API发送
-          await sendFileProactive(config, target, fileInfo, uploadResult.cleanMediaId, log);
+          await sendFileProactive(config, target, fileInfo, uploadResult.mediaId, log);
         }
         statusMessages.push(`✅ 文件已发送: ${fileName}`);
       }

--- a/src/services/media/file.ts
+++ b/src/services/media/file.ts
@@ -29,9 +29,14 @@ export async function parseDocumentFile(filePath: string, log?: any): Promise<st
 }
 
 /**
- * 提取文件标记并发送文件消息
+ * 提取文件标记，上传文件到钉钉，并用文本替换标记。
+ * 
+ * 注意：此函数只做「上传 + 文本替换」，不会发送独立的文件消息。
+ * 如果需要上传后再发送独立文件消息，请使用 media.ts 中的 processFileMarkers。
+ * 
+ * 调用方：reply-dispatcher.ts、message-handler.ts（通过 media/index.ts 导入）
  */
-export async function processFileMarkers(
+export async function uploadAndReplaceFileMarkers(
   content: string,
   sessionWebhook: string,
   config: DingtalkConfig,

--- a/src/services/messaging.ts
+++ b/src/services/messaging.ts
@@ -552,11 +552,17 @@ export async function sendTextToDingTalk(params: {
     return { ok: false, error: "Invalid target parameter", usedAICard: false };
   }
 
-  // 判断目标是用户还是群
-  const isUser = !target.startsWith("cid");
-  const targetParam = isUser
-    ? { type: "user" as const, userId: target }
-    : { type: "group" as const, openConversationId: target };
+  // 判断目标是用户还是群（支持 group:/user: 前缀，与 gateway-methods.ts 逻辑保持一致）
+  let targetParam: { type: "user"; userId: string } | { type: "group"; openConversationId: string };
+  if (target.startsWith("group:")) {
+    targetParam = { type: "group", openConversationId: target.slice(6) };
+  } else if (target.startsWith("user:")) {
+    targetParam = { type: "user", userId: target.slice(5) };
+  } else if (target.startsWith("cid")) {
+    targetParam = { type: "group", openConversationId: target };
+  } else {
+    targetParam = { type: "user", userId: target };
+  }
 
   return sendProactive(config, targetParam, text, {
     msgType: "text",
@@ -595,11 +601,17 @@ export async function sendMediaToDingTalk(params: {
     return { ok: false, error: "Invalid target parameter", usedAICard: false };
   }
 
-  // 判断目标是用户还是群
-  const isUser = !target.startsWith("cid");
-  const targetParam = isUser
-    ? { type: "user" as const, userId: target }
-    : { type: "group" as const, openConversationId: target };
+  // 判断目标是用户还是群（支持 group:/user: 前缀，与 gateway-methods.ts 逻辑保持一致）
+  let targetParam: { type: "user"; userId: string } | { type: "group"; openConversationId: string };
+  if (target.startsWith("group:")) {
+    targetParam = { type: "group", openConversationId: target.slice(6) };
+  } else if (target.startsWith("user:")) {
+    targetParam = { type: "user", userId: target.slice(5) };
+  } else if (target.startsWith("cid")) {
+    targetParam = { type: "group", openConversationId: target };
+  } else {
+    targetParam = { type: "user", userId: target };
+  }
 
   log.info("参数解析完成，mediaUrl:", mediaUrl, "type:", typeof mediaUrl);
 

--- a/src/services/messaging.ts
+++ b/src/services/messaging.ts
@@ -229,7 +229,7 @@ export async function sendNormalToUser(
   try {
     const token = await getAccessToken(config);
     const body = {
-      robotCode: config.clientId,
+      robotCode: String(config.clientId),
       userIds: userIdArray,
       msgKey: payload.msgKey,
       msgParam: JSON.stringify(payload.msgParam),
@@ -306,7 +306,7 @@ export async function sendNormalToGroup(
   try {
     const token = await getAccessToken(config);
     const body = {
-      robotCode: config.clientId,
+      robotCode: String(config.clientId),
       openConversationId,
       msgKey: payload.msgKey,
       msgParam: JSON.stringify(payload.msgParam),
@@ -439,7 +439,7 @@ export async function sendAICardInternal(
     }
 
     // 7. 使用 finishAICard 设置内容
-    await finishAICard(card, processedContent, log);
+    await finishAICard(card, processedContent, config, log);
 
     log?.info?.(
       `AI Card 发送成功: ${targetDesc}, cardInstanceId=${card.cardInstanceId}`,
@@ -767,8 +767,9 @@ export async function sendMediaToDingTalk(params: {
     // 获取文件扩展名作为 fileType
     const fileType = ext || "file";
     
-    // 构建文件信息
+    // 构建文件信息（path 字段用于 sendFileProactive 中 fileName 的 fallback）
     const fileInfo = {
+      path: mediaUrl,
       fileName: fileName,
       fileType: fileType,
     };
@@ -904,7 +905,7 @@ async function sendProactiveInternal(
     try {
       const card = await createAICardForTarget(config, target, externalLog);
       if (card) {
-        await finishAICard(card, content, externalLog);
+        await finishAICard(card, content, config, externalLog);
         return {
           ok: true,
           cardInstanceId: card.cardInstanceId,
@@ -956,7 +957,7 @@ async function sendProactiveInternal(
     }
 
     const body: any = {
-      robotCode: config.clientId,
+      robotCode: String(config.clientId),
       msgKey: payload.msgKey,
       msgParam: JSON.stringify(payload.msgParam),
     };

--- a/src/services/messaging/card.ts
+++ b/src/services/messaging/card.ts
@@ -281,7 +281,6 @@ export async function streamAICard(
       `[DingTalk][AICard] streaming 响应：status=${streamResp.status}`,
     );
   } catch (err: any) {
-    log?.error?.(`[DingTalk][AICard] streaming 更新失败：${err.message}`);
     throw err;
   }
 }

--- a/src/services/messaging/card.ts
+++ b/src/services/messaging/card.ts
@@ -303,7 +303,7 @@ export async function finishAICard(
     `[DingTalk][AICard] 开始 finish，最终内容长度=${fixedContent.length}`,
   );
 
-  await streamAICard(card, fixedContent, true, log);
+  await streamAICard(card, fixedContent, true, config, log);
 
   const body = {
     outTrackId: card.cardInstanceId,

--- a/src/utils/http-client.ts
+++ b/src/utils/http-client.ts
@@ -2,6 +2,7 @@
  * HTTP 客户端配置模块
  * 
  * 提供统一的 axios 实例，用于钉钉 API 请求。
+ * 所有钉钉 API 调用必须使用此模块导出的实例，禁止直接使用 axios 或 fetch。
  * 
  * 使用方式：
  * ```typescript
@@ -13,7 +14,7 @@
 
 import axios, { type AxiosInstance } from 'axios';
 
-/** 钉钉专用 HTTP 客户端（30 秒超时） */
+/** 钉钉新版 API 专用 HTTP 客户端（30 秒超时，用于 api.dingtalk.com） */
 export const dingtalkHttp: AxiosInstance = axios.create({
   timeout: 30000,
   headers: {

--- a/tests/ai-card/ai-card.test.ts
+++ b/tests/ai-card/ai-card.test.ts
@@ -219,7 +219,7 @@ describe('AI Card helpers', () => {
       const card = { cardInstanceId: 'card123', accessToken: 'token123', inputingStarted: false };
 
       await expect(streamAICard(card, 'Hello', false, undefined, log)).rejects.toThrow();
-      expect(log.error).toHaveBeenCalled();
+      // streamAICard no longer pre-logs errors; callers are responsible for error handling
     });
 
     it('should handle streaming failure', async () => {
@@ -236,7 +236,7 @@ describe('AI Card helpers', () => {
       const card = { cardInstanceId: 'card123', accessToken: 'token123', inputingStarted: true };
 
       await expect(streamAICard(card, 'Hello', false, undefined, log)).rejects.toThrow();
-      expect(log.error).toHaveBeenCalled();
+      // streamAICard no longer pre-logs errors; callers are responsible for error handling
     });
   });
 

--- a/tests/ai-card/ai-card.test.ts
+++ b/tests/ai-card/ai-card.test.ts
@@ -254,6 +254,31 @@ describe('AI Card helpers', () => {
       expect(log.info).toHaveBeenCalled();
     });
 
+    it('should pass config to internal streamAICard call', async () => {
+      const { __testables } = await import('../../test');
+      const { finishAICard } = __testables as any;
+
+      mockAxiosPut.mockResolvedValue({ status: 200, data: {} });
+
+      // Use a card with valid (non-expired) token so ensureValidToken skips refresh
+      const card = {
+        cardInstanceId: 'card123',
+        accessToken: 'valid-token',
+        inputingStarted: true,
+        tokenExpireTime: Date.now() + 2 * 60 * 60 * 1000, // 2 hours from now
+      };
+      const config = { clientId: 'test-id', clientSecret: 'test-secret' };
+
+      await finishAICard(card, 'Final content', config, log);
+
+      // Verify streaming PUT was called with the card's accessToken in headers
+      const streamingCall = mockAxiosPut.mock.calls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('/card/streaming')
+      );
+      expect(streamingCall).toBeDefined();
+      expect(streamingCall![2]?.headers?.['x-acs-dingtalk-access-token']).toBe('valid-token');
+    });
+
     it('should handle finish failure gracefully', async () => {
       const { __testables } = await import('../../test');
       const { finishAICard } = __testables as any;

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -21,4 +21,18 @@ describe("DingtalkConfigSchema", () => {
   it("requires allowFrom when dmPolicy is allowlist", () => {
     expect(() => DingtalkConfigSchema.parse({ dmPolicy: "allowlist", allowFrom: [] })).toThrow(/allowFrom/);
   });
+
+  it("accepts enableMediaUpload in per-account config", () => {
+    const out = DingtalkConfigSchema.parse({
+      accounts: { work: { enableMediaUpload: true } },
+    });
+    expect((out.accounts?.work as any)?.enableMediaUpload).toBe(true);
+  });
+
+  it("accepts systemPrompt in per-account config", () => {
+    const out = DingtalkConfigSchema.parse({
+      accounts: { work: { systemPrompt: "你是一个助手" } },
+    });
+    expect((out.accounts?.work as any)?.systemPrompt).toBe("你是一个助手");
+  });
 });

--- a/tests/core/connection.test.ts
+++ b/tests/core/connection.test.ts
@@ -157,4 +157,24 @@ describe("core/connection", () => {
     await running;
     expect(client!.disconnect).toHaveBeenCalled();
   });
+
+  it("rejects (not unhandled) when connect() fails", async () => {
+    const { monitorSingleAccount } = await import("../../src/core/connection");
+    FakeDWClient.nextConnectError = new Error("connection refused");
+
+    await expect(
+      monitorSingleAccount(createOpts()),
+    ).rejects.toThrow("Failed to connect to DingTalk Stream: connection refused");
+  });
+
+  it("rejects with 400 message when connect() fails with status 400", async () => {
+    const { monitorSingleAccount } = await import("../../src/core/connection");
+    const err = new Error("Request failed with status code 400");
+    (err as any).response = { status: 400, data: { message: "invalid_client" } };
+    FakeDWClient.nextConnectError = err;
+
+    await expect(
+      monitorSingleAccount(createOpts()),
+    ).rejects.toThrow("Bad Request (400)");
+  });
 });

--- a/tests/core/message-handler-policy.test.ts
+++ b/tests/core/message-handler-policy.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../src/services/media/index.ts", () => ({
   processLocalImages: vi.fn(async (s: string) => s),
   processVideoMarkers: vi.fn(async (s: string) => s),
   processAudioMarkers: vi.fn(async (s: string) => s),
-  processFileMarkers: vi.fn(async (s: string) => s),
+  uploadAndReplaceFileMarkers: vi.fn(async (s: string) => s),
   uploadMediaToDingTalk: vi.fn(async () => null),
   toLocalPath: vi.fn((s: string) => s),
   FILE_MARKER_PATTERN: /\[DINGTALK_FILE\](.*?)\[\/DINGTALK_FILE\]/gs,

--- a/tests/outbound/outbound-routing.test.ts
+++ b/tests/outbound/outbound-routing.test.ts
@@ -1,0 +1,103 @@
+/**
+ * 出站路由单元测试
+ *
+ * 验证 sendTextToDingTalk / sendMediaToDingTalk 正确解析 group:/user: 前缀，
+ * 以及 channel.ts resolveAllowFrom 返回空列表不影响内部策略过滤。
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock http client
+const mockPost = vi.hoisted(() => vi.fn());
+const mockGet = vi.hoisted(() => vi.fn());
+vi.mock("../../src/utils/http-client.ts", () => ({
+  dingtalkHttp: { post: mockPost, get: mockGet },
+  dingtalkOapiHttp: { get: mockGet, post: mockPost },
+  dingtalkUploadHttp: { post: mockPost, get: mockGet },
+}));
+
+// Mock token — 直接返回 fake token，避免 HTTP 请求
+vi.mock("../../src/utils/token.ts", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("../../src/utils/token.ts")>();
+  return {
+    ...orig,
+    getAccessToken: vi.fn().mockResolvedValue("fake-token"),
+    getOapiAccessToken: vi.fn().mockResolvedValue(null), // media 路径不走
+    DINGTALK_API: orig.DINGTALK_API,
+    DINGTALK_OAPI: orig.DINGTALK_OAPI,
+  };
+});
+
+// Mock AI Card 创建，让 sendProactive 走普通消息路径（useAICard: false）
+vi.mock("../../src/services/messaging/card.ts", () => ({
+  createAICardForTarget: vi.fn().mockResolvedValue(null), // 返回 null → fallback 到普通消息
+  finishAICard: vi.fn(),
+  streamAICard: vi.fn(),
+  updateAICard: vi.fn(),
+}));
+
+const config = {
+  clientId: "ding_client_id",
+  clientSecret: "ding_client_secret",
+};
+
+describe("sendTextToDingTalk target routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // 默认 API 调用返回成功
+    mockPost.mockResolvedValue({ data: { processQueryKey: "pqk-123" }, status: 200 });
+  });
+
+  it("group:cid... 前缀 → 调用群消息 API，openConversationId 去掉前缀", async () => {
+    const { sendTextToDingTalk } = await import("../../src/services/messaging.ts");
+    await sendTextToDingTalk({ config, target: "group:cidABC123==", text: "hello" });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.stringContaining("/groupMessages/send"),
+      expect.objectContaining({ openConversationId: "cidABC123==" }),
+      expect.anything(),
+    );
+  });
+
+  it("cid... 无前缀 → 调用群消息 API（旧格式兼容）", async () => {
+    const { sendTextToDingTalk } = await import("../../src/services/messaging.ts");
+    await sendTextToDingTalk({ config, target: "cidABC123==", text: "hello" });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.stringContaining("/groupMessages/send"),
+      expect.objectContaining({ openConversationId: "cidABC123==" }),
+      expect.anything(),
+    );
+  });
+
+  it("user:xxx 前缀 → 调用单聊消息 API，userId 去掉前缀", async () => {
+    const { sendTextToDingTalk } = await import("../../src/services/messaging.ts");
+    await sendTextToDingTalk({ config, target: "user:staff001", text: "hello" });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.stringContaining("/oToMessages/batchSend"),
+      expect.objectContaining({ userIds: ["staff001"] }),
+      expect.anything(),
+    );
+  });
+
+  it("裸 userId（无前缀且不以 cid 开头）→ 调用单聊消息 API", async () => {
+    const { sendTextToDingTalk } = await import("../../src/services/messaging.ts");
+    await sendTextToDingTalk({ config, target: "staff001", text: "hello" });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.stringContaining("/oToMessages/batchSend"),
+      expect.objectContaining({ userIds: ["staff001"] }),
+      expect.anything(),
+    );
+  });
+
+  it("旧行为回归：group:cidXXX== 不再被误路由为单聊", async () => {
+    const { sendTextToDingTalk } = await import("../../src/services/messaging.ts");
+    await sendTextToDingTalk({ config, target: "group:cidXXX==", text: "hello" });
+
+    // 不应调用单聊 API
+    const calls = mockPost.mock.calls.map((c) => c[0]);
+    expect(calls.every((url: string) => !url.includes("oToMessages"))).toBe(true);
+  });
+});

--- a/tests/reply-dispatcher/reply-dispatcher.test.ts
+++ b/tests/reply-dispatcher/reply-dispatcher.test.ts
@@ -52,7 +52,7 @@ vi.mock("../../src/services/media/audio.ts", () => ({
 }));
 
 vi.mock("../../src/services/media/file.ts", () => ({
-  processFileMarkers: vi.fn(async (s: string) => s),
+  uploadAndReplaceFileMarkers: vi.fn(async (s: string) => s),
 }));
 
 vi.mock("../../src/utils/token.ts", () => ({

--- a/tests/upload/upload.test.ts
+++ b/tests/upload/upload.test.ts
@@ -248,10 +248,10 @@ describe('upload functionality', () => {
     });
   });
 
-  describe('processFileMarkers', () => {
-    it('should process file markers', async () => {
+  describe('uploadAndReplaceFileMarkers', () => {
+    it('should upload files and replace markers with text', async () => {
       const { __testables } = await import('../../test');
-      const { processFileMarkers } = __testables as any;
+      const { uploadAndReplaceFileMarkers } = __testables as any;
 
       const fs = await import('fs');
       vi.mocked(fs.existsSync).mockReturnValue(true);
@@ -269,7 +269,7 @@ describe('upload functionality', () => {
         'prefix\n' +
         '[DINGTALK_FILE]{"path":"/tmp/file.pdf","fileName":"file.pdf","fileType":"pdf"}[/DINGTALK_FILE]\n' +
         'suffix';
-      const result = await processFileMarkers(content, 'https://webhook.example', {}, 'token123', log);
+      const result = await uploadAndReplaceFileMarkers(content, 'https://webhook.example', {}, 'token123', log);
 
       expect(result).toContain('prefix');
       expect(result).toContain('suffix');


### PR DESCRIPTION
## Release v0.8.13-beta.0

### 🐛 修复 / Fixes
- 修复多账号场景下 `sendText`/`sendMedia` 凭据未解析（SecretInput 对象）导致 API 请求失败
- 修复 `connection.ts` async 回调中 `throw` 无法传播，400/401 连接错误被静默忽略 → 改为 `reject()`
- 修复 QPS 限流后立即重试再次触发限流（未更新 `lastUpdateTime`）
- 修复 `resolveAllowFrom` 返回 `allowFrom` 列表导致框架层误拦截群消息（应仅内部按策略检查）

### ✨ 新增 / Added
- 消息路由支持 `group:<id>` / `user:<id>` 前缀，与 `gateway-methods.ts` 保持一致

### 改进 / Improvements
- pdf-parse 兼容 v1（default function）和 v2（PDFParse class）双版本 API
- `enableMediaUpload` / `systemPrompt` 移至 `DingtalkSharedConfigShape`，支持多账号独立配置

### 文档
- README 移除版本号硬编码，新增插件未正确加载时的警示提示

---