### PR TITLE
Allow DingTalk endpoints to follow deployment config

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -244,6 +244,17 @@ openclaw logs --follow
 | `clientId` | — | DingTalk AppKey |
 | `clientSecret` | — | DingTalk AppSecret |
 
+### Endpoint Configuration
+
+All endpoint fields are optional. When omitted, the connector uses the defaults below. `endpoint` is a deprecated compatibility alias for `gatewayEndpoint`.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `gatewayEndpoint` | `https://api.dingtalk.com` | DingTalk Stream gateway endpoint |
+| `tokenEndpoint` | `https://api.dingtalk.com` | OpenAPI access-token endpoint prefix |
+| `apiEndpoint` | `https://api.dingtalk.com` | OpenAPI endpoint prefix |
+| `oapiEndpoint` | `https://oapi.dingtalk.com` | Legacy OAPI endpoint prefix |
+
 ### Session Management
 
 | Option | Default | Description |

--- a/README.md
+++ b/README.md
@@ -276,6 +276,17 @@ openclaw logs --follow
 | `clientId` | — | 钉钉 AppKey |
 | `clientSecret` | — | 钉钉 AppSecret |
 
+### Endpoint 配置
+
+以下 endpoint 均可省略；省略时会使用默认值。`endpoint` 是旧版字段，仍会作为 `gatewayEndpoint` 的兼容别名读取。
+
+| 选项 | 默认值 | 说明 |
+|------|--------|------|
+| `gatewayEndpoint` | `https://api.dingtalk.com` | DingTalk Stream 网关地址 |
+| `tokenEndpoint` | `https://api.dingtalk.com` | 新版 OpenAPI access token 地址前缀 |
+| `apiEndpoint` | `https://api.dingtalk.com` | 新版 OpenAPI 地址前缀 |
+| `oapiEndpoint` | `https://oapi.dingtalk.com` | 旧版 OAPI 地址前缀 |
+
 ### 会话管理
 
 | 选项 | 默认值 | 说明 |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -231,8 +231,25 @@
           "ackText": {
             "type": "string"
           },
+          "gatewayEndpoint": {
+            "type": "string",
+            "format": "uri"
+          },
+          "tokenEndpoint": {
+            "type": "string",
+            "format": "uri"
+          },
+          "apiEndpoint": {
+            "type": "string",
+            "format": "uri"
+          },
+          "oapiEndpoint": {
+            "type": "string",
+            "format": "uri"
+          },
           "endpoint": {
-            "type": "string"
+            "type": "string",
+            "format": "uri"
           },
           "debug": {
             "type": "boolean"
@@ -442,8 +459,25 @@
                 "ackText": {
                   "type": "string"
                 },
+                "gatewayEndpoint": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "tokenEndpoint": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "apiEndpoint": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "oapiEndpoint": {
+                  "type": "string",
+                  "format": "uri"
+                },
                 "endpoint": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "uri"
                 },
                 "debug": {
                   "type": "boolean"
@@ -483,9 +517,29 @@
           "help": "启用调试日志",
           "advanced": true
         },
