### PR TITLE
修复 #497：多 Agent 场景下，dws CLI 使用系统预制的 clientId 发消息，导致机器人串台混乱回复。fix: resolve multi-agent bot credential isolation and add --client-id…

### DIFF
--- a/skills/dws-cli/references/products/chat.md
+++ b/skills/dws-cli/references/products/chat.md
@@ -139,14 +139,17 @@ Flags:
 
 支持两种模式：群聊发送 和 批量单聊发送，通过 `--group` 和 `--users` 互斥区分。
 
+> ⚠️ **多机器人场景必须传 `--client-id`**：当配置了多个机器人账号时，必须通过 `--client-id` 显式指定使用哪个机器人的凭据发送消息。`--client-id` 的值就是当前对话机器人的 clientId（即 DingTalk AppKey），可从会话上下文的 `AccountId` 对应的配置中获取。**如果不传 `--client-id`，dws 会使用默认登录的机器人凭据，可能导致"串台"——用错误的机器人身份发送消息。**
+
 ### 群聊发送
 ```
 Usage:
   dws chat message send-by-bot [flags]
 Example:
-  dws chat message send-by-bot --robot-code <code> --group <openConversationId> \
+  dws chat message send-by-bot --client-id <clientId> --robot-code <code> --group <openConversationId> \
     --title "日报提醒" --text "请提交今日日报" --format json
 Flags:
+      --client-id string    机器人的 clientId / AppKey（多机器人场景必填，确保用正确的机器人身份发送）
       --robot-code string   机器人 code (必填)
       --group string        群会话 ID (必填，与 --users 互斥)
       --title string        消息标题 (必填)
@@ -158,9 +161,10 @@ Flags:
 Usage:
   dws chat message send-by-bot [flags]
 Example:
-  dws chat message send-by-bot --robot-code <code> --users "user1,user2" \
+  dws chat message send-by-bot --client-id <clientId> --robot-code <code> --users "user1,user2" \
     --title "通知" --text "会议已取消" --format json
 Flags:
+      --client-id string    机器人的 clientId / AppKey（多机器人场景必填，确保用正确的机器人身份发送）
       --robot-code string   机器人 code (必填)
       --users string        用户 ID 列表，逗号分隔，最多 20 个 (必填，与 --group 互斥)
       --title string        消息标题 (必填)
@@ -180,9 +184,10 @@ Flags:
 Usage:
   dws chat message recall-by-bot [flags]
 Example:
-  dws chat message recall-by-bot --robot-code <code> --group <openConversationId> \
+  dws chat message recall-by-bot --client-id <clientId> --robot-code <code> --group <openConversationId> \
     --keys "key1,key2" --format json
 Flags:
+      --client-id string    机器人的 clientId / AppKey（多机器人场景必填）
       --robot-code string   机器人 code (必填)
       --group string        群会话 ID (必填，与批量单聊互斥)
       --keys string         消息 key 列表，逗号分隔 (必填)
@@ -193,8 +198,9 @@ Flags:
 Usage:
   dws chat message recall-by-bot [flags]
 Example:
-  dws chat message recall-by-bot --robot-code <code> --keys "key1,key2" --format json
+  dws chat message recall-by-bot --client-id <clientId> --robot-code <code> --keys "key1,key2" --format json
 Flags:
+      --client-id string    机器人的 clientId / AppKey（多机器人场景必填）
       --robot-code string   机器人 code (必填)
       --keys string         消息 key 列表，逗号分隔 (必填)
 ```
@@ -263,8 +269,8 @@ dws chat group members add-bot --id <openConversationId> --robot-code <code> --f
 # 1. 搜索可用机器人
 dws chat bot search --format json
 
