### PR TITLE
feat: Support blocking commands in chat message

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -247,6 +247,79 @@
               "markdown"
             ]
           },
+          "commandPolicy": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "open",
+                  "allowlist",
+                  "denylist"
+                ],
+                "default": "open"
+              },
+              "allow": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deny": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "blockMessage": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "dmCommandPolicy": {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "open",
+                  "allowlist",
+                  "denylist"
+                ],
+                "default": "open"
+              },
+              "allow": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "deny": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "blockMessage": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "dmCommandAllowlist": {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
           "accounts": {
             "type": "object",
             "additionalProperties": {
@@ -471,6 +544,79 @@
                     "text",
                     "markdown"
                   ]
+                },
+                "commandPolicy": {
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "open",
+                        "allowlist",
+                        "denylist"
+                      ],
+                      "default": "open"
+                    },
+                    "allow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deny": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "blockMessage": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "dmCommandPolicy": {
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "open",
+                        "allowlist",
+                        "denylist"
+                      ],
+                      "default": "open"
+                    },
+                    "allow": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "deny": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "blockMessage": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "dmCommandAllowlist": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  }
                 }
               },
               "additionalProperties": false

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -15,6 +15,23 @@ const ToolPolicySchema = z
   .optional();
 
 /**
+ * Command policy for controlling allowed commands in group chats.
+ * - mode: "open" (allow all), "allowlist" (only allow listed), "denylist" (block listed)
+ * - allow: list of allowed commands (used when mode="allowlist")
+ * - deny: list of denied commands (used when mode="denylist")
+ * - blockMessage: custom message shown when command is blocked
+ */
+const CommandPolicySchema = z
+  .object({
+    mode: z.enum(["open", "allowlist", "denylist"]).optional().default("open"),
+    allow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
+    blockMessage: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
+/**
  * Group session scope for routing DingTalk group messages.
  * - "group" (default): one session per group chat
  * - "group_sender": one session per (group + sender)
@@ -85,6 +102,9 @@ const DingtalkSharedConfigShape = {
   enableMediaUpload: z.boolean().optional(),
   systemPrompt: z.string().optional(),
   groupReplyMode: GroupReplyModeSchema,
+  commandPolicy: CommandPolicySchema, // Command whitelist/blacklist for group chats
+  dmCommandPolicy: CommandPolicySchema, // Command whitelist/blacklist for DM chats
+  dmCommandAllowlist: z.array(z.union([z.string(), z.number()])).optional(), // Users who can execute any command in DM
 };
 
 /**

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -51,9 +51,10 @@ import {
   processAudioMarkers, 
   uploadAndReplaceFileMarkers
 } from "../services/media/index.ts";
-import { sendProactive, type AICardTarget } from "../services/messaging/index.ts";
+import { sendProactive, sendMessage, type AICardTarget } from "../services/messaging/index.ts";
 import { createAICardForTarget, streamAICard, type AICardInstance } from "../services/messaging/card.ts";
 import { QUEUE_BUSY_ACK_PHRASES } from "../utils/constants.ts";
+import { checkCommandPolicy, type CommandPolicy } from "../policy.ts";
 import { createDingtalkReplyDispatcher } from "../reply-dispatcher.ts";
 import { normalizeSlashCommand } from "../utils/session.ts";
 import { getDingtalkRuntime } from "../runtime.ts";
@@ -1046,6 +1047,64 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
         return;
       }
     }
+
+    // ===== DM 命令策略检查 =====
+    // 检查 dmCommandAllowlist 白名单人员（白名单中的人员可执行任意命令）
+    const dmCommandAllowlist: (string | number)[] = config.dmCommandAllowlist || [];
+    const normalizedSenderId = String(senderId || '');
+    const isInDmCommandAllowlist = dmCommandAllowlist.length > 0 &&
+      dmCommandAllowlist.map(id => String(id)).includes(normalizedSenderId);
+
+    log?.info?.(`DM 命令策略检查: dmCommandAllowlist=${JSON.stringify(dmCommandAllowlist)}, isInDmCommandAllowlist=${isInDmCommandAllowlist}`);
+
+    // 如果发送者不在 DM 命令白名单中，则应用 commandPolicy
+    if (!isInDmCommandAllowlist) {
+      // 使用 data.text?.content 获取原始消息内容（与群聊保持一致）
+      const rawText = data.text?.content || '';
+      const commandPolicy = config.dmCommandPolicy as CommandPolicy | undefined;
+
+      log?.info?.(`DM 命令策略检查: dmCommandPolicy=${JSON.stringify(commandPolicy)}, rawText="${rawText.slice(0, 50)}"`);
+
+      // 只在配置了 dmCommandPolicy 且 mode 不是 open 时进行检查
+      if (commandPolicy && commandPolicy.mode !== 'open') {
+        const result = checkCommandPolicy(rawText, commandPolicy);
+
+        log?.info?.(`DM 命令策略检查: checkCommandPolicy result=${JSON.stringify(result)}`);
+
+        if (!result.isAllowed) {
+          log?.warn?.(`DM 命令被拦截: 消息="${rawText.slice(0, 50)}" 不符合 dmCommandPolicy (mode=${commandPolicy.mode})`);
+
+          // 确保 senderId 存在才能发送拦截提示
+          if (!senderId) {
+            log?.error?.(`无法发送 DM 命令拦截提示: senderId 为空`);
+            return;
+          }
+
+          try {
+            log?.info?.(`发送 DM 命令拦截提示 via sessionWebhook`);
+            // 使用 sendMessage 通过 sessionWebhook 发送拦截提示，而不是 sendProactive
+            // sessionWebhook 不需要额外的权限验证，与普通消息回复方式一致
+            await sendMessage(
+              config,
+              sessionWebhook,
+              result.blockMessage || '抱歉，该命令不可用。如需帮助，请联系管理员。',
+              {
+                useMarkdown: true,
+                log,
+              }
+            );
+            log?.info?.(`发送 DM 命令拦截提示成功`);
+          } catch (err: any) {
+            log?.error?.(`发送 DM 命令拦截提示失败: ${err.message}`);
+          }
+          return;
+        }
+      } else {
+        log?.info?.(`DM 命令策略检查: 跳过检查 (commandPolicy 未配置或为 open)`);
+      }
+    } else {
+      log?.info?.(`DM 命令白名单用户: senderId=${senderId}，跳过 commandPolicy 检查`);
+    }
   }
 
   // ===== 群聊 Policy 检查 =====
@@ -1112,6 +1171,34 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
           });
         } catch (err: any) {
           log?.error?.(`发送群聊 allowlist 提示失败: ${err.message}`);
+        }
+        return;
+      }
+    }
+
+    // ===== 群聊命令策略检查 =====
+    // 根据 commandPolicy 配置限制群聊用户可使用的命令
+    // 使用 content.text（extractMessageContent 处理后的内容）作为命令检查输入
+    const rawText = content.text || '';
+    const commandPolicy = config.commandPolicy as CommandPolicy | undefined;
+
+    // 只在配置了 commandPolicy 且 mode 不是 open 时进行检查
+    if (commandPolicy && commandPolicy.mode !== 'open') {
+      const result = checkCommandPolicy(rawText, commandPolicy);
+
+      if (!result.isAllowed) {
+        log?.warn?.(`群聊命令被拦截: 消息="${rawText.slice(0, 50)}" 不符合 commandPolicy (mode=${commandPolicy.mode})`);
+
+        try {
+          await sendProactive(config, { openConversationId: conversationId },
+            result.blockMessage || '抱歉，该命令不可用。如需帮助，请联系管理员。', {
+            msgType: 'text',
+            useAICard: false,
+            fallbackToNormal: true,
+            log,
+          });
+        } catch (err: any) {
+          log?.error?.(`发送群聊命令拦截提示失败: ${err.message}`);
         }
         return;
       }

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -30,3 +30,89 @@ export function resolveDingtalkGroupToolPolicy(params: {
   // Fall back to account-level default (allow all)
   return { allow: ["*"] };
 }
+
+import { DEFAULT_ALLOWED_COMMANDS, DEFAULT_COMMAND_BLOCK_MESSAGE } from "./utils/constants.ts";
+
+/**
+ * Command policy configuration interface
+ */
+export interface CommandPolicy {
+  mode?: 'open' | 'allowlist' | 'denylist';
+  allow?: string[];
+  deny?: string[];
+  blockMessage?: string;
+}
+
+/**
+ * 检查消息是否符合命令策略
+ * @param text - 用户输入的消息
+ * @param policy - 命令策略配置
+ * @returns { isAllowed: boolean; blockMessage?: string } - 是否允许及拦截消息
+ *
+ * 注意：仅对以 / 开头的命令进行过滤，普通消息（不以 / 开头）直接放行
+ */
+export function checkCommandPolicy(
+  text: string,
+  policy?: CommandPolicy
+): { isAllowed: boolean; blockMessage?: string } {
+  const trimmed = text.trim();
+  const lowerTrimmed = trimmed.toLowerCase();
+
+  // 空消息允许通过
+  if (!trimmed) {
+    return { isAllowed: true };
+  }
+
+  // 非命令消息（不以 / 开头）直接放行，不做过滤
+  if (!trimmed.startsWith('/')) {
+    return { isAllowed: true };
+  }
+
+  // 默认策略：open（允许所有）
+  const mode = policy?.mode ?? 'open';
+
+  // open 模式：允许所有命令
+  if (mode === 'open') {
+    return { isAllowed: true };
+  }
+
+  // allowlist 模式：只允许列表中的命令
+  if (mode === 'allowlist') {
+    const allowedCommands = policy?.allow?.length
+      ? policy.allow.filter(cmd => cmd.startsWith('/'))
+      : DEFAULT_ALLOWED_COMMANDS.filter(cmd => cmd.startsWith('/'));
+
+    const isAllowed = allowedCommands.some(
+      cmd => lowerTrimmed === cmd.toLowerCase()
+    );
+
+    if (!isAllowed) {
+      return {
+        isAllowed: false,
+        blockMessage: policy?.blockMessage || DEFAULT_COMMAND_BLOCK_MESSAGE,
+      };
+    }
+    return { isAllowed: true };
+  }
+
+  // denylist 模式：禁止列表中的命令
+  if (mode === 'denylist') {
+    const deniedCommands = (policy?.deny ?? []).filter(cmd => cmd.startsWith('/'));
+
+    const isDenied = deniedCommands.some(
+      cmd => lowerTrimmed === cmd.toLowerCase()
+    );
+
+    if (isDenied) {
+      return {
+        isAllowed: false,
+        blockMessage:
+          policy?.blockMessage ||
+          `抱歉，该命令已被禁用。如需帮助，请联系管理员。`,
+      };
+    }
+    return { isAllowed: true };
+  }
+
+  return { isAllowed: true };
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,6 +5,15 @@
 /** 新会话触发命令 */
 export const NEW_SESSION_COMMANDS = ['/new', '/reset', '/clear', '新会话', '重新开始', '清空对话'];
 
+/** 默认的允许命令白名单 */
+export const DEFAULT_ALLOWED_COMMANDS = [
+  '/new', '/reset', '/clear'
+];
+
+/** 默认的拦截提示消息 */
+export const DEFAULT_COMMAND_BLOCK_MESSAGE =
+  '抱歉，我目前仅支持以下会话管理命令：\n/new、/reset、/clear\n如需其他帮助，请联系管理员。';
+
 /**
  * 媒体类消息类型集合。
  *

--- a/tests/policy/command-policy.test.ts
+++ b/tests/policy/command-policy.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkCommandPolicy,
+  CommandPolicy,
+} from "../../src/policy";
+import {
+  DEFAULT_COMMAND_BLOCK_MESSAGE,
+} from "../../src/utils/constants";
+
+describe("checkCommandPolicy", () => {
+  describe("open mode (default)", () => {
+    it("should allow all commands when mode is open", () => {
+      const policy: CommandPolicy = { mode: "open" };
+      const result = checkCommandPolicy("/any-command", policy);
+      expect(result.isAllowed).toBe(true);
+    });
+
+    it("should allow all commands when policy is undefined", () => {
+      const result = checkCommandPolicy("/any-command", undefined);
+      expect(result.isAllowed).toBe(true);
+    });
+
+    it("should allow non-command messages", () => {
+      const policy: CommandPolicy = { mode: "open" };
+      const result = checkCommandPolicy("你好，世界", policy);
+      expect(result.isAllowed).toBe(true);
+    });
+  });
+
+  describe("allowlist mode", () => {
+    it("should allow commands in allowlist", () => {
+      const policy: CommandPolicy = {
+        mode: "allowlist",
+        allow: ["/new", "/reset", "/clear"],
+      };
+      const result = checkCommandPolicy("/new", policy);
+      expect(result.isAllowed).toBe(true);
+    });
+
+    it("should block commands not in allowlist", () => {
+      const policy: CommandPolicy = {
+        mode: "allowlist",
+        allow: ["/new", "/reset", "/clear"],
+      };
+      const result = checkCommandPolicy("/tools", policy);
+      expect(result.isAllowed).toBe(false);
+      expect(result.blockMessage).toBe(DEFAULT_COMMAND_BLOCK_MESSAGE);
+    });
+
+    it("should use custom blockMessage when provided", () => {
+      const customMessage = "自定义拦截消息";
+      const policy: CommandPolicy = {
+        mode: "allowlist",
+        allow: ["/new"],
+        blockMessage: customMessage,
+      };
+      const result = checkCommandPolicy("/tools", policy);
+      expect(result.isAllowed).toBe(false);
+      expect(result.blockMessage).toBe(customMessage);
+    });
+
+    it("should be case-insensitive for command comparison", () => {
+      const policy: CommandPolicy = {
+        mode: "allowlist",
+        allow: ["/NEW", "/Reset"],
+      };
+      expect(checkCommandPolicy("/new", policy).isAllowed).toBe(true);
+      expect(checkCommandPolicy("/RESET", policy).isAllowed).toBe(true);
+    });
+
+    it("should allow non-command messages even in allowlist mode", () => {
+      const policy: CommandPolicy = {
+        mode: "allowlist",
+        allow: ["/new"],
+      };
+      const result = checkCommandPolicy("普通消息", policy);
+      expect(result.isAllowed).toBe(true);
+    });
+
+    it("should handle empty allow list with default commands", () => {
+      const policy: CommandPolicy = {
+        mode: "allowlist",
+        allow: [],
+      };
+      // Should use default allowed commands
+      expect(checkCommandPolicy("/new", policy).isAllowed).toBe(true);
+      expect(checkCommandPolicy("/tools", policy).isAllowed).toBe(false);
+    });
+  });
+
+  describe("denylist mode", () => {
+    it("should block commands in denylist", () => {
+      const policy: CommandPolicy = {
+        mode: "denylist",
+        deny: ["/tools", "/admin"],
+      };
+      const result = checkCommandPolicy("/tools", policy);
+      expect(result.isAllowed).toBe(false);
+    });
+
+    it("should allow commands not in denylist", () => {
+      const policy: CommandPolicy = {
+        mode: "denylist",
+        deny: ["/tools", "/admin"],
+      };
+      const result = checkCommandPolicy("/new", policy);
+      expect(result.isAllowed).toBe(true);
+    });
+
+    it("should use custom blockMessage when provided", () => {
+      const customMessage = "该命令已被禁用";
+      const policy: CommandPolicy = {
+        mode: "denylist",
+        deny: ["/tools"],
+        blockMessage: customMessage,
+      };
+      const result = checkCommandPolicy("/tools", policy);
+      expect(result.isAllowed).toBe(false);
+      expect(result.blockMessage).toBe(customMessage);
+    });
+
+    it("should be case-insensitive for command comparison", () => {
+      const policy: CommandPolicy = {
+        mode: "denylist",
+        deny: ["/TOOLS"],
+      };
+      expect(checkCommandPolicy("/tools", policy).isAllowed).toBe(false);
+      expect(checkCommandPolicy("/Tools", policy).isAllowed).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty messages", () => {
+      const policy: CommandPolicy = { mode: "allowlist", allow: ["/new"] };
+      expect(checkCommandPolicy("", policy).isAllowed).toBe(true);
+      expect(checkCommandPolicy("   ", policy).isAllowed).toBe(true);
+    });
+
+    it("should handle messages with whitespace", () => {
+      const policy: CommandPolicy = {
+        mode: "allowlist",
+        allow: ["/new"],
+      };
+      expect(checkCommandPolicy("  /new  ", policy).isAllowed).toBe(true);
+      expect(checkCommandPolicy("  /tools  ", policy).isAllowed).toBe(false);
+    });
+
+    it("should only filter commands starting with /", () => {
+      const policy: CommandPolicy = {
+        mode: "allowlist",
+        allow: ["/new"],
+      };
+      // Messages not starting with / should be allowed
+      expect(checkCommandPolicy("new", policy).isAllowed).toBe(true);
+      expect(checkCommandPolicy("tools", policy).isAllowed).toBe(true);
+    });
+  });
+});
+
+// DM Command Policy specific tests
+describe("DM Command Policy Scenarios", () => {
+  it("should block /tools in DM when allowlist only allows /new", () => {
+    const dmCommandPolicy: CommandPolicy = {
+      mode: "allowlist",
+      allow: ["/new", "/reset", "/clear"],
+      blockMessage: "抱歉，我目前仅支持以下会话管理命令：\n/new、/reset、/clear\n如需其他帮助，请联系管理员。",
+    };
+
+    // Allowed commands
+    expect(checkCommandPolicy("/new", dmCommandPolicy).isAllowed).toBe(true);
+    expect(checkCommandPolicy("/reset", dmCommandPolicy).isAllowed).toBe(true);
+    expect(checkCommandPolicy("/clear", dmCommandPolicy).isAllowed).toBe(true);
+
+    // Blocked commands
+    const toolsResult = checkCommandPolicy("/tools", dmCommandPolicy);
+    expect(toolsResult.isAllowed).toBe(false);
+    expect(toolsResult.blockMessage).toBe(dmCommandPolicy.blockMessage);
+
+    const adminResult = checkCommandPolicy("/admin", dmCommandPolicy);
+    expect(adminResult.isAllowed).toBe(false);
+
+    // /stop is not supported (requires immediate termination semantics)
+    const stopResult = checkCommandPolicy("/stop", dmCommandPolicy);
+    expect(stopResult.isAllowed).toBe(false);
+  });
+
+  it("should allow normal messages in DM regardless of command policy", () => {
+    const dmCommandPolicy: CommandPolicy = {
+      mode: "allowlist",
+      allow: ["/new"],
+    };
+
+    // Normal messages should pass through
+    expect(checkCommandPolicy("你好", dmCommandPolicy).isAllowed).toBe(true);
+    expect(checkCommandPolicy("开场白", dmCommandPolicy).isAllowed).toBe(true);
+    expect(checkCommandPolicy("帮助", dmCommandPolicy).isAllowed).toBe(true);
+  });
+
+  it("should handle dmCommandAllowlist bypass scenario", () => {
+    // This test documents the expected behavior:
+    // When a user is in dmCommandAllowlist, command policy check should be skipped
+    // This is implemented in message-handler.ts, not in checkCommandPolicy itself
+    const dmCommandPolicy: CommandPolicy = {
+      mode: "allowlist",
+      allow: ["/new"],
+    };
+
+    // Without allowlist bypass, /tools should be blocked
+    const result = checkCommandPolicy("/tools", dmCommandPolicy);
+    expect(result.isAllowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概述

为 DingTalk Connector 插件新增**命令策略**功能，支持在单聊和群聊中灵活控制用户可使用的命令，增强机器人的安全性和可控性。

解决issue：https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/549
---

## 功能详情

### 1. 三种策略模式

| 模式 | 说明 | 适用场景 |
|------|------|----------|
| `open` | 允许所有命令（默认） | 无限制场景 |
| `allowlist` | 仅允许白名单中的命令 | 严格限制，只允许特定命令 |
| `denylist` | 禁止黑名单中的命令 | 宽松限制，只禁用特定命令 |

### 2. 配置项说明

#### 群聊命令策略 (`commandPolicy`)
```json
{
  "commandPolicy": {
    "mode": "allowlist",
    "allow": ["/new", "/reset", "/clear"],
    "deny": ["/tools", "/admin"],
    "blockMessage": "抱歉，该命令已被禁用。如需帮助，请联系管理员。"
  }
}
```

#### 单聊命令策略 (`dmCommandPolicy`)
```json
{
  "dmCommandPolicy": {
    "mode": "allowlist",
    "allow": ["/new", "/reset", "/clear"],
    "blockMessage": "抱歉，我目前仅支持以下会话管理命令：\n/new、/reset、/clear"
  }
}
```

#### 单聊命令白名单 (`dmCommandAllowlist`)
```json
{
  "dmCommandAllowlist": ["user123", "admin456"]
}
```
- 白名单中的用户**跳过命令策略检查**
- 适用于管理员或特权用户

### 3. 配置字段说明

| 字段 | 类型 | 必填 | 说明 |
|------|------|------|------|
| `mode` | string | 否 | 策略模式：`open`/`allowlist`/`denylist`，默认 `open` |
| `allow` | string[] | 否 | 允许列表（`allowlist` 模式生效） |
| `deny` | string[] | 否 | 禁止列表（`denylist` 模式生效） |
| `blockMessage` | string | 否 | 自定义拦截提示消息 |

---

## 使用场景

### 场景1：限制群聊只能使用会话管理命令

**OpenClaw 配置示例：**
```json
{
  "channels": {
    "dingtalk-connector": {
      ...
      "commandPolicy": {
        "mode": "allowlist",
        "allow": ["/new", "/reset", "/clear"],
        "blockMessage": "抱歉，本群仅支持 /new、/reset、/clear 命令，其他功能请联系管理员。"
      }
    }
  }
}
```

---

### 场景2：禁用特定危险命令

**OpenClaw 配置示例：**
```json
{
  "channels": {
    "dingtalk-connector": {
      ...
      "commandPolicy": {
        "mode": "denylist",
        "deny": ["/tools", "/admin", "/config"],
        "blockMessage": "抱歉，该命令已被管理员禁用。如需帮助，请联系管理员。"
      }
    }
  }
}
```

---

### 场景3：单聊严格限制 + 管理员白名单

**完整 OpenClaw 配置示例：**
```json
{
  "channels": {
    "dingtalk-connector": {
      ...
      "dmCommandPolicy": {
        "mode": "allowlist",
        "allow": ["/new", "/reset", "/clear"],
        "blockMessage": "抱歉，我目前仅支持以下会话管理命令：\n/new、/reset、/clear\n如需其他帮助，请联系管理员。"
      },
      "dmCommandAllowlist": ["1234567890", "0987654321"]
    }
  }
}
```

**说明：**
- `dmCommandAllowlist` 中的用户 ID 跳过 `dmCommandPolicy` 检查
- 适用于管理员或特权用户，让他们可以使用所有命令

---

---

## 技术实现

### 核心逻辑
- **仅过滤命令**：只检查以 `/` 开头的消息，普通消息直接放行
- **大小写不敏感**：命令匹配不区分大小写（`/NEW` 等同于 `/new`）
- **默认放行**：未配置策略或 `mode` 为 `open` 时，允许所有命令

### 拦截流程
1. 接收用户消息
2. 检查是否为命令（以 `/` 开头）
3. 根据策略模式验证命令
4. 如被拦截，发送拦截提示消息给用户
5. 终止后续处理

### 默认配置
```typescript
// 默认允许的命令
const DEFAULT_ALLOWED_COMMANDS = ['/new', '/reset', '/clear'];

// 默认拦截提示
const DEFAULT_COMMAND_BLOCK_MESSAGE = 
  '抱歉，我目前仅支持以下会话管理命令：\n/new、/reset、/clear\n如需其他帮助，请联系管理员。';
```

---

## 注意事项

1. **向后兼容**：未配置策略时默认 `open` 模式，不影响现有功能
2. **白名单优先**：`dmCommandAllowlist` 中的用户完全跳过策略检查
3. **仅拦截命令**：普通聊天消息不受策略影响
4. **拦截提示**：被拦截时会主动发送提示消息给用户