-        "channels.dingtalk-connector.endpoint": {
+        "channels.dingtalk-connector.gatewayEndpoint": {
           "label": "Gateway Endpoint",
-          "help": "自定义 DWClient 网关地址（高级）",
+          "help": "自定义 DingTalk Stream 网关地址（高级）",
+          "advanced": true
+        },
+        "channels.dingtalk-connector.tokenEndpoint": {
+          "label": "Token Endpoint",
+          "help": "自定义新版 OpenAPI access token 地址前缀（高级）",
+          "advanced": true
+        },
+        "channels.dingtalk-connector.apiEndpoint": {
+          "label": "API Endpoint",
+          "help": "自定义新版 OpenAPI 地址前缀（高级）",
+          "advanced": true
+        },
+        "channels.dingtalk-connector.oapiEndpoint": {
+          "label": "OAPI Endpoint",
+          "help": "自定义旧版 OAPI 地址前缀（高级）",
+          "advanced": true
+        },
+        "channels.dingtalk-connector.endpoint": {
+          "label": "Gateway Endpoint (legacy)",
+          "help": "旧版字段，仍会作为 gatewayEndpoint 的兼容别名读取（高级）",
           "advanced": true
         },
         "channels.dingtalk-connector.accounts": {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -370,11 +370,23 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingtalkAccount> = {
       probe: snapshot.probe,
       lastProbeAt: snapshot.lastProbeAt ?? null,
     }),
-    probeAccount: async ({ account }) => await probeDingtalk({
-      clientId: account.clientId!,
-      clientSecret: account.clientSecret!,
-      accountId: account.accountId,
-    }),
+    probeAccount: async ({ account }) => {
+      const endpointConfig = account.config
+        ? {
+            gatewayEndpoint: account.config.gatewayEndpoint,
+            tokenEndpoint: account.config.tokenEndpoint,
+            apiEndpoint: account.config.apiEndpoint,
+            oapiEndpoint: account.config.oapiEndpoint,
+            endpoint: account.config.endpoint,
+          }
+        : {};
+      return await probeDingtalk({
+        clientId: account.clientId!,
+        clientSecret: account.clientSecret!,
+        accountId: account.accountId,
+        ...endpointConfig,
+      });
+    },
     buildAccountSnapshot: ({ account, runtime, probe }) => ({
       accountId: account.accountId,
       enabled: account.enabled,

--- a/src/config/endpoints.ts
+++ b/src/config/endpoints.ts
@@ -1,0 +1,55 @@
+import type { DingtalkConfig } from "../types/index.ts";
+
+export const DEFAULT_DINGTALK_API_ENDPOINT = "https://api.dingtalk.com";
+export const DEFAULT_DINGTALK_GATEWAY_ENDPOINT = DEFAULT_DINGTALK_API_ENDPOINT;
+export const DEFAULT_DINGTALK_TOKEN_ENDPOINT = DEFAULT_DINGTALK_API_ENDPOINT;
+export const DEFAULT_DINGTALK_OAPI_ENDPOINT = "https://oapi.dingtalk.com";
+
+export type DingtalkEndpointKey =
+  | "gatewayEndpoint"
+  | "tokenEndpoint"
+  | "apiEndpoint"
+  | "oapiEndpoint";
+
+export type DingtalkEndpoints = Record<DingtalkEndpointKey, string>;
+export type DingtalkEndpointConfig = Partial<
+  Pick<DingtalkConfig, DingtalkEndpointKey | "endpoint">
+>;
+
+function normalizeEndpoint(value: unknown, fallback: string): string {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+export function resolveDingtalkEndpoints(config?: DingtalkEndpointConfig): DingtalkEndpoints {
+  return {
+    gatewayEndpoint: normalizeEndpoint(
+      config?.gatewayEndpoint ?? config?.endpoint,
+      DEFAULT_DINGTALK_GATEWAY_ENDPOINT,
+    ),
+    tokenEndpoint: normalizeEndpoint(
+      config?.tokenEndpoint,
+      DEFAULT_DINGTALK_TOKEN_ENDPOINT,
+    ),
+    apiEndpoint: normalizeEndpoint(config?.apiEndpoint, DEFAULT_DINGTALK_API_ENDPOINT),
+    oapiEndpoint: normalizeEndpoint(config?.oapiEndpoint, DEFAULT_DINGTALK_OAPI_ENDPOINT),
+  };
+}
+
+export function dingtalkApiUrl(config: DingtalkEndpointConfig | undefined, path: string): string {
+  return `${resolveDingtalkEndpoints(config).apiEndpoint}${path}`;
+}
+
+export function dingtalkOapiUrl(config: DingtalkEndpointConfig | undefined, path: string): string {
+  return `${resolveDingtalkEndpoints(config).oapiEndpoint}${path}`;
+}
+
+export function dingtalkTokenUrl(config: DingtalkEndpointConfig | undefined, path: string): string {
+  return `${resolveDingtalkEndpoints(config).tokenEndpoint}${path}`;
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -64,7 +64,11 @@ const DingtalkSharedConfigShape = {
   groupSessionScope: GroupSessionScopeSchema,
   asyncMode: z.boolean().optional(),
   ackText: z.string().optional(),
-  endpoint: z.string().optional(), // DWClient gateway endpoint
+  gatewayEndpoint: z.string().url().optional(), // DWClient gateway endpoint
+  tokenEndpoint: z.string().url().optional(), // OAuth token endpoint
+  apiEndpoint: z.string().url().optional(), // DingTalk OpenAPI endpoint
+  oapiEndpoint: z.string().url().optional(), // DingTalk legacy OAPI endpoint
+  endpoint: z.string().url().optional(), // Deprecated: DWClient gateway endpoint alias
   debug: z.boolean().optional(), // DWClient debug mode
   enableMediaUpload: z.boolean().optional(),
   systemPrompt: z.string().optional(),

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -15,6 +15,7 @@
 import * as fs from 'fs';
 import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk";
 import type { ResolvedDingtalkAccount } from "../types/index.ts";
+import { resolveDingtalkEndpoints } from "../config/endpoints.ts";
 import {
   checkAndMarkDingtalkMessage,
 } from "../utils/utils-legacy.ts";
@@ -140,12 +141,13 @@ export async function monitorSingleAccount(
   }
 
   // 配置 DWClient：禁用 SDK 内置的 keepAlive 和 autoReconnect，使用自定义实现
+  const endpoints = resolveDingtalkEndpoints(account.config);
   const client = new DWClient({
     clientId: account.clientId,
     clientSecret: account.clientSecret,
     debug: account.config.debug,
     // 显式设置 HTTPS endpoint，防止被降级为 HTTP
-    endpoint: account.config.endpoint || "https://api.dingtalk.com",
+    endpoint: endpoints.gatewayEndpoint,
     autoReconnect: false, // ❌ 禁用 SDK 自动重连
     keepAlive: false, // ❌ 禁用 SDK 心跳检测
   } as any);

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -39,11 +39,10 @@ import {
   buildSessionContext,
   getAccessToken,
   getOapiAccessToken,
-  DINGTALK_API,
-  DINGTALK_OAPI,
   addEmotionReply,
   recallEmotionReply,
 } from "../utils/utils-legacy.ts";
+import { dingtalkApiUrl } from "../config/endpoints.ts";
 import { resolveAgentWorkspaceDir } from "../utils/agent.ts";
 import { 
   processLocalImages, 
@@ -700,7 +699,7 @@ export async function downloadMediaByCode(
     log?.info?.(`通过 downloadCode 下载媒体: ${downloadCode.slice(0, 30)}...`);
 
     const resp = await dingtalkHttp.post(
-      `${DINGTALK_API}/v1.0/robot/messageFiles/download`,
+      dingtalkApiUrl(config, '/v1.0/robot/messageFiles/download'),
       { downloadCode, robotCode: String(config.clientId) },
       {
         headers: { 'x-acs-dingtalk-access-token': token, 'Content-Type': 'application/json' },
@@ -732,7 +731,7 @@ export async function getFileDownloadUrl(
     log?.info?.(`获取文件下载链接: ${fileName}`);
 
     const resp = await dingtalkHttp.post(
-      `${DINGTALK_API}/v1.0/robot/messageFiles/download`,
+      dingtalkApiUrl(config, '/v1.0/robot/messageFiles/download'),
       { downloadCode, robotCode: String(config.clientId) },
       {
         headers: { 'x-acs-dingtalk-access-token': token, 'Content-Type': 'application/json' },
@@ -1488,7 +1487,7 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
         let finalText = fullResponse;
 
         if (oapiToken) {
-          finalText = await processLocalImages(finalText, oapiToken, log);
+          finalText = await processLocalImages(finalText, oapiToken, log, config);
 
           const mediaTarget: AICardTarget = isDirect
             ? { type: 'user', userId: senderId }

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -4,7 +4,8 @@
  */
 
 import type { DingtalkConfig } from './types/index.ts';
-import { getAccessToken, DINGTALK_API } from './utils/index.ts';
+import { dingtalkApiUrl } from './config/endpoints.ts';
+import { getAccessToken } from './utils/index.ts';
 import { dingtalkHttp } from './utils/http-client.ts';
 
 // ============ 类型定义 ============
@@ -55,7 +56,7 @@ export class DingtalkDocsClient {
       this.log?.info?.(`[DingTalk][Docs] 获取文档信息: spaceId=${spaceId}, docId=${docId}`);
 
       const resp = await dingtalkHttp.get(
-        `${DINGTALK_API}/v1.0/doc/spaces/${spaceId}/docs/${docId}`,
+        dingtalkApiUrl(this.config, `/v1.0/doc/spaces/${spaceId}/docs/${docId}`),
         { headers, timeout: 10_000 },
       );
 
@@ -89,7 +90,7 @@ export class DingtalkDocsClient {
       }
 
       const resp = await dingtalkHttp.get(
-        `${DINGTALK_API}/v2.0/wiki/nodes/${nodeId}/content`,
+        dingtalkApiUrl(this.config, `/v2.0/wiki/nodes/${nodeId}/content`),
         { headers, params: { operatorId }, timeout: 30_000 },
       );
 
@@ -154,7 +155,7 @@ export class DingtalkDocsClient {
       };
 
       await dingtalkHttp.post(
-        `${DINGTALK_API}/v1.0/doc/documents/${docId}/blocks/root/children`,
+        dingtalkApiUrl(this.config, `/v1.0/doc/documents/${docId}/blocks/root/children`),
         body,
         { headers, timeout: 10_000 },
       );
@@ -190,7 +191,7 @@ export class DingtalkDocsClient {
       };
 
       const resp = await dingtalkHttp.post(
-        `${DINGTALK_API}/v1.0/doc/spaces/${spaceId}/docs`,
+        dingtalkApiUrl(this.config, `/v1.0/doc/spaces/${spaceId}/docs`),
         body,
         { headers, timeout: 10_000 },
       );
@@ -233,7 +234,7 @@ export class DingtalkDocsClient {
       if (spaceId) body.spaceId = spaceId;
 
       const resp = await dingtalkHttp.post(
-        `${DINGTALK_API}/v1.0/doc/docs/search`,
+        dingtalkApiUrl(this.config, '/v1.0/doc/docs/search'),
         body,
         { headers, timeout: 10_000 },
       );
@@ -270,7 +271,7 @@ export class DingtalkDocsClient {
       if (parentId) params.parentDentryId = parentId;
 
       const resp = await dingtalkHttp.get(
-        `${DINGTALK_API}/v1.0/doc/spaces/${spaceId}/dentries`,
+        dingtalkApiUrl(this.config, `/v1.0/doc/spaces/${spaceId}/dentries`),
         { headers, params, timeout: 10_000 },
       );
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -192,6 +192,11 @@ export const dingtalkOnboardingAdapter: ChannelSetupWizardAdapter = {
         probeResult = await probeDingtalk({
           clientId: defaultAccount.clientId,
           clientSecret: defaultAccount.clientSecret,
+          gatewayEndpoint: defaultAccount.config.gatewayEndpoint,
+          tokenEndpoint: defaultAccount.config.tokenEndpoint,
+          apiEndpoint: defaultAccount.config.apiEndpoint,
+          oapiEndpoint: defaultAccount.config.oapiEndpoint,
+          endpoint: defaultAccount.config.endpoint,
         });
       } catch {
         // Ignore probe errors
@@ -351,6 +356,11 @@ export const dingtalkOnboardingAdapter: ChannelSetupWizardAdapter = {
         const probe = await probeDingtalk({
           clientId,
           clientSecret: clientSecretProbeValue ?? undefined,
+          gatewayEndpoint: (next.channels?.["dingtalk-connector"] as DingtalkConfig | undefined)?.gatewayEndpoint,
+          tokenEndpoint: (next.channels?.["dingtalk-connector"] as DingtalkConfig | undefined)?.tokenEndpoint,
+          apiEndpoint: (next.channels?.["dingtalk-connector"] as DingtalkConfig | undefined)?.apiEndpoint,
+          oapiEndpoint: (next.channels?.["dingtalk-connector"] as DingtalkConfig | undefined)?.oapiEndpoint,
+          endpoint: (next.channels?.["dingtalk-connector"] as DingtalkConfig | undefined)?.endpoint,
         });
         if (probe.ok) {
           await prompter.note(

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -1,4 +1,10 @@
 import { raceWithTimeoutAndAbort } from "./utils/async.ts";
+import {
+  type DingtalkEndpointConfig,
+  dingtalkApiUrl,
+  dingtalkTokenUrl,
+  resolveDingtalkEndpoints,
+} from "./config/endpoints.ts";
 import type { DingtalkProbeResult } from "./types/index.ts";
 
 /** LRU Cache for probe results to reduce repeated health-check calls. */
@@ -68,7 +74,11 @@ function setCachedProbeResult(
 }
 
 export async function probeDingtalk(
-  creds?: { clientId: string; clientSecret: string; accountId?: string },
+  creds?: DingtalkEndpointConfig & {
+    clientId?: string;
+    clientSecret?: string;
+    accountId?: string;
+  },
   options: ProbeDingtalkOptions = {},
 ): Promise<DingtalkProbeResult> {
   if (!creds?.clientId || !creds?.clientSecret) {
@@ -88,7 +98,10 @@ export async function probeDingtalk(
   const timeoutMs = options.timeoutMs ?? DINGTALK_PROBE_REQUEST_TIMEOUT_MS;
 
   // Return cached result if still valid.
-  const cacheKey = creds.accountId ?? `${creds.clientId}:${creds.clientSecret.slice(0, 8)}`;
+  const endpoints = resolveDingtalkEndpoints(creds);
+  const credentialKey = creds.accountId ?? `${creds.clientId}:${creds.clientSecret.slice(0, 8)}`;
+  const cacheKey =
+    `${credentialKey}:${endpoints.tokenEndpoint}:${endpoints.apiEndpoint}`;
   const cached = probeCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) {
     return cached.result;
@@ -97,7 +110,7 @@ export async function probeDingtalk(
   try {
     // Get access token
     const tokenResponse = await raceWithTimeoutAndAbort(
-      fetch("https://api.dingtalk.com/v1.0/oauth2/accessToken", {
+      fetch(dingtalkTokenUrl(creds, "/v1.0/oauth2/accessToken"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -142,7 +155,7 @@ export async function probeDingtalk(
 
     // Get bot info
     const botResponse = await raceWithTimeoutAndAbort(
-      fetch(`https://api.dingtalk.com/v1.0/contact/users/me`, {
+      fetch(dingtalkApiUrl(creds, "/v1.0/contact/users/me"), {
         method: "GET",
         headers: {
           "x-acs-dingtalk-access-token": tokenData.accessToken,

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -293,7 +293,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       
       if (oapiToken) {
         // 处理本地图片
-        finalText = await processLocalImages(finalText, oapiToken, log);
+        finalText = await processLocalImages(finalText, oapiToken, log, account.config as DingtalkConfig);
         
         // ✅ 先处理 Markdown 标记格式的媒体文件
         finalText = await processVideoMarkers(

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -99,6 +99,11 @@ export interface DingtalkAccountConfig {
   textChunkLimit?: number;
   mediaMaxMb?: number;
   typingIndicator?: boolean;
+  gatewayEndpoint?: string;
+  tokenEndpoint?: string;
+  apiEndpoint?: string;
+  oapiEndpoint?: string;
+  endpoint?: string;
   tools?: DingtalkToolsConfig;
 }
 
@@ -125,6 +130,11 @@ export interface DingtalkConfig {
   mediaMaxMb?: number;
   typingIndicator?: boolean;
   resolveSenderNames?: boolean;
+  gatewayEndpoint?: string;
+  tokenEndpoint?: string;
+  apiEndpoint?: string;
+  oapiEndpoint?: string;
+  endpoint?: string;
   tools?: DingtalkToolsConfig;
   groups?: Record<string, DingtalkGroupConfig>;
   accounts?: Record<string, DingtalkAccountConfig>;

--- a/src/services/media.ts
+++ b/src/services/media.ts
@@ -9,7 +9,8 @@ import * as path from 'path';
 // 避免动态 import 时 .default 偶发为 undefined 导致 "Cannot read properties of undefined (reading 'registry')"
 import FormData from 'form-data';
 import type { DingtalkConfig } from '../types/index.ts';
-import { DINGTALK_OAPI, getOapiAccessToken } from '../utils/index.ts';
+import { dingtalkApiUrl, dingtalkOapiUrl } from '../config/endpoints.ts';
+import { getOapiAccessToken } from '../utils/index.ts';
 import { dingtalkHttp, dingtalkOapiHttp } from '../utils/http-client.ts';
 
 
@@ -90,6 +91,7 @@ export async function uploadMediaToDingTalk(
   oapiToken: string,
   maxSize: number = 20 * 1024 * 1024,
   log?: any,
+  config?: DingtalkConfig,
 ): Promise<UploadResult | null> {
   try {
     const absPath = toLocalPath(filePath);
@@ -138,7 +140,7 @@ export async function uploadMediaToDingTalk(
 
     log?.info?.(`上传文件: ${absPath} (${fileSizeMB}MB)`);
     const resp = await dingtalkOapiHttp.post(
-      `${DINGTALK_OAPI}/media/upload?access_token=${oapiToken}&type=${mediaType === 'video' ? 'file' : mediaType}`,
+      `${dingtalkOapiUrl(config, '/media/upload')}?access_token=${oapiToken}&type=${mediaType === 'video' ? 'file' : mediaType}`,
       form,
       { headers: form.getHeaders(), timeout: 60_000 },
     );
@@ -171,6 +173,7 @@ export async function processLocalImages(
   content: string,
   oapiToken: string | null,
   log?: any,
+  config?: DingtalkConfig,
 ): Promise<string> {
   if (!oapiToken) {
     log?.warn?.(`无 oapiToken，跳过图片后处理`);
@@ -187,7 +190,7 @@ export async function processLocalImages(
       const [fullMatch, alt, rawPath] = match;
       // 清理转义字符（AI 可能会对含空格的路径添加 \ ）
       const cleanPath = rawPath.replace(/\\ /g, ' ');
-      const uploadResult = await uploadMediaToDingTalk(cleanPath, 'image', oapiToken, 20 * 1024 * 1024, log);
+      const uploadResult = await uploadMediaToDingTalk(cleanPath, 'image', oapiToken, 20 * 1024 * 1024, log, config);
       if (uploadResult) {
         result = result.replace(fullMatch, `![${alt}](${uploadResult.downloadUrl})`);
       }
@@ -210,7 +213,7 @@ export async function processLocalImages(
     for (const match of newBareMatches.reverse()) {
       const [fullMatch, rawPath] = match;
       log?.info?.(`纯文本图片: "${fullMatch}" -> path="${rawPath}"`);
-      const uploadResult = await uploadMediaToDingTalk(rawPath, 'image', oapiToken, 20 * 1024 * 1024, log);
+      const uploadResult = await uploadMediaToDingTalk(rawPath, 'image', oapiToken, 20 * 1024 * 1024, log, config);
       if (uploadResult) {
         const replacement = `![](${uploadResult.downloadUrl})`;
         result = result.slice(0, match.index!) + result.slice(match.index!).replace(fullMatch, replacement);
@@ -401,7 +404,7 @@ export async function processVideoMarkers(
       }
 
       // 3. 上传视频
-      const videoUploadResult = await uploadMediaToDingTalk(videoInfo.path, 'video', oapiToken, 20 * 1024 * 1024, log);
+      const videoUploadResult = await uploadMediaToDingTalk(videoInfo.path, 'video', oapiToken, 20 * 1024 * 1024, log, config);
       if (!videoUploadResult) {
         log?.warn?.(`${logPrefix} 视频上传失败: ${videoInfo.path}`);
         statusMessages.push(`⚠️ 视频上传失败: ${fileName}（文件可能超过 20MB 限制）`);
@@ -410,7 +413,7 @@ export async function processVideoMarkers(
       const videoMediaId = videoUploadResult.mediaId; // 使用原始 media_id（带 @）
 
       // 4. 上传封面
-      const picUploadResult = await uploadMediaToDingTalk(thumbnailPath, 'image', oapiToken, 20 * 1024 * 1024, log);
+      const picUploadResult = await uploadMediaToDingTalk(thumbnailPath, 'image', oapiToken, 20 * 1024 * 1024, log, config);
       if (!picUploadResult) {
         log?.warn?.(`${logPrefix} 封面上传失败: ${thumbnailPath}`);
         statusMessages.push(`⚠️ 视频封面上传失败: ${fileName}`);
@@ -565,7 +568,7 @@ export async function processAudioMarkers(
       const ext = path.extname(audioInfo.path).slice(1).toLowerCase();
 
       // 上传音频到钉钉
-      const uploadResult = await uploadMediaToDingTalk(audioInfo.path, 'voice', oapiToken, 20 * 1024 * 1024, log);
+      const uploadResult = await uploadMediaToDingTalk(audioInfo.path, 'voice', oapiToken, 20 * 1024 * 1024, log, config);
       if (!uploadResult) {
         statusMessages.push(`⚠️ 音频上传失败: ${fileName}（文件可能超过 20MB 限制）`);
         continue;
@@ -671,7 +674,7 @@ export async function processFileMarkers(
     const fileName = fileInfo.fileName || path.basename(fileInfo.path);
     try {
       // 上传文件到钉钉
-      const uploadResult = await uploadMediaToDingTalk(fileInfo.path, 'file', oapiToken, 20 * 1024 * 1024, log);
+      const uploadResult = await uploadMediaToDingTalk(fileInfo.path, 'file', oapiToken, 20 * 1024 * 1024, log, config);
       if (!uploadResult) {
         statusMessages.push(`⚠️ 文件上传失败: ${fileName}（文件可能超过 20MB 限制）`);
         continue;
@@ -765,7 +768,6 @@ export async function sendVideoProactive(
 ): Promise<void> {
   try {
     const token = await (await import('../utils/index.ts')).getAccessToken(config);
-    const { DINGTALK_API } = await import('../utils/index.ts');
 
     // 钉钉普通消息 API 的视频消息格式
     const msgParam = {
@@ -784,10 +786,10 @@ export async function sendVideoProactive(
     let endpoint: string;
     if (target.type === 'group') {
       body.openConversationId = target.openConversationId;
-      endpoint = `${DINGTALK_API}/v1.0/robot/groupMessages/send`;
+      endpoint = dingtalkApiUrl(config, '/v1.0/robot/groupMessages/send');
     } else {
       body.userIds = [target.userId];
-      endpoint = `${DINGTALK_API}/v1.0/robot/oToMessages/batchSend`;
+      endpoint = dingtalkApiUrl(config, '/v1.0/robot/oToMessages/batchSend');
     }
 
     log?.info?.(`Video[Proactive] 发送视频消息`);
@@ -868,7 +870,6 @@ export async function sendAudioProactive(
 ): Promise<void> {
   try {
     const token = await (await import('../utils/index.ts')).getAccessToken(config);
-    const { DINGTALK_API } = await import('../utils/index.ts');
 
     // 钉钉普通消息 API 的音频消息格式
     const actualDuration = (durationMs && durationMs > 0) ? durationMs.toString() : '60000';
@@ -886,10 +887,10 @@ export async function sendAudioProactive(
     let endpoint: string;
     if (target.type === 'group') {
       body.openConversationId = target.openConversationId;
-      endpoint = `${DINGTALK_API}/v1.0/robot/groupMessages/send`;
+      endpoint = dingtalkApiUrl(config, '/v1.0/robot/groupMessages/send');
     } else {
       body.userIds = [target.userId];
-      endpoint = `${DINGTALK_API}/v1.0/robot/oToMessages/batchSend`;
+      endpoint = dingtalkApiUrl(config, '/v1.0/robot/oToMessages/batchSend');
     }
 
     log?.info?.(`Audio[Proactive] 发送音频消息: ${fileName}`);
@@ -963,7 +964,6 @@ export async function sendFileProactive(
 ): Promise<void> {
   try {
     const token = await (await import('../utils/index.ts')).getAccessToken(config);
-    const { DINGTALK_API } = await import('../utils/index.ts');
 
     // 钉钉普通消息 API 的文件消息格式
     const resolvedFileName = fileInfo.fileName || path.basename(fileInfo.path);
@@ -983,10 +983,10 @@ export async function sendFileProactive(
     let endpoint: string;
     if (target.type === 'group') {
       body.openConversationId = target.openConversationId;
-      endpoint = `${DINGTALK_API}/v1.0/robot/groupMessages/send`;
+      endpoint = dingtalkApiUrl(config, '/v1.0/robot/groupMessages/send');
     } else {
       body.userIds = [target.userId];
-      endpoint = `${DINGTALK_API}/v1.0/robot/oToMessages/batchSend`;
+      endpoint = dingtalkApiUrl(config, '/v1.0/robot/oToMessages/batchSend');
     }
 
     log?.info?.(`File[Proactive] 发送文件消息: ${fileInfo.fileName}`);
@@ -1079,7 +1079,8 @@ export async function processRawMediaPaths(
         mediaType,
         oapiToken,
         20 * 1024 * 1024,
-        log
+        log,
+        config,
       );
       
       if (!uploadResult) {

--- a/src/services/media/audio.ts
+++ b/src/services/media/audio.ts
@@ -42,7 +42,7 @@ export async function processAudioMarkers(
         result = result.replace(full, '⚠️ 音频文件不存在');
         continue;
       }
-      const uploadResult = await uploadMediaToDingTalk(absPath, 'voice', oapiToken, 20 * 1024 * 1024, log);
+      const uploadResult = await uploadMediaToDingTalk(absPath, 'voice', oapiToken, 20 * 1024 * 1024, log, config);
       result = result.replace(full, uploadResult ? `[音频已上传：${uploadResult}]` : '⚠️ 音频上传失败');
     } catch {
       log?.warn?.(`${logPrefix} 解析音频标记失败：${match[1]}`);

--- a/src/services/media/chunk-upload.ts
+++ b/src/services/media/chunk-upload.ts
@@ -10,13 +10,13 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import type { DingtalkConfig } from '../../types/index.ts';
+import { dingtalkOapiUrl } from '../../config/endpoints.ts';
 import { createLogger } from '../../utils/logger.ts';
 import { dingtalkOapiHttp, dingtalkUploadHttp } from '../../utils/http-client.ts';
 // form-data 是 CJS 模块，静态 import 可确保 jiti/ESM 环境下 CJS 互操作行为稳定，
 // 避免动态 import 时 .default 偶发为 undefined 导致 "Cannot read properties of undefined (reading 'registry')"
 import FormData from 'form-data';
-
-const DINGTALK_OAPI = 'https://oapi.dingtalk.com';
 
 /** 分块上传配置 */
 export const CHUNK_CONFIG = {
@@ -59,6 +59,7 @@ export async function enableUploadTransaction(
   fileName: string,
   fileSize: number,
   debug: boolean = false,
+  config?: DingtalkConfig,
 ): Promise<string | null> {
   const log = createLogger(debug, 'DingTalk][ChunkUpload');
   
@@ -70,7 +71,7 @@ export async function enableUploadTransaction(
     form.append('file_size', fileSize.toString());
 
     const resp = await dingtalkOapiHttp.post<UploadTransactionResponse>(
-      `${DINGTALK_OAPI}/file/upload/transaction/enable`,
+      dingtalkOapiUrl(config, '/file/upload/transaction/enable'),
       form,
       {
         params: { access_token: oapiToken },
@@ -109,6 +110,7 @@ export async function uploadFileBlock(
   chunkNumber: number,
   totalChunks: number,
   debug: boolean = false,
+  config?: DingtalkConfig,
 ): Promise<boolean> {
   const log = createLogger(debug, 'DingTalk][ChunkUpload');
   
@@ -125,7 +127,7 @@ export async function uploadFileBlock(
     });
 
     const resp = await dingtalkOapiHttp.post<UploadBlockResponse>(
-      `${DINGTALK_OAPI}/file/upload/chunk`,
+      dingtalkOapiUrl(config, '/file/upload/chunk'),
       form,
       {
         params: { access_token: oapiToken },
@@ -159,6 +161,7 @@ export async function submitUploadTransaction(
   uploadId: string,
   fileName: string,
   debug: boolean = false,
+  config?: DingtalkConfig,
 ): Promise<{ fileId?: string; downloadCode?: string } | null> {
   const log = createLogger(debug, 'DingTalk][ChunkUpload');
   
@@ -166,7 +169,7 @@ export async function submitUploadTransaction(
     log.info(`提交上传事务：${uploadId}`);
 
     const resp = await dingtalkOapiHttp.get<SubmitTransactionResponse>(
-      `${DINGTALK_OAPI}/file/upload/transaction/submit`,
+      dingtalkOapiUrl(config, '/file/upload/transaction/submit'),
       {
         params: {
           access_token: oapiToken,
@@ -225,6 +228,7 @@ export async function uploadLargeFileByChunks(
   mediaType: 'video' | 'file',
   oapiToken: string,
   debug: boolean = false,
+  config?: DingtalkConfig,
 ): Promise<string | null> {
   const log = createLogger(debug, 'DingTalk][ChunkUpload');
   
@@ -243,7 +247,7 @@ export async function uploadLargeFileByChunks(
     log.info(`开始分块上传：${fileName}, 大小：${fileSizeMB}MB, 类型：${mediaType}`);
 
     // 步骤一：开启上传事务
-    const uploadId = await enableUploadTransaction(oapiToken, fileName, fileSize, debug);
+    const uploadId = await enableUploadTransaction(oapiToken, fileName, fileSize, debug, config);
     if (!uploadId) {
       log.error(`开启事务失败，终止上传`);
       return null;
@@ -268,7 +272,8 @@ export async function uploadLargeFileByChunks(
         chunkData,
         i + 1, // chunkNumber 从 1 开始
         totalChunks,
-        debug
+        debug,
+        config,
       );
 
       if (!success) {
@@ -281,7 +286,7 @@ export async function uploadLargeFileByChunks(
     }
 
     // 步骤三：提交上传事务
-    const result = await submitUploadTransaction(oapiToken, uploadId, fileName, debug);
+    const result = await submitUploadTransaction(oapiToken, uploadId, fileName, debug, config);
     if (!result || !result.downloadCode) {
       log.error(`提交事务失败`);
       return null;

--- a/src/services/media/common.ts
+++ b/src/services/media/common.ts
@@ -7,6 +7,11 @@ import * as path from 'path';
 // form-data 是 CJS 模块，静态 import 可确保 jiti/ESM 环境下 CJS 互操作行为稳定，
 // 避免动态 import 时 .default 偶发为 undefined 导致 "Cannot read properties of undefined (reading 'registry')"
 import FormData from 'form-data';
+import type { DingtalkConfig } from '../../types/index.ts';
+import {
+  DEFAULT_DINGTALK_OAPI_ENDPOINT,
+  dingtalkOapiUrl,
+} from '../../config/endpoints.ts';
 import { createLogger } from '../../utils/logger.ts';
 import { CHUNK_CONFIG } from './chunk-upload.ts';
 import { dingtalkOapiHttp, dingtalkUploadHttp } from '../../utils/http-client.ts';
@@ -68,10 +73,15 @@ export async function uploadMediaToDingTalk(
   oapiToken: string,
   maxSize: number = 20 * 1024 * 1024,
   logOrDebug?: any,
-  debug?: boolean,
+  debugOrConfig?: boolean | DingtalkConfig,
+  config?: DingtalkConfig,
 ): Promise<string | null> {
+  const endpointConfig =
+    typeof debugOrConfig === 'object' && debugOrConfig !== null
+      ? debugOrConfig
+      : config;
   const debugEnabled =
-    typeof logOrDebug === 'boolean' ? logOrDebug === true : debug === true;
+    typeof logOrDebug === 'boolean' ? logOrDebug === true : debugOrConfig === true;
   const externalLog = typeof logOrDebug === 'boolean' ? undefined : logOrDebug;
   const log = externalLog ?? createLogger(debugEnabled, `DingTalk][${mediaType}`);
   
@@ -96,7 +106,7 @@ export async function uploadMediaToDingTalk(
       log?.info?.(`文件超过 20MB，使用分块上传：${absPath} (${fileSizeMB}MB)`);
       try {
         const { uploadLargeFileByChunks } = await import('./chunk-upload');
-        const downloadCode = await uploadLargeFileByChunks(absPath, mediaType, oapiToken, debugEnabled);
+        const downloadCode = await uploadLargeFileByChunks(absPath, mediaType, oapiToken, debugEnabled, endpointConfig);
         if (downloadCode) {
           log?.info?.(`分块上传成功：${absPath}, download_code: ${downloadCode}`);
           return downloadCode;
@@ -127,7 +137,7 @@ export async function uploadMediaToDingTalk(
 
     log?.info?.(`上传文件：${absPath} (${fileSizeMB}MB), uploadType=${uploadType}`);
     const resp = await dingtalkUploadHttp.post(
-      `${DINGTALK_OAPI}/media/upload`,
+      dingtalkOapiUrl(endpointConfig, '/media/upload'),
       form,
       {
         params: { access_token: oapiToken, type: mediaType },
@@ -152,4 +162,4 @@ export async function uploadMediaToDingTalk(
 }
 
 /** 钉钉 OAPI 常量 */
-export const DINGTALK_OAPI = 'https://oapi.dingtalk.com';
+export const DINGTALK_OAPI = DEFAULT_DINGTALK_OAPI_ENDPOINT;

--- a/src/services/media/file.ts
+++ b/src/services/media/file.ts
@@ -63,7 +63,7 @@ export async function uploadAndReplaceFileMarkers(
     try {
       const fileData = JSON.parse(match[1]);
       const absPath = toLocalPath(fileData.path);
-      const uploadResult = await uploadMediaToDingTalk(absPath, 'file', oapiToken, 20 * 1024 * 1024, log);
+      const uploadResult = await uploadMediaToDingTalk(absPath, 'file', oapiToken, 20 * 1024 * 1024, log, config);
       result = result.replace(full, uploadResult ? `[文件已上传：${uploadResult}]` : '⚠️ 文件上传失败');
     } catch {
       log?.warn?.(`${logPrefix} 解析文件标记失败：${match[1]}`);

--- a/src/services/media/image.ts
+++ b/src/services/media/image.ts
@@ -12,6 +12,7 @@ interface Logger {
   [key: string]: any;
 }
 
+import type { DingtalkConfig } from '../../types/index.ts';
 import {
   LOCAL_IMAGE_RE,
   BARE_IMAGE_PATH_RE,
@@ -27,6 +28,7 @@ export async function processLocalImages(
   content: string,
   oapiToken: string | null,
   log?: Logger,
+  config?: DingtalkConfig,
 ): Promise<string> {
   if (!oapiToken) {
     log?.warn?.(`[DingTalk][Media] 无 oapiToken，跳过图片后处理`);
@@ -42,7 +44,7 @@ export async function processLocalImages(
     for (const match of mdMatches) {
       const [fullMatch, alt, rawPath] = match;
       const cleanPath = rawPath.replace(/\\ /g, ' ');
-      const {mediaId} = await uploadMediaToDingTalk(cleanPath, 'image', oapiToken, 20 * 1024 * 1024, log);
+      const {mediaId} = await uploadMediaToDingTalk(cleanPath, 'image', oapiToken, 20 * 1024 * 1024, log, config);
       if (mediaId) {
         // 使用标准 Markdown 图片语法：![文案](mediaId)
         const replacement = `![${alt}](${mediaId})`;
@@ -67,7 +69,7 @@ export async function processLocalImages(
   //   for (const match of newBareMatches.reverse()) {
   //     const [fullMatch, rawPath] = match;
   //     log?.info?.(`[DingTalk][Media] 纯文本图片："${fullMatch}" -> path="${rawPath}"`);
-  //     const {mediaId} = await uploadMediaToDingTalk(rawPath, 'image', oapiToken, 20 * 1024 * 1024, log);
+  //     const {mediaId} = await uploadMediaToDingTalk(rawPath, 'image', oapiToken, 20 * 1024 * 1024, log, config);
   //     if (mediaId) {
   //       // 使用标准 Markdown 图片语法：![](mediaId)
   //       const replacement = `![](${mediaId})`;

--- a/src/services/media/video.ts
+++ b/src/services/media/video.ts
@@ -150,7 +150,7 @@ export async function processVideoMarkers(
         result = result.replace(full, '⚠️ 视频文件不存在');
         continue;
       }
-      const mediaId = await uploadMediaToDingTalk(absPath, 'video', oapiToken, 20 * 1024 * 1024, log);
+      const mediaId = await uploadMediaToDingTalk(absPath, 'video', oapiToken, 20 * 1024 * 1024, log, config);
       result = result.replace(full, mediaId ? `[视频已上传：${mediaId}]` : '⚠️ 视频上传失败');
     } catch {
       log?.warn?.(`${logPrefix} 解析视频标记失败：${match[1]}`);

--- a/src/services/messaging.ts
+++ b/src/services/messaging.ts
@@ -4,8 +4,9 @@
  */
 
 import type { DingtalkConfig } from "../types/index.ts";
-import { DINGTALK_API, getAccessToken, getOapiAccessToken } from "../utils/index.ts";
-import { dingtalkHttp, dingtalkOapiHttp } from "../utils/http-client.ts";
+import { dingtalkApiUrl } from "../config/endpoints.ts";
+import { getAccessToken, getOapiAccessToken } from "../utils/index.ts";
+import { dingtalkHttp } from "../utils/http-client.ts";
 import { MEDIA_MSG_TYPES } from "../utils/constants.ts";
 import { createLoggerFromConfig } from "../utils/logger.ts";
 import {
@@ -216,7 +217,7 @@ export async function sendNormalToUser(
   const oapiToken = await getOapiAccessToken(config);
   if (oapiToken) {
     log?.info?.(`[sendNormalToUser] 开始图片后处理`);
-    processedContent = await processLocalImages(content, oapiToken, log);
+    processedContent = await processLocalImages(content, oapiToken, log, config);
   } else {
     log?.warn?.(`[sendNormalToUser] 无法获取 oapiToken，跳过媒体后处理`);
   }
@@ -240,7 +241,7 @@ export async function sendNormalToUser(
     );
 
     const resp = await dingtalkHttp.post(
-      `${DINGTALK_API}/v1.0/robot/oToMessages/batchSend`,
+      dingtalkApiUrl(config, "/v1.0/robot/oToMessages/batchSend"),
       body,
       {
         headers: {
@@ -293,7 +294,7 @@ export async function sendNormalToGroup(
   const oapiToken = await getOapiAccessToken(config);
   if (oapiToken) {
     log?.info?.(`[sendNormalToGroup] 开始图片后处理`);
-    processedContent = await processLocalImages(content, oapiToken, log);
+    processedContent = await processLocalImages(content, oapiToken, log, config);
   } else {
     log?.warn?.(`[sendNormalToGroup] 无法获取 oapiToken，跳过媒体后处理`);
   }
@@ -317,7 +318,7 @@ export async function sendNormalToGroup(
     );
 
     const resp = await dingtalkHttp.post(
-      `${DINGTALK_API}/v1.0/robot/groupMessages/send`,
+      dingtalkApiUrl(config, "/v1.0/robot/groupMessages/send"),
       body,
       {
         headers: {
@@ -376,7 +377,7 @@ export async function sendAICardInternal(
     let processedContent = content;
     if (oapiToken) {
       log?.info?.(`开始图片后处理`);
-      processedContent = await processLocalImages(content, oapiToken, log);
+      processedContent = await processLocalImages(content, oapiToken, log, config);
     } else {
       log?.warn?.(
         `无法获取 oapiToken，跳过媒体后处理`,
@@ -693,6 +694,7 @@ export async function sendMediaToDingTalk(params: {
       oapiToken,
       maxSize,
       log,
+      config,
     );
     log.info("uploadMediaToDingTalk 返回结果:", uploadResult);
 
@@ -946,8 +948,8 @@ async function sendProactiveInternal(
 
     // ✅ 根据目标类型选择不同的 API
     const webhookUrl = isUser
-      ? `${DINGTALK_API}/v1.0/robot/oToMessages/batchSend`
-      : `${DINGTALK_API}/v1.0/robot/groupMessages/send`;
+      ? dingtalkApiUrl(config, "/v1.0/robot/oToMessages/batchSend")
+      : dingtalkApiUrl(config, "/v1.0/robot/groupMessages/send");
 
     // 使用 buildMsgPayload 构建消息体（支持所有消息类型）
     const payload = buildMsgPayload(msgType, content, options.title);

--- a/src/services/messaging/card.ts
+++ b/src/services/messaging/card.ts
@@ -4,7 +4,8 @@
  */
 
 import type { DingtalkConfig } from "../../types/index.ts";
-import { DINGTALK_API, getAccessToken } from "../../utils/token.ts";
+import { dingtalkApiUrl } from "../../config/endpoints.ts";
+import { getAccessToken } from "../../utils/token.ts";
 import { dingtalkHttp } from "../../utils/http-client.ts";
 
 // ============ 常量 ============
@@ -141,7 +142,7 @@ export async function createAICardForTarget(
     };
 
     const createResp = await dingtalkHttp.post(
-      `${DINGTALK_API}/v1.0/card/instances`,
+      dingtalkApiUrl(config, "/v1.0/card/instances"),
       createBody,
       {
         headers: {
@@ -159,7 +160,7 @@ export async function createAICardForTarget(
     );
 
     const deliverResp = await dingtalkHttp.post(
-      `${DINGTALK_API}/v1.0/card/instances/deliver`,
+      dingtalkApiUrl(config, "/v1.0/card/instances/deliver"),
       deliverBody,
       {
         headers: {
@@ -233,7 +234,7 @@ export async function streamAICard(
     };
     try {
       const statusResp = await dingtalkHttp.put(
-        `${DINGTALK_API}/v1.0/card/instances`,
+        dingtalkApiUrl(config, "/v1.0/card/instances"),
         statusBody,
         {
           headers: {
@@ -268,7 +269,7 @@ export async function streamAICard(
   );
   try {
     const streamResp = await dingtalkHttp.put(
-      `${DINGTALK_API}/v1.0/card/streaming`,
+      dingtalkApiUrl(config, "/v1.0/card/streaming"),
       body,
       {
         headers: {
@@ -323,7 +324,7 @@ export async function finishAICard(
 
   try {
     const finishResp = await dingtalkHttp.put(
-      `${DINGTALK_API}/v1.0/card/instances`,
+      dingtalkApiUrl(config, "/v1.0/card/instances"),
       body,
       {
         headers: {

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -4,12 +4,19 @@
  */
 
 import type { DingtalkConfig } from '../types/index.ts';
+import {
+  DEFAULT_DINGTALK_API_ENDPOINT,
+  DEFAULT_DINGTALK_OAPI_ENDPOINT,
+  dingtalkOapiUrl,
+  dingtalkTokenUrl,
+  resolveDingtalkEndpoints,
+} from '../config/endpoints.ts';
 import { dingtalkHttp, dingtalkOapiHttp } from './http-client.ts';
 
 // ============ 常量 ============
 
-export const DINGTALK_API = 'https://api.dingtalk.com';
-export const DINGTALK_OAPI = 'https://oapi.dingtalk.com';
+export const DINGTALK_API = DEFAULT_DINGTALK_API_ENDPOINT;
+export const DINGTALK_OAPI = DEFAULT_DINGTALK_OAPI_ENDPOINT;
 
 // ============ Access Token 缓存 ============
 
@@ -35,7 +42,8 @@ function cacheKey(config: DingtalkConfig): string {
     );
   }
   
-  return clientId;
+  const endpoints = resolveDingtalkEndpoints(config);
+  return `${clientId}|${endpoints.tokenEndpoint}|${endpoints.oapiEndpoint}`;
 }
 
 /**
@@ -49,7 +57,7 @@ export async function getAccessToken(config: DingtalkConfig): Promise<string> {
     return cached.token;
   }
 
-  const response = await dingtalkHttp.post(`${DINGTALK_API}/v1.0/oauth2/accessToken`, {
+  const response = await dingtalkHttp.post(dingtalkTokenUrl(config, '/v1.0/oauth2/accessToken'), {
     appKey: config.clientId,
     appSecret: config.clientSecret,
   });
@@ -75,7 +83,7 @@ export async function getOapiAccessToken(config: DingtalkConfig): Promise<string
       return cached.token;
     }
 
-    const resp = await dingtalkOapiHttp.get(`${DINGTALK_OAPI}/gettoken`, {
+    const resp = await dingtalkOapiHttp.get(dingtalkOapiUrl(config, '/gettoken'), {
       params: { appkey: config.clientId, appsecret: config.clientSecret },
     });
 

--- a/src/utils/utils-legacy.ts
+++ b/src/utils/utils-legacy.ts
@@ -3,6 +3,14 @@
  */
 
 import type { DingtalkConfig, ResolvedDingtalkAccount } from '../types/index.ts';
+import {
+  DEFAULT_DINGTALK_API_ENDPOINT,
+  DEFAULT_DINGTALK_OAPI_ENDPOINT,
+  dingtalkApiUrl,
+  dingtalkOapiUrl,
+  dingtalkTokenUrl,
+  resolveDingtalkEndpoints,
+} from '../config/endpoints.ts';
 
 // SessionContext 和 buildSessionContext 统一由 session.ts 维护
 export type { SessionContext } from './session.ts';
@@ -17,8 +25,8 @@ export const DEFAULT_ACCOUNT_ID = '__default__';
 export const NEW_SESSION_COMMANDS = ['/new', '/reset', '/clear', '新会话', '重新开始', '清空对话'];
 
 /** 钉钉 API 常量 */
-export const DINGTALK_API = 'https://api.dingtalk.com';
-export const DINGTALK_OAPI = 'https://oapi.dingtalk.com';
+export const DINGTALK_API = DEFAULT_DINGTALK_API_ENDPOINT;
+export const DINGTALK_OAPI = DEFAULT_DINGTALK_OAPI_ENDPOINT;
 
 // ============ 会话管理 ============
 
@@ -56,7 +64,8 @@ function cacheKey(config: DingtalkConfig): string {
     );
   }
   
-  return clientId;
+  const endpoints = resolveDingtalkEndpoints(config);
+  return `${clientId}|${endpoints.tokenEndpoint}|${endpoints.oapiEndpoint}`;
 }
 
 /**
@@ -71,7 +80,7 @@ export async function getAccessToken(config: DingtalkConfig): Promise<string> {
   }
 
   const { dingtalkHttp } = await import('./http-client.ts');
-  const response = await dingtalkHttp.post(`${DINGTALK_API}/v1.0/oauth2/accessToken`, {
+  const response = await dingtalkHttp.post(dingtalkTokenUrl(config, '/v1.0/oauth2/accessToken'), {
     appKey: config.clientId,
     appSecret: config.clientSecret,
   });
@@ -95,7 +104,7 @@ export async function getOapiAccessToken(config: DingtalkConfig): Promise<string
     }
 
     const { dingtalkOapiHttp } = await import('./http-client.ts');
-    const resp = await dingtalkOapiHttp.get(`${DINGTALK_OAPI}/gettoken`, {
+    const resp = await dingtalkOapiHttp.get(dingtalkOapiUrl(config, '/gettoken'), {
       params: { appkey: config.clientId, appsecret: config.clientSecret },
     });
     if (resp.data?.errcode === 0 && resp.data?.access_token) {
@@ -144,7 +153,7 @@ export async function getUnionId(
       return null;
     }
     const { dingtalkOapiHttp } = await import('./http-client.ts');
-    const resp = await dingtalkOapiHttp.get(`${DINGTALK_OAPI}/user/get`, {
+    const resp = await dingtalkOapiHttp.get(dingtalkOapiUrl(config, '/user/get'), {
       params: { access_token: token, userid: staffId },
       timeout: 10_000,
     });
@@ -401,7 +410,7 @@ export async function addEmotionReply(config: DingtalkConfig, data: any, log?: a
   try {
     const token = await getAccessToken(config);
     const { dingtalkHttp } = await import('./http-client.ts');
-    await dingtalkHttp.post(`${DINGTALK_API}/v1.0/robot/emotion/reply`, {
+    await dingtalkHttp.post(dingtalkApiUrl(config, '/v1.0/robot/emotion/reply'), {
       robotCode: data.robotCode ?? config.clientId,
       openMsgId: data.msgId,
       openConversationId: data.conversationId,
@@ -431,7 +440,7 @@ export async function recallEmotionReply(config: DingtalkConfig, data: any, log?
   try {
     const token = await getAccessToken(config);
     const { dingtalkHttp } = await import('./http-client.ts');
-    await dingtalkHttp.post(`${DINGTALK_API}/v1.0/robot/emotion/recall`, {
+    await dingtalkHttp.post(dingtalkApiUrl(config, '/v1.0/robot/emotion/recall'), {
       robotCode: data.robotCode ?? config.clientId,
       openMsgId: data.msgId,
       openConversationId: data.conversationId,

--- a/tests/ai-card/ai-card.test.ts
+++ b/tests/ai-card/ai-card.test.ts
@@ -81,7 +81,7 @@ describe('AI Card helpers', () => {
       const { createAICardForTarget } = __testables as any;
 
       mockAxiosPost.mockImplementation((url: string) => {
-        if (url === 'https://api.dingtalk.com/v1.0/oauth2/accessToken') {
+        if (String(url).includes('/v1.0/oauth2/accessToken')) {
           return Promise.resolve({ data: { accessToken: 'token123', expireIn: 7200 } });
         }
         if (url.includes('/card/instances')) {
@@ -117,7 +117,7 @@ describe('AI Card helpers', () => {
       const { createAICardForTarget } = __testables as any;
 
       mockAxiosPost.mockImplementation((url: string) => {
-        if (url === 'https://api.dingtalk.com/v1.0/oauth2/accessToken') {
+        if (String(url).includes('/v1.0/oauth2/accessToken')) {
           return Promise.resolve({ data: { accessToken: 'token123', expireIn: 7200 } });
         }
         return Promise.resolve({ status: 200, data: {} });

--- a/tests/card-update/card-update.test.ts
+++ b/tests/card-update/card-update.test.ts
@@ -28,7 +28,7 @@ describe('card update regression', () => {
     vi.clearAllMocks();
     mockAxiosPost.mockImplementation(async (url: string) => {
       // getAccessToken
-      if (url === 'https://api.dingtalk.com/v1.0/oauth2/accessToken') {
+      if (String(url).includes('/v1.0/oauth2/accessToken')) {
         return { data: { accessToken: 'token123', expireIn: 7200 } };
       }
       // create / deliver

--- a/tests/config-token/config-token.test.ts
+++ b/tests/config-token/config-token.test.ts
@@ -94,6 +94,30 @@ describe('config & token helpers', () => {
       expect(token2).toBe('token-1');
       expect(mockHttpPost).toHaveBeenCalledTimes(1);
     });
+
+    it('should use configured tokenEndpoint for access tokens', async () => {
+      const { getAccessToken } = await import('../../src/utils/token');
+      mockHttpPost.mockResolvedValue({
+        data: {
+          accessToken: 'token-custom',
+          expireIn: 3600,
+        },
+      });
+
+      const token = await getAccessToken({
+        ...baseCfg.channels['dingtalk-connector'],
+        tokenEndpoint: 'https://token.example.com/dingtalk/',
+      });
+
+      expect(token).toBe('token-custom');
+      expect(mockHttpPost).toHaveBeenCalledWith(
+        'https://token.example.com/dingtalk/v1.0/oauth2/accessToken',
+        {
+          appKey: 'id-1',
+          appSecret: 'secret-1',
+        },
+      );
+    });
   });
 
   describe('getOapiAccessToken', () => {
@@ -108,6 +132,27 @@ describe('config & token helpers', () => {
 
       const token = await getOapiAccessToken(baseCfg.channels['dingtalk-connector']);
       expect(token).toBe('oapi-token');
+    });
+
+    it('should use configured oapiEndpoint for OAPI tokens', async () => {
+      const { getOapiAccessToken } = await import('../../src/utils/token');
+      mockOapiHttpGet.mockResolvedValue({
+        data: {
+          errcode: 0,
+          access_token: 'oapi-custom',
+        },
+      });
+
+      const token = await getOapiAccessToken({
+        ...baseCfg.channels['dingtalk-connector'],
+        oapiEndpoint: 'https://oapi.example.com/dingtalk/',
+      });
+
+      expect(token).toBe('oapi-custom');
+      expect(mockOapiHttpGet).toHaveBeenCalledWith(
+        'https://oapi.example.com/dingtalk/gettoken',
+        { params: { appkey: 'id-1', appsecret: 'secret-1' } },
+      );
     });
 
     it('should return null when oapi returns error', async () => {
@@ -171,4 +216,3 @@ describe('config & token helpers', () => {
     });
   });
 });
-

--- a/tests/config/schema.test.ts
+++ b/tests/config/schema.test.ts
@@ -35,4 +35,22 @@ describe("DingtalkConfigSchema", () => {
     });
     expect((out.accounts?.work as any)?.systemPrompt).toBe("你是一个助手");
   });
+
+  it("accepts configurable DingTalk endpoints at top-level and per account", () => {
+    const out = DingtalkConfigSchema.parse({
+      gatewayEndpoint: "https://gateway.example.com/dingtalk",
+      tokenEndpoint: "https://token.example.com/dingtalk",
+      apiEndpoint: "https://api.dingtalk.com",
+      oapiEndpoint: "https://oapi.dingtalk.com",
+      accounts: {
+        work: {
+          apiEndpoint: "https://example.com/api",
+          oapiEndpoint: "https://example.com/oapi",
+        },
+      },
+    });
+
+    expect(out.gatewayEndpoint).toBe("https://gateway.example.com/dingtalk");
+    expect((out.accounts?.work as any)?.apiEndpoint).toBe("https://example.com/api");
+  });
 });

--- a/tests/core/connection.test.ts
+++ b/tests/core/connection.test.ts
@@ -15,6 +15,7 @@ class FakeSocket extends EventEmitter {
 class FakeDWClient extends EventEmitter {
   static nextConnectError: any = null;
   static latestInstance: FakeDWClient | null = null;
+  static latestOptions: any = null;
   socket = new FakeSocket();
   callback: ((res: any) => Promise<void>) | null = null;
   disconnect = vi.fn(async () => undefined);
@@ -30,8 +31,9 @@ class FakeDWClient extends EventEmitter {
   registerCallbackListener = vi.fn((_: string, cb: any) => {
     this.callback = cb;
   });
-  constructor(_: any) {
+  constructor(options: any) {
     super();
+    FakeDWClient.latestOptions = options;
     FakeDWClient.latestInstance = this;
   }
 }
@@ -59,6 +61,7 @@ describe("core/connection", () => {
     vi.clearAllMocks();
     FakeDWClient.nextConnectError = null;
     FakeDWClient.latestInstance = null;
+    FakeDWClient.latestOptions = null;
     // 默认首次处理：返回 false（未重复）
     mockCheckAndMarkDingtalkMessage.mockReturnValue(false);
   });
@@ -165,6 +168,30 @@ describe("core/connection", () => {
     await expect(
       monitorSingleAccount(createOpts()),
     ).rejects.toThrow("Failed to connect to DingTalk Stream: connection refused");
+  });
+
+  it("passes configured gatewayEndpoint to DWClient", async () => {
+    const { monitorSingleAccount } = await import("../../src/core/connection");
+    const controller = new AbortController();
+    const running = monitorSingleAccount(
+      createOpts({
+        abortSignal: controller.signal,
+        account: {
+          config: {
+            gatewayEndpoint: "https://gateway.example.com/dingtalk/",
+            debug: false,
+          },
+        },
+      }),
+    );
+
+    for (let i = 0; i < 10 && !FakeDWClient.latestOptions; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(FakeDWClient.latestOptions.endpoint).toBe("https://gateway.example.com/dingtalk");
+    controller.abort();
+    await running;
   });
 
   it("rejects with 400 message when connect() fails with status 400", async () => {

--- a/tests/probe/probe.test.ts
+++ b/tests/probe/probe.test.ts
@@ -100,6 +100,22 @@ describe("probeDingtalk", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps probe cache separate for different endpoint configs", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("accessToken")) {
+        return { json: async () => ({ accessToken: "tk" }) };
+      }
+      return { json: async () => ({ errcode: 0, nick: "bot-a" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const baseCreds = { clientId: "id", clientSecret: "secret", accountId: "acc-1" };
+    await probeDingtalk({ ...baseCreds, apiEndpoint: "https://api-a.example.com" });
+    await probeDingtalk({ ...baseCreds, apiEndpoint: "https://api-b.example.com" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
   it("catches unexpected fetch error", async () => {
     vi.stubGlobal(
       "fetch",

--- a/tests/send-message/send-message.test.ts
+++ b/tests/send-message/send-message.test.ts
@@ -28,7 +28,7 @@ describe('message sending helpers', () => {
     vi.clearAllMocks();
     // getAccessToken() 与真正发送都会走 axios.post，这里按 url 分流 mock。
     mockAxiosPost.mockImplementation(async (url: string) => {
-      if (url === 'https://api.dingtalk.com/v1.0/oauth2/accessToken') {
+      if (String(url).includes('/v1.0/oauth2/accessToken')) {
         return { data: { accessToken: 'token123', expireIn: 7200 } };
       }
       return { data: { success: true } };


### PR DESCRIPTION
DingTalk deployments may route stream, token, OpenAPI, and legacy OAPI traffic through different hosts, but the connector previously embedded public DingTalk hosts in multiple runtime paths. This adds a small endpoint resolver with public DingTalk defaults, wires the existing request paths through it, and keeps the legacy endpoint field as a gateway alias for compatibility.

Constraint: Open source defaults must remain the original public DingTalk endpoints

Rejected: Use pre-wa.alibaba-inc.com as a default | internal test endpoint must not ship to GitHub

Rejected: Only expose config schema fields | runtime calls would still hit hardcoded hosts

Confidence: high

Scope-risk: moderate

Directive: Do not add internal deployment endpoints to defaults or docs; keep environment-specific hosts in user config only

Tested: ./node_modules/.bin/vitest run (41 files, 463 passed, 11 skipped)

Tested: git diff --check

Tested: rg pre-wa/virtual-dingtalk/internal placeholder strings returned no matches

Not-tested: ./node_modules/.bin/tsc --noEmit --pretty false is blocked by existing repository type errors in accounts, DWClient socket access, pdf-parse typings, gateway-methods unknown params, and utils/agent