-# 2. 发送群消息
-dws chat message send-by-bot --robot-code <code> --group <groupId> \
+# 2. 发送群消息（多机器人场景必须加 --client-id，使用当前对话机器人的 clientId）
+dws chat message send-by-bot --client-id <clientId> --robot-code <code> --group <groupId> \
   --title "通知" --text "内容" --format json
 ```
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -44,25 +44,34 @@ export const CHANNEL_ID = "dingtalk-connector" as const;
 const _env = (globalThis as Record<string, unknown>)["proc" + "ess"] as NodeJS.Process;
 
 /**
- * Private holder for DWS credentials. Stored in module scope instead of
+ * Per-account holder for DWS credentials. Stored in module scope instead of
  * the global env so that child processes (e.g. Shell Executor) cannot read
  * the clientSecret via `env` / `printenv` commands.
+ *
+ * Keyed by accountId to avoid multi-account credential overwriting.
+ * Previously a single object — the last-started account would silently
+ * overwrite all earlier accounts, causing "agent cross-talk" (Issue #497).
  */
-const dwsCredentialHolder: { clientId: string; clientSecret: string } = {
-  clientId: "",
-  clientSecret: "",
-};
+const dwsCredentialsByAccount = new Map<string, { clientId: string; clientSecret: string }>();
 
 /**
  * Returns environment variables for spawning dws CLI.
  * Credentials are injected locally — they are NOT in process.env.
+ *
+ * @param accountId - The account whose credentials should be injected.
+ *   When omitted, falls back to the first (or only) stored entry for
+ *   backward compatibility with single-account setups.
  */
-export function getDwsSpawnEnv(): Record<string, string> {
+export function getDwsSpawnEnv(accountId?: string): Record<string, string> {
+  const creds = accountId
+    ? dwsCredentialsByAccount.get(accountId)
+    : dwsCredentialsByAccount.values().next().value;
+
   return {
     ..._env.env as Record<string, string>,
     DINGTALK_AGENT: "DING_DWS_CLAW",
-    ...(dwsCredentialHolder.clientId && { DWS_CLIENT_ID: dwsCredentialHolder.clientId }),
-    ...(dwsCredentialHolder.clientSecret && { DWS_CLIENT_SECRET: dwsCredentialHolder.clientSecret }),
+    ...(creds?.clientId && { DWS_CLIENT_ID: creds.clientId }),
+    ...(creds?.clientSecret && { DWS_CLIENT_SECRET: creds.clientSecret }),
   };
 }
 
@@ -474,15 +483,15 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingtalkAccount> = {
       }
 
       // Set DINGTALK_AGENT to identify the calling context (non-sensitive).
-      // DWS credentials are stored in a private module-level holder instead of
-      // the global env to prevent child processes (e.g. Shell Executor) from
-      // reading the clientSecret via `env` / `printenv` commands.
+      // DWS credentials are stored in a per-account Map instead of the global
+      // env to prevent child processes (e.g. Shell Executor) from reading the
+      // clientSecret via `env` / `printenv` commands.
       _env.env.DINGTALK_AGENT = "DING_DWS_CLAW";
-      if (account.clientId) {
-        dwsCredentialHolder.clientId = String(account.clientId);
-      }
-      if (account.clientSecret) {
-        dwsCredentialHolder.clientSecret = String(account.clientSecret);
+      if (account.clientId && account.clientSecret) {
+        dwsCredentialsByAccount.set(ctx.accountId, {
+          clientId: String(account.clientId),
+          clientSecret: String(account.clientSecret),
+        });
       }
 
       ctx.setStatus({ accountId: ctx.accountId, port: null });

--- a/src/gateway-methods.ts
+++ b/src/gateway-methods.ts
@@ -5,12 +5,33 @@
  */
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { resolveDingtalkAccount } from "./config/accounts.ts";
+import { resolveDingtalkAccount, listDingtalkAccountIds } from "./config/accounts.ts";
 import { DingtalkDocsClient } from "./docs.ts";
 import { sendProactive } from "./services/messaging.ts";
 import { getUnionId, recallEmotionReply } from "./utils/utils-legacy.ts";
 import { finishAICard } from "./services/messaging/card.ts";
 import type { AICardInstance } from "./services/messaging/card.ts";
+
+/**
+ * Warn when accountId is not explicitly provided and multiple accounts exist.
+ * Returns the resolved account (unchanged), but emits a log warning so that
+ * callers (typically AI agents) learn to pass accountId explicitly.
+ */
+function warnIfAccountIdMissing(
+  cfg: any,
+  accountId: unknown,
+  method: string,
+  log?: any,
+): void {
+  if (accountId) return;
+  const allIds = listDingtalkAccountIds(cfg);
+  if (allIds.length > 1) {
+    log?.warn?.(
+      `[Gateway][${method}] accountId not specified but ${allIds.length} accounts configured (${allIds.join(", ")}). ` +
+      `Falling back to default account. To use the correct bot, pass accountId explicitly.`,
+    );
+  }
+}
 
 /**
  * 注册所有 Gateway Methods
@@ -37,6 +58,7 @@ export function registerGatewayMethods(api: OpenClawPluginApi) {
     const cfg = loadConfig();
     try {
       const { userId, userIds, content, msgType, title, useAICard, fallbackToNormal, accountId } = params || {};
+      warnIfAccountIdMissing(cfg, accountId, 'sendToUser', log);
       const account = resolveDingtalkAccount({ cfg, accountId });
       if (!account.config?.clientId) {
         return respond(false, { error: 'DingTalk not configured' });
@@ -64,7 +86,7 @@ export function registerGatewayMethods(api: OpenClawPluginApi) {
         fallbackToNormal: fallbackToNormal !== false,
       });
 
-      respond(result.ok, result);
+      respond(result.ok, { ...result, usedAccountId: account.accountId });
     } catch (err: any) {
       log?.error?.(`[Gateway][sendToUser] 错误: ${err.message}`);
       respond(false, { error: err.message });
@@ -88,6 +110,7 @@ export function registerGatewayMethods(api: OpenClawPluginApi) {
     const cfg = loadConfig();
     try {
       const { openConversationId, content, msgType, title, useAICard, fallbackToNormal, accountId } = params || {};
+      warnIfAccountIdMissing(cfg, accountId, 'sendToGroup', log);
       const account = resolveDingtalkAccount({ cfg, accountId });
       if (!account.config?.clientId) {
         return respond(false, { error: 'DingTalk not configured' });
@@ -109,7 +132,7 @@ export function registerGatewayMethods(api: OpenClawPluginApi) {
         fallbackToNormal: fallbackToNormal !== false,
       });
 
-      respond(result.ok, result);
+      respond(result.ok, { ...result, usedAccountId: account.accountId });
     } catch (err: any) {
       log?.error?.(`[Gateway][sendToGroup] 错误: ${err.message}`);
       console.error(err);
@@ -123,8 +146,9 @@ export function registerGatewayMethods(api: OpenClawPluginApi) {
     try {
       const { target, content, message, msgType, title, useAICard, fallbackToNormal, accountId } = params || {};
       const actualContent = content || message;
+      warnIfAccountIdMissing(cfg, accountId, 'send', log);
       const account = resolveDingtalkAccount({ cfg, accountId });
-      log?.info?.(`[Gateway][send] 收到请求: target=${target}, contentLen=${actualContent?.length}`);
+      log?.info?.(`[Gateway][send] 收到请求: target=${target}, contentLen=${typeof actualContent === 'string' ? actualContent.length : 0}, accountId=${account.accountId}`);
 
       if (!account.config?.clientId) {
         return respond(false, { error: 'DingTalk not configured' });


### PR DESCRIPTION
… to dws CLI skill

- Change dwsCredentialHolder singleton to per-account Map (dwsCredentialsByAccount)
- getDwsSpawnEnv() now accepts accountId to return correct bot credentials
- Add warnIfAccountIdMissing() in gateway-methods for multi-account scenarios
- Add --client-id parameter guidance in dws-cli skill for send-by-bot and recall-by-bot

Fixes #497 to # to #