### PR TITLE
fix: 修复认证错误导致无限重启循环问题

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -29,4 +29,20 @@ export default function register(api: OpenClawPluginApi) {
   
   // 注册 Gateway Methods
   registerGatewayMethods(api);
+  
+  // 添加全局未处理 Promise Rejection 处理器，防止认证错误导致进程崩溃
+  process.on('unhandledRejection', (reason: any) => {
+    if (reason?.message?.includes('Authentication failed') || 
+        reason?.message?.includes('401') ||
+        reason?.message?.includes('Bad Request (400)')) {
+      console.error(
+        '[dingtalk-connector] ⚠️ 认证错误，避免无限重启循环。' +
+        '请检查配置后手动重启。'
+      );
+      // 不抛出，让进程继续运行
+      return;
+    }
+    // 其他未处理的 rejection 继续传播
+    console.error('[dingtalk-connector] Unhandled Promise Rejection:', reason);
+  });
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -513,6 +513,13 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingtalkAccount> = {
       } catch (err: any) {
         // 打印真实错误到 stderr，绕过框架 log 系统（框架的 runtime.log 可能未初始化）
         ctx.log?.error(`[dingtalk-connector][${ctx.accountId}] startAccount error: ${err?.message ?? err}\n${err?.stack ?? ''}`);
+        
+        // 检查是否为永久错误（如认证失败）
+        if ((err as any).isPermanent) {
+          ctx.log?.error(`[dingtalk-connector][${ctx.accountId}] Permanent error detected, keeping process running`);
+          return; // 永久错误不重新抛出，避免进程崩溃
+        }
+        
         throw err;
       }
     },

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -293,6 +293,15 @@ export async function monitorSingleAccount(
       logger.error(
         `重连失败：${err.message} (尝试 ${reconnectAttempts})`,
       );
+      
+      // 检测永久认证错误，停止重连
+      if (err.response?.status === 401 || err.response?.status === 400 ||
+          err.message?.includes("401") || err.message?.includes("400")) {
+        logger.error(`❌ 认证失败：凭据无效，停止重连。请检查 clientId 和 clientSecret。`);
+        isStopped = true;
+        return;
+      }
+      
       throw err;
     } finally {
       isReconnecting = false;
@@ -664,7 +673,7 @@ export async function monitorSingleAccount(
 
       // 处理 400 错误（请求参数错误）
       if (error.response?.status === 400 || error.message?.includes("status code 400") || error.message?.includes("400")) {
-        reject(new Error(
+        const badRequestError = new Error(
           `[DingTalk][${accountId}] Bad Request (400):\n` +
             `  - clientId or clientSecret format is invalid\n` +
             `  - clientId: ${clientIdStr} (type: ${typeof account.clientId}, length: ${clientIdStr.length})\n` +
@@ -676,19 +685,23 @@ export async function monitorSingleAccount(
             `    4. Check if clientId starts with 'ding' prefix\n` +
             `  - Error details: ${error.message}\n` +
             `  - Response data: ${JSON.stringify(error.response?.data || {})}`,
-        ));
+        );
+        (badRequestError as any).isPermanent = true;
+        reject(badRequestError);
         return;
       }
 
       // 处理 401 认证错误
       if (error.response?.status === 401 || error.message?.includes("401")) {
-        reject(new Error(
+        const authError = new Error(
           `[DingTalk][${accountId}] Authentication failed (401 Unauthorized):\n` +
             `  - Your clientId or clientSecret is invalid, expired, or revoked\n` +
             `  - clientId: ${clientIdStr.substring(0, 8)}...\n` +
             `  - Please verify your credentials at DingTalk Developer Console\n` +
             `  - Error details: ${error.message}`,
-        ));
+        );
+        (authError as any).isPermanent = true;
+        reject(authError);
         return;
       }
 

--- a/src/core/provider.ts
+++ b/src/core/provider.ts
@@ -92,14 +92,28 @@ export async function monitorDingtalkProvider(opts: MonitorDingtalkOpts = {}): P
     }
 
     monitorPromises.push(
-      monitorSingleAccount({
-        cfg,
-        account,
-        runtime: opts.runtime,
-        abortSignal: opts.abortSignal,
-        messageHandler: handleDingTalkMessage,
-        onStatusChange: opts.onStatusChange,
-      }),
+      (async () => {
+        try {
+          await monitorSingleAccount({
+            cfg,
+            account,
+            runtime: opts.runtime,
+            abortSignal: opts.abortSignal,
+            messageHandler: handleDingTalkMessage,
+            onStatusChange: opts.onStatusChange,
+          });
+        } catch (err: any) {
+          // 检查是否为永久错误（如认证失败）
+          if ((err as any).isPermanent) {
+            log?.error?.(
+              `[dingtalk-connector] Account ${account.accountId} stopped due to permanent error: ${err.message}`
+            );
+            return; // 跳过该账号，不阻止其他账号
+          }
+          // 非永久错误继续抛出
+          throw err;
+        }
+      })(),
     );
   }
 


### PR DESCRIPTION
- doReconnect() 函数添加 401/400 错误检测和停止逻辑
- 初始连接错误添加 isPermanent 标记
- provider.ts 捕获永久错误并跳过该账号
- channel.ts 检测永久错误避免进程崩溃
- index.ts 添加全局未处理 Promise Rejection 处理器 Fixes: 配置错误的钉钉账号导致 OpenClaw Gateway 无限重启