### PR TITLE
feat: 西游妖魔榜养成系统 v2 — 完整实现降妖机制、图鉴收集、悬赏令、随机事件、bot凭证隔离

### DIFF
--- a/skills/dingtalk-channel-rules/SKILL.md
+++ b/skills/dingtalk-channel-rules/SKILL.md
@@ -58,6 +58,26 @@ alwaysActive: true
 | 文件、云盘、上传、下载 | `dws drive` | 上传/下载文件到钉钉云盘 |
 | DING、紧急消息、强提醒 | `dws ding` | 向用户/群发送强提醒 DING |
 
+### 🔑 多机器人场景：bot 凭证隔离（重要）
+
+当配置了多个钉钉机器人时，必须确保 dws 命令使用**当前对话机器人**的凭据，避免"串台"（用错误的机器人身份操作）。
+
+**当前 bot 的 clientId 获取方式：**
+
+每条用户消息的上下文中会自动包含 `[DingTalk Bot Context]` 标记，其中含有当前对话 bot 的 `clientId`。在执行 `dws chat message send-by-bot` 命令时，**必须从该上下文中提取 clientId 并传给 `--client-id` 参数**。
+
+**示例：**
+```
+用户消息上下文中包含:
+[DingTalk Bot Context] Current bot clientId: dingXXXXXXXX. ...
+
+执行命令时注入:
+dws chat message send-by-bot --client-id dingXXXXXXXX --robot-code <code> --users "userId" \
+  --title "通知" --text "消息内容" --format json
+```
+
+> ⚠️ **如果不传 `--client-id`，dws 会使用默认登录的机器人凭据，可能导致消息从错误的机器人发出。** 每次执行 `dws chat` 相关命令时都必须从上下文中获取并传入 `--client-id`。
+
 ### 易混淆场景速查
 
 | 场景 | 正确选择 | 错误选择 |

--- a/skills/dws-cli/references/products/chat.md
+++ b/skills/dws-cli/references/products/chat.md
@@ -139,14 +139,17 @@ Flags:
 
 支持两种模式：群聊发送 和 批量单聊发送，通过 `--group` 和 `--users` 互斥区分。
 
+> ⚠️ **多机器人场景必须传 `--client-id`**：当配置了多个机器人账号时，必须通过 `--client-id` 显式指定使用哪个机器人的凭据发送消息。`--client-id` 的值就是当前对话机器人的 clientId（即 DingTalk AppKey），可从会话上下文的 `AccountId` 对应的配置中获取。**如果不传 `--client-id`，dws 会使用默认登录的机器人凭据，可能导致"串台"——用错误的机器人身份发送消息。**
+
 ### 群聊发送
 ```
 Usage:
   dws chat message send-by-bot [flags]
 Example:
-  dws chat message send-by-bot --robot-code <code> --group <openConversationId> \
+  dws chat message send-by-bot --client-id <clientId> --robot-code <code> --group <openConversationId> \
     --title "日报提醒" --text "请提交今日日报" --format json
 Flags:
+      --client-id string    机器人的 clientId / AppKey（多机器人场景必填，确保用正确的机器人身份发送）
       --robot-code string   机器人 code (必填)
       --group string        群会话 ID (必填，与 --users 互斥)
       --title string        消息标题 (必填)
@@ -158,9 +161,10 @@ Flags:
 Usage:
   dws chat message send-by-bot [flags]
 Example:
-  dws chat message send-by-bot --robot-code <code> --users "user1,user2" \
+  dws chat message send-by-bot --client-id <clientId> --robot-code <code> --users "user1,user2" \
     --title "通知" --text "会议已取消" --format json
 Flags:
+      --client-id string    机器人的 clientId / AppKey（多机器人场景必填，确保用正确的机器人身份发送）
       --robot-code string   机器人 code (必填)
       --users string        用户 ID 列表，逗号分隔，最多 20 个 (必填，与 --group 互斥)
       --title string        消息标题 (必填)
@@ -180,9 +184,10 @@ Flags:
 Usage:
   dws chat message recall-by-bot [flags]
 Example:
-  dws chat message recall-by-bot --robot-code <code> --group <openConversationId> \
+  dws chat message recall-by-bot --client-id <clientId> --robot-code <code> --group <openConversationId> \
     --keys "key1,key2" --format json
 Flags:
+      --client-id string    机器人的 clientId / AppKey（多机器人场景必填）
       --robot-code string   机器人 code (必填)
       --group string        群会话 ID (必填，与批量单聊互斥)
       --keys string         消息 key 列表，逗号分隔 (必填)
@@ -193,8 +198,9 @@ Flags:
 Usage:
   dws chat message recall-by-bot [flags]
 Example:
-  dws chat message recall-by-bot --robot-code <code> --keys "key1,key2" --format json
+  dws chat message recall-by-bot --client-id <clientId> --robot-code <code> --keys "key1,key2" --format json
 Flags:
+      --client-id string    机器人的 clientId / AppKey（多机器人场景必填）
       --robot-code string   机器人 code (必填)
       --keys string         消息 key 列表，逗号分隔 (必填)
 ```
@@ -263,8 +269,8 @@ dws chat group members add-bot --id <openConversationId> --robot-code <code> --f
 # 1. 搜索可用机器人
 dws chat bot search --format json
 
-# 2. 发送群消息
-dws chat message send-by-bot --robot-code <code> --group <groupId> \
+# 2. 发送群消息（多机器人场景必须加 --client-id，使用当前对话机器人的 clientId）
+dws chat message send-by-bot --client-id <clientId> --robot-code <code> --group <groupId> \
   --title "通知" --text "内容" --format json
 ```
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -44,25 +44,34 @@ export const CHANNEL_ID = "dingtalk-connector" as const;
 const _env = (globalThis as Record<string, unknown>)["proc" + "ess"] as NodeJS.Process;
 
 /**
- * Private holder for DWS credentials. Stored in module scope instead of
+ * Per-account holder for DWS credentials. Stored in module scope instead of
  * the global env so that child processes (e.g. Shell Executor) cannot read
  * the clientSecret via `env` / `printenv` commands.
+ *
+ * Keyed by accountId to avoid multi-account credential overwriting.
+ * Previously a single object — the last-started account would silently
+ * overwrite all earlier accounts, causing "agent cross-talk" (Issue #497).
  */
-const dwsCredentialHolder: { clientId: string; clientSecret: string } = {
-  clientId: "",
-  clientSecret: "",
-};
+const dwsCredentialsByAccount = new Map<string, { clientId: string; clientSecret: string }>();
 
 /**
  * Returns environment variables for spawning dws CLI.
  * Credentials are injected locally — they are NOT in process.env.
+ *
+ * @param accountId - The account whose credentials should be injected.
+ *   When omitted, falls back to the first (or only) stored entry for
+ *   backward compatibility with single-account setups.
  */
-export function getDwsSpawnEnv(): Record<string, string> {
+export function getDwsSpawnEnv(accountId?: string): Record<string, string> {
+  const creds = accountId
+    ? dwsCredentialsByAccount.get(accountId)
+    : dwsCredentialsByAccount.values().next().value;
+
   return {
     ..._env.env as Record<string, string>,
     DINGTALK_AGENT: "DING_DWS_CLAW",
-    ...(dwsCredentialHolder.clientId && { DWS_CLIENT_ID: dwsCredentialHolder.clientId }),
-    ...(dwsCredentialHolder.clientSecret && { DWS_CLIENT_SECRET: dwsCredentialHolder.clientSecret }),
+    ...(creds?.clientId && { DWS_CLIENT_ID: creds.clientId }),
+    ...(creds?.clientSecret && { DWS_CLIENT_SECRET: creds.clientSecret }),
   };
 }
 
@@ -474,15 +483,21 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingtalkAccount> = {
       }
 
       // Set DINGTALK_AGENT to identify the calling context (non-sensitive).
-      // DWS credentials are stored in a private module-level holder instead of
-      // the global env to prevent child processes (e.g. Shell Executor) from
-      // reading the clientSecret via `env` / `printenv` commands.
+      // DWS credentials are stored in a per-account Map instead of the global
+      // env to prevent child processes (e.g. Shell Executor) from reading the
+      // clientSecret via `env` / `printenv` commands.
       _env.env.DINGTALK_AGENT = "DING_DWS_CLAW";
-      if (account.clientId) {
-        dwsCredentialHolder.clientId = String(account.clientId);
-      }
-      if (account.clientSecret) {
-        dwsCredentialHolder.clientSecret = String(account.clientSecret);
+      if (account.clientId && account.clientSecret) {
+        dwsCredentialsByAccount.set(ctx.accountId, {
+          clientId: String(account.clientId),
+          clientSecret: String(account.clientSecret),
+        });
+        // Expose clientId (non-sensitive) in process.env so that AI agents
+        // can read it via `echo $DWS_CLIENT_ID` and inject `--client-id`
+        // into dws CLI commands for correct bot identity isolation.
+        // Note: in multi-bot setups the last-started bot's clientId wins,
+        // but the skill prompt instructs the AI to always read & pass it.
+        _env.env.DWS_CLIENT_ID = String(account.clientId);
       }
 
       ctx.setStatus({ accountId: ctx.accountId, port: null });

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -1165,6 +1165,30 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
   const normalizedText = normalizeSlashCommand(rawText);
   let userContent = normalizedText || (content.imageUrls.length > 0 ? '请描述这张图片' : '');
 
+  // ===== 养成系统命令拦截 =====
+  try {
+    const { GamificationEngine, isGamificationCommand } = await import('../game-xiyou/index.ts');
+    if (isGamificationCommand(rawText)) {
+      const engine = GamificationEngine.getInstanceForUser(senderId);
+      // /西游 命令始终可用（用于开关切换），其他命令需要 enabled
+      const isToggleCommand = rawText.trim().startsWith('/西游');
+      if (isToggleCommand || engine.isEnabled()) {
+        const response = engine.handleCommand(rawText);
+        if (response) {
+          log?.info?.(`[DingTalk][Gamification] 处理养成系统命令: ${rawText.slice(0, 20)}`);
+          await sendProactive(config, isDirect ? { userId: senderId } : { openConversationId: data.conversationId }, response, {
+            useAICard: true,
+            fallbackToNormal: true,
+            log,
+          });
+          return;
+        }
+      }
+    }
+  } catch (gamErr: any) {
+    log?.warn?.(`[DingTalk][Gamification] 命令处理失败: ${gamErr?.message || gamErr}`);
+  }
+
   // ===== 图片下载到本地文件 =====
   const imageLocalPaths: string[] = [];
   
@@ -1447,6 +1471,16 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
       asyncMode,
       preCreatedCard: params.preCreatedCard,
     });
+
+    // ===== 注入当前 bot 的 clientId（用于 dws CLI --client-id 参数） =====
+    // 多 bot 场景下，AI 需要知道当前对话属于哪个 bot，以便在调用
+    // dws chat message send-by-bot 时传入正确的 --client-id，避免消息串台。
+    if (config.clientId) {
+      const botIdentityHint = `[DingTalk Bot Context] Current bot clientId: ${String(config.clientId)}. When executing \`dws chat message send-by-bot\`, always pass \`--client-id ${String(config.clientId)}\` to ensure messages are sent from the correct bot.`;
+      finalContent = finalContent
+        ? `${finalContent}\n\n${botIdentityHint}`
+        : botIdentityHint;
+    }
 
     // ===== 构建卡片链接路由指令（对齐 Rust agent_support.rs build_link_routing_prompt）=====
     // 识别 interactiveCard / actionCard 消息中的 URL，根据 host 注入不同的 AI 指令：

--- a/src/device-auth-config.ts
+++ b/src/device-auth-config.ts
@@ -1,9 +1,4 @@
 /**
- * Configuration helpers for DingTalk device registration.
- *
- * Separated from device-auth.ts to isolate environment variable access
- * from network modules, avoiding security scanner "env + network" patterns.
- *
  * Uses indirect reference to avoid security scanner false positive:
  * the scanner flags env access + network-send in the same bundled file
  * as "credential harvesting".

--- a/src/game-xiyou/achievement-engine.ts
+++ b/src/game-xiyou/achievement-engine.ts
@@ -1,0 +1,252 @@
+/**
+ * 成就判定引擎
+ *
+ * 每次操作后检查是否解锁新成就。
+ * 成就分为：修行成就、收集成就、产品成就、隐藏成就。
+ */
+
+import type { Achievement, AchievementCondition, UserProfile, UserCollection, HistoryRecord } from './types.ts';
+import { PRODUCT_BASE_EXP } from './types.ts';
+
+/**
+ * 成就数据（内联）
+ */
+const allAchievements: Achievement[] = [
+  // 修行成就
+  { id: "A001", name: "初出茅庐", emoji: "🐒", description: "首次成功调用 dws CLI", category: "cultivation", condition: { type: "totalOperations", count: 1 }, expReward: 10 },
+  { id: "A002", name: "三天打鱼", emoji: "🔥", description: "连续 3 天签到", category: "cultivation", condition: { type: "consecutiveSignIn", days: 3 }, expReward: 15 },
+  { id: "A003", name: "七七四十九", emoji: "📅", description: "连续 49 天签到", category: "cultivation", condition: { type: "consecutiveSignIn", days: 49 }, expReward: 200 },
+  { id: "A004", name: "十连斩", emoji: "⚡", description: "单次连击达到 10 次", category: "cultivation", condition: { type: "maxCombo", count: 10 }, expReward: 50 },
+  { id: "A005", name: "五行山下", emoji: "🏔️", description: "累计 500 次成功调用", category: "cultivation", condition: { type: "totalOperations", count: 500 }, expReward: 100 },
+  { id: "A006", name: "八十一难", emoji: "🌋", description: "累计 81 次 recovery 成功", category: "cultivation", condition: { type: "totalRecoveries", count: 81 }, expReward: 300 },
+  // 收集成就
+  { id: "A101", name: "妖怪猎人", emoji: "📖", description: "收服 10 种不同妖怪", category: "collection", condition: { type: "uniqueMonsters", count: 10 }, expReward: 30 },
+  { id: "A102", name: "半部西游", emoji: "📚", description: "收服 24 种不同妖怪", category: "collection", condition: { type: "uniqueMonsters", count: 24 }, expReward: 100 },
+  { id: "A103", name: "妖魔全书", emoji: "📜", description: "收服全部 48 种妖怪", category: "collection", condition: { type: "uniqueMonsters", count: 48 }, expReward: 500, titleReward: "妖魔克星" },
+  { id: "A104", name: "闪光猎人", emoji: "✨", description: "收服 1 只闪光妖怪", category: "collection", condition: { type: "shinyMonsters", count: 1 }, expReward: 200 },
+  { id: "A105", name: "闪光大师", emoji: "🌈", description: "收服 5 只闪光妖怪", category: "collection", condition: { type: "shinyMonsters", count: 5 }, expReward: 500, titleReward: "欧皇" },
+  { id: "A106", name: "全闪通关", emoji: "👑", description: "收服 10 只闪光妖怪", category: "collection", condition: { type: "shinyMonsters", count: 10 }, expReward: 1000, titleReward: "天选之人" },
+  // 产品成就
+  { id: "A201", name: "表格大师", emoji: "📊", description: "aitable 相关命令成功 50 次", category: "product", condition: { type: "productUsage", product: "aitable", count: 50 }, expReward: 30 },
+  { id: "A202", name: "时间管理者", emoji: "📅", description: "calendar 相关命令成功 50 次", category: "product", condition: { type: "productUsage", product: "calendar", count: 50 }, expReward: 30 },
+  { id: "A203", name: "群聊达人", emoji: "💬", description: "chat 相关命令成功 50 次", category: "product", condition: { type: "productUsage", product: "chat", count: 50 }, expReward: 30 },
+  { id: "A204", name: "待办终结者", emoji: "✅", description: "todo 相关命令成功 50 次", category: "product", condition: { type: "productUsage", product: "todo", count: 50 }, expReward: 30 },
+  { id: "A205", name: "日报之王", emoji: "📝", description: "report 连续 30 天提交", category: "product", condition: { type: "consecutiveReport", days: 30 }, expReward: 100 },
+  { id: "A206", name: "全能战士", emoji: "🎯", description: "使用过所有 11 个产品", category: "product", condition: { type: "allProducts" }, expReward: 200 },
+  // 隐藏成就
+  { id: "A301", name: "夜猫子", emoji: "🌙", description: "凌晨 2:00-5:00 成功调用", category: "hidden", condition: { type: "nightOwl" }, expReward: 20 },
+  { id: "A302", name: "非酋翻身", emoji: "🎰", description: "触发天命保底（150 次未出传说）", category: "hidden", condition: { type: "pityTriggered" }, expReward: 100, titleReward: "大器晚成" },
+  { id: "A303", name: "屡败屡战", emoji: "💀", description: "连续 10 次失败后第 11 次成功", category: "hidden", condition: { type: "consecutiveFailThenSuccess", failCount: 10 }, expReward: 50 },
+  { id: "A304", name: "屠龙勇士", emoji: "🐉", description: "单日收服 3 只稀有及以上妖怪", category: "hidden", condition: { type: "dailyRareOrAbove", count: 3 }, expReward: 100 },
+  { id: "A305", name: "生日快乐", emoji: "🎂", description: "在账号注册日当天使用", category: "hidden", condition: { type: "birthday" }, expReward: 50 },
+  // v2: 逃跑相关成就
+  { id: "A401", name: "逃跑大师", emoji: "💨", description: "累计被妖怪逃跑 50 次", category: "hidden", condition: { type: "totalEscapes", count: 50 }, expReward: 30 },
+  { id: "A402", name: "一网打尽", emoji: "🪤", description: "连续 10 次掉落无妖怪逃跑", category: "hidden", condition: { type: "consecutiveNoEscape", count: 10 }, expReward: 50 },
+  // v2: 悬赏令相关成就
+  { id: "A403", name: "赏金猎人", emoji: "📜", description: "累计完成 30 张悬赏令", category: "hidden", condition: { type: "totalBountiesCompleted", count: 30 }, expReward: 100, titleReward: "赏金猎人" },
+  { id: "A404", name: "金牌猎人", emoji: "🥇", description: "累计完成 10 张金令", category: "hidden", condition: { type: "goldBountiesCompleted", count: 10 }, expReward: 150 },
+  { id: "A405", name: "全勤猎人", emoji: "📅", description: "连续 7 天每日完成全部 3 张悬赏令", category: "hidden", condition: { type: "consecutiveFullClear", days: 7 }, expReward: 200 },
+  // v2: 随机事件相关成就
+  { id: "A406", name: "见多识广", emoji: "🎪", description: "累计触发 10 次随机事件", category: "hidden", condition: { type: "totalEventsTriggered", count: 10 }, expReward: 30 },
+  { id: "A407", name: "百战百胜", emoji: "⚔️", description: "累计完成 10 次挑战事件", category: "hidden", condition: { type: "challengesCompleted", count: 10 }, expReward: 100, titleReward: "战神" },
+  { id: "A408", name: "劫后余生", emoji: "😈", description: "触发「走火入魔」后存活（修行值未归零）", category: "hidden", condition: { type: "survivedMadness" }, expReward: 50, titleReward: "大难不死" },
+  { id: "A409", name: "蟠桃常客", emoji: "🍑", description: "累计触发 3 次「蟠桃大会」", category: "hidden", condition: { type: "specificEventCount", eventId: "EV001", count: 3 }, expReward: 80 },
+  { id: "A410", name: "火焰山主", emoji: "🔥", description: "累计完成 3 次「火焰山」挑战", category: "hidden", condition: { type: "specificEventCount", eventId: "EV102", count: 3 }, expReward: 60 },
+  { id: "A411", name: "真假悟空", emoji: "🐒", description: "在「真假美猴王」事件中选对", category: "hidden", condition: { type: "specificChallengeSuccess", eventId: "EV104" }, expReward: 100, titleReward: "火眼金睛" },
+  { id: "A412", name: "否极泰来", emoji: "🌈", description: "灾厄事件结束后立即触发增益事件", category: "hidden", condition: { type: "disasterThenBlessing" }, expReward: 200 },
+  { id: "A413", name: "化险为夷", emoji: "🛡️", description: "累计 5 次通过化解方式提前解除灾厄", category: "hidden", condition: { type: "disastersResolved", count: 5 }, expReward: 80 },
+];
+
+/**
+ * 获取所有成就
+ */
+export function getAllAchievements(): Achievement[] {
+  return allAchievements;
+}
+
+/**
+ * 根据 ID 查找成就
+ */
+export function getAchievementById(achievementId: string): Achievement | undefined {
+  return allAchievements.find(a => a.id === achievementId);
+}
+
+/**
+ * 检查单个成就条件是否满足
+ */
+function isConditionMet(
+  condition: AchievementCondition,
+  profile: UserProfile,
+  collection: UserCollection,
+  todayRecords: HistoryRecord[]
+): boolean {
+  switch (condition.type) {
+    case 'totalOperations':
+      return profile.totalOperations >= condition.count;
+
+    case 'consecutiveSignIn':
+      return profile.consecutiveSignInDays >= condition.days;
+
+    case 'maxCombo':
+      return profile.maxCombo >= condition.count;
+
+    case 'totalRecoveries':
+      return profile.totalRecoveries >= condition.count;
+
+    case 'uniqueMonsters': {
+      const uniqueNonShiny = collection.entries.filter(e => !e.isShiny).length;
+      return uniqueNonShiny >= condition.count;
+    }
+
+    case 'shinyMonsters': {
+      const shinyCount = collection.entries.filter(e => e.isShiny).length;
+      return shinyCount >= condition.count;
+    }
+
+    case 'productUsage': {
+      const usage = profile.productUsage[condition.product] ?? 0;
+      return usage >= condition.count;
+    }
+
+    case 'allProducts': {
+      const allProducts = Object.keys(PRODUCT_BASE_EXP);
+      return allProducts.every(p => (profile.productUsage[p] ?? 0) > 0);
+    }
+
+    case 'dailyOperations': {
+      return todayRecords.filter(r => r.success).length >= condition.count;
+    }
+
+    case 'nightOwl': {
+      const hour = new Date().getHours();
+      return hour >= 2 && hour < 5;
+    }
+
+    case 'pityTriggered':
+      // 由掉落引擎在触发天命保底时标记
+      return false;
+
+    case 'consecutiveFailThenSuccess':
+      return profile.consecutiveFailures >= condition.failCount;
+
+    case 'dailyRareOrAbove': {
+      const rareOrAboveToday = todayRecords.filter(r => {
+        if (!r.monsterId) return false;
+        // 简化判断：monsterId 以 S/E/L 开头的是稀有及以上
+        return r.monsterId.startsWith('S') || r.monsterId.startsWith('E') || r.monsterId.startsWith('L');
+      });
+      return rareOrAboveToday.length >= condition.count;
+    }
+
+    case 'birthday': {
+      const createdDate = new Date(profile.createdAt);
+      const now = new Date();
+      return (
+        createdDate.getMonth() === now.getMonth() &&
+        createdDate.getDate() === now.getDate() &&
+        now.getFullYear() > createdDate.getFullYear()
+      );
+    }
+
+    case 'consecutiveReport': {
+      const reportUsage = profile.productUsage['report'] ?? 0;
+      return reportUsage >= condition.days;
+    }
+
+    // v2: 逃跑相关
+    case 'totalEscapes':
+      return profile.totalEscapes >= condition.count;
+
+    case 'consecutiveNoEscape':
+      // 由主引擎在连续无逃跑时通过 triggerSpecialAchievement 触发
+      return false;
+
+    // v2: 悬赏令相关
+    case 'totalBountiesCompleted':
+      return profile.bountyHistory.totalCompleted >= condition.count;
+
+    case 'goldBountiesCompleted':
+      return profile.bountyHistory.goldCompleted >= condition.count;
+
+    case 'consecutiveFullClear':
+      return profile.bountyHistory.consecutiveFullClear >= condition.days;
+
+    // v2: 随机事件相关
+    case 'totalEventsTriggered':
+      return profile.eventStats.totalTriggered >= condition.count;
+
+    case 'challengesCompleted':
+      return profile.eventStats.challengesCompleted >= condition.count;
+
+    case 'survivedMadness': {
+      // 触发过"走火入魔"且修行值 > 0
+      const hadMadness = profile.eventHistory.some(e => e.eventId === 'EV206');
+      return hadMadness && profile.totalExp > 0;
+    }
+
+    case 'specificEventCount': {
+      const eventCount = profile.eventHistory.filter(e => e.eventId === condition.eventId).length;
+      return eventCount >= condition.count;
+    }
+
+    case 'specificChallengeSuccess': {
+      return profile.eventHistory.some(
+        e => e.eventId === condition.eventId && e.outcome === 'success'
+      );
+    }
+
+    case 'disasterThenBlessing':
+      // 由主引擎在灾厄结束后立即触发增益时通过 triggerSpecialAchievement 触发
+      return false;
+
+    case 'disastersResolved':
+      return profile.eventStats.disastersResolved >= condition.count;
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * 检查所有未解锁的成就，返回新解锁的成就列表
+ */
+export function checkAchievements(
+  profile: UserProfile,
+  collection: UserCollection,
+  todayRecords: HistoryRecord[]
+): Achievement[] {
+  const newlyUnlocked: Achievement[] = [];
+
+  for (const achievement of allAchievements) {
+    // 跳过已解锁的
+    if (profile.unlockedAchievements.includes(achievement.id)) {
+      continue;
+    }
+
+    // 检查条件
+    if (isConditionMet(achievement.condition, profile, collection, todayRecords)) {
+      newlyUnlocked.push(achievement);
+      profile.unlockedAchievements.push(achievement.id);
+    }
+  }
+
+  return newlyUnlocked;
+}
+
+/**
+ * 手动触发特殊成就（如保底触发）
+ */
+export function triggerSpecialAchievement(
+  profile: UserProfile,
+  achievementId: string
+): Achievement | null {
+  if (profile.unlockedAchievements.includes(achievementId)) {
+    return null;
+  }
+
+  const achievement = getAchievementById(achievementId);
+  if (!achievement) return null;
+
+  profile.unlockedAchievements.push(achievementId);
+  return achievement;
+}

--- a/src/game-xiyou/bounty-system.ts
+++ b/src/game-xiyou/bounty-system.ts
@@ -1,0 +1,315 @@
+/**
+ * 悬赏令系统 (v2)
+ *
+ * 每日刷新 3 张悬赏令（铜/银/金），为日常使用增加目标感和方向性。
+ * 使用基于 UID + 日期的种子随机，确保同一用户同一天结果一致。
+ */
+
+import { createHash } from 'crypto';
+import type {
+  Bounty, BountyTier, BountyCondition, BountyReward,
+  DailyBountyState, BountyHistory, UserProfile, MonsterQuality,
+  DropResult,
+} from './types.ts';
+
+// ============ 悬赏令模板池 ============
+
+interface BountyTemplate {
+  id: string;
+  tier: BountyTier;
+  descriptionTemplate: string;
+  reward: BountyReward;
+  condition: BountyCondition;
+  hasProductPlaceholder?: boolean;
+}
+
+const BRONZE_POOL: BountyTemplate[] = [
+  { id: 'B001', tier: 'bronze', descriptionTemplate: '成功执行 3 次任意 dws 命令', reward: { exp: 15 }, condition: { type: 'command', count: 3 } },
+  { id: 'B002', tier: 'bronze', descriptionTemplate: '使用 {product} 成功执行 1 次命令', reward: { exp: 10 }, condition: { type: 'command', count: 1 }, hasProductPlaceholder: true },
+  { id: 'B003', tier: 'bronze', descriptionTemplate: '收服 1 只任意妖怪', reward: { exp: 10 }, condition: { type: 'capture', count: 1 } },
+  { id: 'B004', tier: 'bronze', descriptionTemplate: '达成 3 连击', reward: { exp: 20 }, condition: { type: 'combo', count: 3 } },
+  { id: 'B005', tier: 'bronze', descriptionTemplate: '使用 2 种不同产品的命令', reward: { exp: 15 }, condition: { type: 'product_variety', count: 2 } },
+  { id: 'B006', tier: 'bronze', descriptionTemplate: '收服 1 只精良及以上妖怪', reward: { exp: 20 }, condition: { type: 'capture', qualityMin: 'fine', count: 1 } },
+  { id: 'B007', tier: 'bronze', descriptionTemplate: '成功执行 5 次任意 dws 命令', reward: { exp: 25 }, condition: { type: 'command', count: 5 } },
+  { id: 'B008', tier: 'bronze', descriptionTemplate: '收服 2 只任意妖怪（不含逃跑）', reward: { exp: 20 }, condition: { type: 'capture', count: 2 } },
+];
+
+const SILVER_POOL: BountyTemplate[] = [
+  { id: 'B101', tier: 'silver', descriptionTemplate: '收服 1 只稀有及以上妖怪', reward: { exp: 50 }, condition: { type: 'capture', qualityMin: 'rare', count: 1 } },
+  { id: 'B102', tier: 'silver', descriptionTemplate: '达成 5 连击', reward: { exp: 40 }, condition: { type: 'combo', count: 5 } },
+  { id: 'B103', tier: 'silver', descriptionTemplate: '使用 3 种不同产品的命令', reward: { exp: 35 }, condition: { type: 'product_variety', count: 3 } },
+  { id: 'B104', tier: 'silver', descriptionTemplate: '收服 1 只与 {product} 关联的妖怪', reward: { exp: 30 }, condition: { type: 'capture', count: 1 }, hasProductPlaceholder: true },
+  { id: 'B105', tier: 'silver', descriptionTemplate: '成功执行 10 次任意 dws 命令', reward: { exp: 50 }, condition: { type: 'command', count: 10 } },
+  { id: 'B106', tier: 'silver', descriptionTemplate: '收服 3 只不同品质的妖怪', reward: { exp: 45 }, condition: { type: 'quality_variety', count: 3 } },
+  { id: 'B107', tier: 'silver', descriptionTemplate: '触发 1 次神仙机缘', reward: { exp: 40 }, condition: { type: 'encounter', count: 1 } },
+  { id: 'B108', tier: 'silver', descriptionTemplate: '收服 1 只图鉴中未拥有的新妖怪', reward: { exp: 60 }, condition: { type: 'capture', count: 1, isNew: true } },
+];
+
+const GOLD_POOL: BountyTemplate[] = [
+  { id: 'B201', tier: 'gold', descriptionTemplate: '收服 1 只史诗及以上妖怪', reward: { exp: 100, treasureFragment: 'random' }, condition: { type: 'capture', qualityMin: 'epic', count: 1 } },
+  { id: 'B202', tier: 'gold', descriptionTemplate: '达成 10 连击', reward: { exp: 80 }, condition: { type: 'combo', count: 10 } },
+  { id: 'B203', tier: 'gold', descriptionTemplate: '使用 5 种不同产品的命令', reward: { exp: 70 }, condition: { type: 'product_variety', count: 5 } },
+  { id: 'B204', tier: 'gold', descriptionTemplate: '单日收服 5 只不同妖怪', reward: { exp: 100 }, condition: { type: 'capture', count: 5 } },
+  { id: 'B205', tier: 'gold', descriptionTemplate: '收服本周 UP 妖怪', reward: { exp: 120 }, condition: { type: 'capture', count: 1, isUpMonster: true } },
+  { id: 'B206', tier: 'gold', descriptionTemplate: '触发 1 次赐宝机缘', reward: { exp: 80 }, condition: { type: 'encounter', count: 1 } },
+  { id: 'B207', tier: 'gold', descriptionTemplate: '连续成功 15 次不中断', reward: { exp: 100 }, condition: { type: 'combo', count: 15 } },
+  { id: 'B208', tier: 'gold', descriptionTemplate: '收服 2 只稀有及以上妖怪', reward: { exp: 90 }, condition: { type: 'capture', qualityMin: 'rare', count: 2 } },
+];
+
+const AVAILABLE_PRODUCTS = [
+  'aitable', 'calendar', 'chat', 'contact', 'todo',
+  'approval', 'attendance', 'report', 'ding', 'workbench', 'devdoc',
+];
+
+// ============ 种子随机 ============
+
+function hashString(input: string): number {
+  const hash = createHash('sha256').update(input).digest();
+  return hash.readUInt32BE(0);
+}
+
+function seededRandom(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state * 1664525 + 1013904223) & 0xFFFFFFFF;
+    return (state >>> 0) / 0xFFFFFFFF;
+  };
+}
+
+function pickRandom<T>(pool: T[], rng: () => number): T {
+  const index = Math.floor(rng() * pool.length);
+  return pool[index];
+}
+
+function getDayKey(): string {
+  const now = new Date();
+  const offset = 8 * 60; // UTC+8
+  const local = new Date(now.getTime() + offset * 60 * 1000);
+  return local.toISOString().slice(0, 10);
+}
+
+// ============ 核心逻辑 ============
+
+/**
+ * 生成每日悬赏令
+ */
+export function generateDailyBounties(profile: UserProfile): DailyBountyState {
+  const today = getDayKey();
+
+  // 如果今天已经生成过，直接返回
+  if (profile.dailyBounty && profile.dailyBounty.date === today) {
+    return profile.dailyBounty;
+  }
+
+  const seed = hashString(profile.uidHash + today + 'bounty-salt');
+  const rng = seededRandom(seed);
+
+  const bronzeTemplate = pickRandom(BRONZE_POOL, rng);
+  const silverTemplate = pickRandom(SILVER_POOL, rng);
+  const goldTemplate = pickRandom(GOLD_POOL, rng);
+
+  const bounties = [bronzeTemplate, silverTemplate, goldTemplate].map(template =>
+    instantiateTemplate(template, rng)
+  );
+
+  const state: DailyBountyState = {
+    date: today,
+    bounties,
+    completedCount: 0,
+  };
+
+  profile.dailyBounty = state;
+  return state;
+}
+
+/**
+ * 将模板实例化为具体的悬赏令
+ */
+function instantiateTemplate(template: BountyTemplate, rng: () => number): Bounty {
+  let description = template.descriptionTemplate;
+  const condition = { ...template.condition };
+
+  if (template.hasProductPlaceholder) {
+    const product = pickRandom(AVAILABLE_PRODUCTS, rng);
+    description = description.replace('{product}', product);
+    condition.product = product;
+  }
+
+  return {
+    id: template.id,
+    tier: template.tier,
+    description,
+    target: condition.count,
+    current: 0,
+    completed: false,
+    reward: { ...template.reward },
+    condition,
+  };
+}
+
+// ============ 品质比较 ============
+
+const QUALITY_RANK: Record<MonsterQuality, number> = {
+  normal: 0,
+  fine: 1,
+  rare: 2,
+  epic: 3,
+  legendary: 4,
+  shiny: 5,
+};
+
+function isQualityAtLeast(actual: MonsterQuality, minimum: MonsterQuality): boolean {
+  return QUALITY_RANK[actual] >= QUALITY_RANK[minimum];
+}
+
+// ============ 进度追踪 ============
+
+/**
+ * 操作后更新悬赏令进度
+ *
+ * @returns 本次新完成的悬赏令列表
+ */
+export function updateBountyProgress(
+  profile: UserProfile,
+  context: BountyUpdateContext
+): Bounty[] {
+  const bountyState = profile.dailyBounty;
+  if (!bountyState) return [];
+
+  const today = getDayKey();
+  if (bountyState.date !== today) return [];
+
+  const newlyCompleted: Bounty[] = [];
+
+  for (const bounty of bountyState.bounties) {
+    if (bounty.completed) continue;
+
+    const progressBefore = bounty.current;
+    updateSingleBountyProgress(bounty, context);
+
+    if (!bounty.completed && bounty.current >= bounty.target) {
+      bounty.completed = true;
+      bountyState.completedCount += 1;
+      newlyCompleted.push(bounty);
+
+      // 发放奖励
+      profile.totalExp += bounty.reward.exp;
+
+      // 更新悬赏历史
+      profile.bountyHistory.totalCompleted += 1;
+      switch (bounty.tier) {
+        case 'bronze': profile.bountyHistory.bronzeCompleted += 1; break;
+        case 'silver': profile.bountyHistory.silverCompleted += 1; break;
+        case 'gold': profile.bountyHistory.goldCompleted += 1; break;
+      }
+    }
+  }
+
+  // 检查全部完成
+  if (bountyState.completedCount === 3) {
+    profile.bountyHistory.consecutiveFullClear += 1;
+  }
+
+  return newlyCompleted;
+}
+
+export interface BountyUpdateContext {
+  commandSuccess: boolean;
+  product: string;
+  dropResult?: DropResult;
+  encounterTriggered: boolean;
+  encounterType?: string;
+  currentCombo: number;
+  /** 今日使用过的不同产品集合 */
+  todayProducts: Set<string>;
+  /** 今日收服的不同品质集合 */
+  todayQualities: Set<MonsterQuality>;
+}
+
+function updateSingleBountyProgress(bounty: Bounty, ctx: BountyUpdateContext): void {
+  const { condition } = bounty;
+
+  switch (condition.type) {
+    case 'command':
+      if (ctx.commandSuccess) {
+        if (condition.product) {
+          if (ctx.product === condition.product) bounty.current += 1;
+        } else {
+          bounty.current += 1;
+        }
+      }
+      break;
+
+    case 'capture':
+      if (ctx.dropResult && !ctx.dropResult.escaped) {
+        let matches = true;
+
+        if (condition.qualityMin) {
+          matches = matches && isQualityAtLeast(ctx.dropResult.monster.quality, condition.qualityMin);
+        }
+        if (condition.isUpMonster) {
+          matches = matches && ctx.dropResult.isUpMonster;
+        }
+        if (condition.isNew) {
+          matches = matches && ctx.dropResult.isNew;
+        }
+        if (condition.product) {
+          matches = matches && ctx.dropResult.monster.relatedProduct === condition.product;
+        }
+
+        if (matches) bounty.current += 1;
+      }
+      break;
+
+    case 'combo':
+      // 连击类悬赏：直接用当前连击数作为进度
+      bounty.current = Math.min(ctx.currentCombo, bounty.target);
+      break;
+
+    case 'encounter':
+      if (ctx.encounterTriggered) {
+        // B206 金令要求赐宝机缘
+        if (bounty.id === 'B206') {
+          if (ctx.encounterType === 'treasure') bounty.current += 1;
+        } else {
+          bounty.current += 1;
+        }
+      }
+      break;
+
+    case 'product_variety':
+      bounty.current = Math.min(ctx.todayProducts.size, bounty.target);
+      break;
+
+    case 'quality_variety':
+      bounty.current = Math.min(ctx.todayQualities.size, bounty.target);
+      break;
+  }
+}
+
+/**
+ * 初始化默认的悬赏历史
+ */
+export function createDefaultBountyHistory(): BountyHistory {
+  return {
+    totalCompleted: 0,
+    bronzeCompleted: 0,
+    silverCompleted: 0,
+    goldCompleted: 0,
+    consecutiveFullClear: 0,
+  };
+}
+
+/**
+ * 检查今日是否需要重置连续全清计数
+ * （如果昨天没有全部完成，重置为 0）
+ */
+export function checkBountyDayReset(profile: UserProfile): void {
+  const today = getDayKey();
+  if (profile.dailyBounty && profile.dailyBounty.date !== today) {
+    // 昨天没全清
+    if (profile.dailyBounty.completedCount < 3) {
+      profile.bountyHistory.consecutiveFullClear = 0;
+    }
+  }
+}

--- a/src/game-xiyou/commands.ts
+++ b/src/game-xiyou/commands.ts
@@ -1,0 +1,223 @@
+/**
+ * 聊天命令注册
+ *
+ * 处理 /修行 /图鉴 /成就 /法宝 /妖魔榜 /机缘 /保底 /使用 /炫耀 等命令。
+ */
+
+import type { UserProfile, UserCollection } from './types.ts';
+import {
+  renderProfilePanel,
+  renderCollectionPanel,
+  renderAchievementPanel,
+  renderTreasurePanel,
+  renderPityPanel,
+  renderEncounterPanel,
+  renderLeaderboard,
+  renderTreasureUse,
+  renderShowOff,
+  renderBountyPanel,
+  renderEventPanel,
+} from './renderer.ts';
+import { consumeTreasure } from './treasure-system.ts';
+import { getNextLevel } from './level-system.ts';
+import { getMonsterById, getAllMonsters } from './monster-pool.ts';
+import type { Monster } from './types.ts';
+import { QUALITY_LABELS } from './types.ts';
+
+/** 养成系统支持的命令列表 */
+export const GAMIFICATION_COMMANDS = [
+  '/修行', '/图鉴', '/成就', '/法宝', '/使用',
+  '/妖魔榜', '/机缘', '/保底', '/炫耀',
+  '/悬赏', '/事件', '/西游',
+];
+
+/**
+ * 检查消息是否是养成系统命令
+ */
+export function isGamificationCommand(text: string): boolean {
+  const trimmed = text.trim();
+  return GAMIFICATION_COMMANDS.some(cmd => trimmed.startsWith(cmd));
+}
+
+/**
+ * 处理养成系统命令，返回 Markdown 响应
+ *
+ * @returns Markdown 字符串，或 null（不是养成系统命令）
+ */
+export function handleGamificationCommand(
+  text: string,
+  profile: UserProfile,
+  collection: UserCollection,
+  saveCallback: () => void
+): string | null {
+  const trimmed = text.trim();
+
+  if (trimmed === '/修行') {
+    return renderProfilePanel(profile, collection);
+  }
+
+  if (trimmed === '/图鉴') {
+    return renderCollectionPanel(collection);
+  }
+
+  if (trimmed.startsWith('/图鉴 ')) {
+    const monsterName = trimmed.slice(4).trim();
+    return renderMonsterDetail(monsterName, collection);
+  }
+
+  if (trimmed === '/成就') {
+    return renderAchievementPanel(profile);
+  }
+
+  if (trimmed === '/法宝') {
+    return renderTreasurePanel(profile);
+  }
+
+  if (trimmed.startsWith('/使用 ')) {
+    const treasureName = trimmed.slice(4).trim();
+    return handleUseTreasure(profile, treasureName, saveCallback);
+  }
+
+  if (trimmed === '/妖魔榜') {
+    return renderLeaderboard(profile, collection);
+  }
+
+  if (trimmed === '/机缘') {
+    return renderEncounterPanel(profile);
+  }
+
+  if (trimmed === '/保底') {
+    return renderPityPanel(profile);
+  }
+
+  if (trimmed === '/炫耀') {
+    return renderShowOff(profile, collection);
+  }
+
+  if (trimmed === '/悬赏' || trimmed === '/悬赏 历史') {
+    return renderBountyPanel(profile);
+  }
+
+  if (trimmed === '/事件' || trimmed === '/事件 历史') {
+    return renderEventPanel(profile);
+  }
+
+  // ===== 帮助面板 & 一键开关 =====
+  if (trimmed === '/西游' || trimmed === '/西游 --h' || trimmed === '/西游 -h' || trimmed === '/西游 help') {
+    const statusText = profile.settings.enabled ? '✅ 已开启' : '❌ 已关闭';
+    return [
+      `### 🐒 西游妖魔榜 · 命令一览`,
+      ``,
+      `当前状态：${statusText}`,
+      ``,
+      `| 命令 | 功能 |`,
+      `|------|------|`,
+      `| \`/修行\` | 查看个人修行面板（等级、修行值、连击、签到等） |`,
+      `| \`/图鉴\` | 查看妖怪图鉴收集进度 |`,
+      `| \`/图鉴 妖怪名\` | 查看指定妖怪详情 |`,
+      `| \`/成就\` | 查看成就列表及解锁状态 |`,
+      `| \`/法宝\` | 查看法宝背包 |`,
+      `| \`/使用 法宝名\` | 使用一次性法宝（如蟠桃、人参果） |`,
+      `| \`/妖魔榜\` | 查看本周 UP 妖怪、掉落统计、保底状态 |`,
+      `| \`/机缘\` | 查看神仙机缘录 |`,
+      `| \`/保底\` | 查看保底计数器详情（含软保底状态） |`,
+      `| \`/炫耀\` | 生成炫耀卡片 |`,
+      `| \`/悬赏\` | 查看今日悬赏令及历史统计 |`,
+      `| \`/事件\` | 查看当前活跃事件及事件统计 |`,
+      `| \`/西游 开启\` | 开启养成系统 |`,
+      `| \`/西游 关闭\` | 关闭养成系统 |`,
+      ``,
+      `> 关闭后，dws 命令执行不再触发降妖掉落，但已有数据会保留。`,
+    ].join('\n');
+  }
+
+  if (trimmed === '/西游 开启' || trimmed === '/西游 开') {
+    profile.settings.enabled = true;
+    saveCallback();
+    return [
+      `### 🐒 西游妖魔榜 · 已开启`,
+      ``,
+      `✅ 养成系统已开启！每次使用钉钉产品能力都会触发降妖掉落。`,
+      ``,
+      `发送 \`/修行\` 查看你的修行面板。`,
+    ].join('\n');
+  }
+
+  if (trimmed === '/西游 关闭' || trimmed === '/西游 关') {
+    profile.settings.enabled = false;
+    saveCallback();
+    return [
+      `### 🐒 西游妖魔榜 · 已关闭`,
+      ``,
+      `❌ 养成系统已关闭。dws 命令执行不再触发降妖掉落。`,
+      ``,
+      `你的修行数据已保留，随时可以发送 \`/西游 开启\` 重新开启。`,
+    ].join('\n');
+  }
+
+  return null;
+}
+
+/**
+ * 渲染妖怪详情
+ */
+function renderMonsterDetail(monsterName: string, collection: UserCollection): string {
+  // 在所有妖怪中搜索
+  const allMonsters = getAllMonsters();
+  const monster = allMonsters.find(m => m.name === monsterName);
+
+  if (!monster) {
+    return `未找到名为「${monsterName}」的妖怪。`;
+  }
+
+  const entry = collection.entries.find(e => e.monsterId === monster.id && !e.isShiny);
+  const shinyEntry = collection.entries.find(e => e.monsterId === monster.id && e.isShiny);
+
+  const lines = [
+    `### ${QUALITY_LABELS[monster.quality]} ${monster.name}`,
+    '',
+    `- **出处**：${monster.origin}`,
+    `- **关联产品**：${monster.relatedProduct ?? '任意'}`,
+    `- **收服台词**："${monster.captureQuote}"`,
+    '',
+  ];
+
+  if (entry) {
+    lines.push(
+      `✅ **已收服**`,
+      `- 首次收服：${new Date(entry.firstCapturedAt).toLocaleDateString('zh-CN')}`,
+      `- 收服次数：${entry.captureCount}`,
+    );
+  } else {
+    lines.push(`❌ **未收服**`);
+  }
+
+  if (shinyEntry) {
+    lines.push('', `✨ **闪光变体已收服**`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * 处理使用法宝命令
+ */
+function handleUseTreasure(
+  profile: UserProfile,
+  treasureName: string,
+  saveCallback: () => void
+): string {
+  const result = consumeTreasure(profile, treasureName);
+
+  if (!result) {
+    return `无法使用「${treasureName}」。可能原因：未拥有、已使用、或不是一次性法宝。\n\n发送 \`/法宝\` 查看背包。`;
+  }
+
+  const nextLevel = getNextLevel(profile.level);
+  const nextLevelExp = nextLevel?.requiredExp ?? null;
+
+  // 保存数据
+  saveCallback();
+
+  return renderTreasureUse(treasureName, result.expGained, profile.totalExp, nextLevelExp);
+}

--- a/src/game-xiyou/drop-engine.ts
+++ b/src/game-xiyou/drop-engine.ts
@@ -1,0 +1,241 @@
+/**
+ * 概率掉落引擎（核心）
+ *
+ * 每次 dws CLI 成功执行后触发一次"降妖"事件。
+ * 流程：保底判定 → 随机品质 → 等级门槛降级 → 加权选妖 → 闪光判定 → 更新计数器
+ */
+
+import { randomBytes } from 'crypto';
+import type {
+  MonsterQuality, Monster, UserProfile, DropResult,
+  Buff, UserCollection, EscapeModifier,
+} from './types.ts';
+import {
+  DROP_RATES, QUALITY_LEVEL_GATES, QUALITY_ORDER,
+} from './types.ts';
+import { checkPityTrigger, updatePityCounters, getSoftPityBonuses } from './pity-counter.ts';
+import { getMonstersByQuality, getWeeklyUpMonster, weightedRandomSelect } from './monster-pool.ts';
+import { getQualityBoost, getQualityCap, isDropSuppressed } from './random-event-engine.ts';
+
+/**
+ * 使用 crypto.randomBytes 生成安全随机数
+ */
+function cryptoRandom(): number {
+  const buffer = randomBytes(4);
+  return buffer.readUInt32BE(0) / 0xFFFFFFFF;
+}
+
+/**
+ * 根据随机数和用户等级判定掉落品质
+ *
+ * v2: 集成软保底概率加成
+ */
+function resolveQuality(roll: number, level: number, buffs: Buff[], softPityBonuses: Partial<Record<MonsterQuality, number>>): MonsterQuality {
+  // 计算 buff 加成后的掉落率
+  const rateBonus: Partial<Record<MonsterQuality, number>> = {};
+  for (const buff of buffs) {
+    switch (buff.effect) {
+      case 'epicRateBonus':
+        rateBonus.epic = (rateBonus.epic ?? 0) + buff.value;
+        break;
+      case 'rareRateBonus':
+        rateBonus.rare = (rateBonus.rare ?? 0) + buff.value;
+        break;
+      case 'legendaryRateBonus':
+        rateBonus.legendary = (rateBonus.legendary ?? 0) + buff.value;
+        break;
+      case 'shinyRateBonus':
+        rateBonus.shiny = (rateBonus.shiny ?? 0) + buff.value;
+        break;
+      case 'allRateBonus':
+        for (const quality of QUALITY_ORDER) {
+          if (quality !== 'normal' && quality !== 'fine') {
+            rateBonus[quality] = (rateBonus[quality] ?? 0) + buff.value;
+          }
+        }
+        break;
+    }
+  }
+
+  // 合并软保底加成
+  for (const [quality, bonus] of Object.entries(softPityBonuses)) {
+    const qualityKey = quality as MonsterQuality;
+    rateBonus[qualityKey] = (rateBonus[qualityKey] ?? 0) + (bonus ?? 0);
+  }
+
+  // 从高品质到低品质依次判定
+  let cumulative = 0;
+  const qualitiesHighToLow: MonsterQuality[] = ['shiny', 'legendary', 'epic', 'rare', 'fine', 'normal'];
+
+  for (const quality of qualitiesHighToLow) {
+    const baseRate = DROP_RATES[quality];
+    const bonus = rateBonus[quality] ?? 0;
+    cumulative += baseRate + bonus;
+
+    if (roll < cumulative) {
+      return quality;
+    }
+  }
+
+  return 'normal';
+}
+
+/**
+ * 应用等级门槛降级
+ */
+function applyLevelGate(quality: MonsterQuality, level: number): MonsterQuality {
+  const gate = QUALITY_LEVEL_GATES[quality];
+  if (gate !== undefined && level < gate) {
+    // 降级到最高可用品质
+    const qualityIndex = QUALITY_ORDER.indexOf(quality);
+    for (let i = qualityIndex - 1; i >= 0; i--) {
+      const lowerQuality = QUALITY_ORDER[i];
+      const lowerGate = QUALITY_LEVEL_GATES[lowerQuality];
+      if (lowerGate === undefined || level >= lowerGate) {
+        return lowerQuality;
+      }
+    }
+    return 'normal';
+  }
+  return quality;
+}
+
+/**
+ * 检查玲珑宝塔 buff：普通掉落有概率升级为精良
+ */
+function checkNormalUpgrade(quality: MonsterQuality, buffs: Buff[]): MonsterQuality {
+  if (quality !== 'normal') return quality;
+
+  const upgradeChance = buffs
+    .filter(b => b.effect === 'normalUpgrade')
+    .reduce((sum, b) => sum + b.value, 0);
+
+  if (upgradeChance > 0 && cryptoRandom() < upgradeChance) {
+    return 'fine';
+  }
+  return quality;
+}
+
+/**
+ * 将品质提升一级（用于月光宝盒事件）
+ */
+function boostQuality(quality: MonsterQuality): MonsterQuality {
+  const index = QUALITY_ORDER.indexOf(quality);
+  if (index < 0 || index >= QUALITY_ORDER.length - 1) return quality;
+  return QUALITY_ORDER[index + 1];
+}
+
+/**
+ * 执行一次掉落
+ *
+ * v2: 集成软保底概率加成、事件品质提升/上限、禁止掉落检查
+ */
+export function executeDrop(
+  product: string,
+  profile: UserProfile,
+  collection: UserCollection
+): DropResult {
+  const emptyResult: DropResult = {
+    monster: { id: '', name: '', quality: 'normal', origin: '', relatedProduct: null, captureQuote: '' },
+    isShiny: false, isNew: false, expGained: 0,
+    isPityTriggered: false, isUpMonster: false,
+    escaped: false, escapeRate: 0, escapeModifiers: [],
+  };
+
+  // v2: 检查是否被事件禁止掉落（五行山镇压）
+  if (isDropSuppressed(profile)) {
+    return emptyResult;
+  }
+
+  const pity = profile.pityCounters;
+  let isPityTriggered = false;
+  let quality: MonsterQuality;
+
+  // 1. 保底判定（优先级最高）
+  const pityQuality = checkPityTrigger(pity);
+  if (pityQuality) {
+    quality = pityQuality;
+    isPityTriggered = true;
+  } else {
+    // 2. 随机品质判定（v2: 含软保底加成）
+    const roll = cryptoRandom();
+    const softPityBonuses = getSoftPityBonuses(pity);
+    quality = resolveQuality(roll, profile.level, profile.buffs, softPityBonuses);
+  }
+
+  // 3. 等级门槛降级
+  quality = applyLevelGate(quality, profile.level);
+
+  // 4. 玲珑宝塔 buff 检查
+  quality = checkNormalUpgrade(quality, profile.buffs);
+
+  // v2: 事件品质上限（妖雾弥漫）
+  const qualityCap = getQualityCap(profile);
+  if (qualityCap) {
+    const capIndex = QUALITY_ORDER.indexOf(qualityCap);
+    const currentIndex = QUALITY_ORDER.indexOf(quality);
+    if (currentIndex > capIndex) {
+      quality = qualityCap;
+    }
+  }
+
+  // v2: 事件品质提升（月光宝盒）
+  const qualityBoostLevel = getQualityBoost(profile);
+  if (qualityBoostLevel > 0) {
+    for (let i = 0; i < qualityBoostLevel; i++) {
+      quality = boostQuality(quality);
+    }
+    quality = applyLevelGate(quality, profile.level);
+  }
+
+  // 5. 闪光判定（独立于品质判定）
+  let isShiny = false;
+  if (quality === 'shiny') {
+    isShiny = true;
+    const availableQualities = QUALITY_ORDER.filter(q => {
+      if (q === 'shiny') return false;
+      const gate = QUALITY_LEVEL_GATES[q];
+      return gate === undefined || profile.level >= gate;
+    });
+    quality = availableQualities[Math.floor(cryptoRandom() * availableQualities.length)] || 'normal';
+  } else if (profile.level >= 9) {
+    const shinyBonus = profile.buffs
+      .filter(b => b.effect === 'shinyRateBonus')
+      .reduce((sum, b) => sum + b.value, 0);
+    if (cryptoRandom() < 0.001 + shinyBonus) {
+      isShiny = true;
+    }
+  }
+
+  // 6. 在品质池中选择妖怪
+  const pool = getMonstersByQuality(quality);
+  const upMonster = getWeeklyUpMonster();
+  let monster: Monster;
+
+  if (pool.length === 0) {
+    const normalPool = getMonstersByQuality('normal');
+    monster = weightedRandomSelect(normalPool, product, null, cryptoRandom());
+  } else {
+    monster = weightedRandomSelect(pool, product, upMonster, cryptoRandom());
+  }
+
+  // 7. 判定是否为新妖怪
+  const isNew = !collection.entries.some(e =>
+    e.monsterId === monster.id && (isShiny ? e.isShiny : !e.isShiny)
+  );
+
+  // 8. 更新保底计数器
+  updatePityCounters(pity, quality, isShiny);
+
+  return {
+    monster,
+    isShiny,
+    isNew,
+    expGained: 0,
+    isPityTriggered,
+    isUpMonster: upMonster?.id === monster.id,
+    escaped: false,
+    escapeRate: 0,
+    escapeModifiers: [],
+  };
+}

--- a/src/game-xiyou/encounter-system.ts
+++ b/src/game-xiyou/encounter-system.ts
@@ -1,0 +1,135 @@
+/**
+ * 神仙机缘系统
+ *
+ * 等级 ≥ 3（修行者）后解锁。
+ * 每次 dws CLI 成功执行，除了掉落妖怪外，还有独立概率触发"神仙机缘"事件。
+ */
+
+import { randomBytes } from 'crypto';
+import type { Encounter, EncounterType, Immortal, UserProfile, Buff, Treasure } from './types.ts';
+import { ENCOUNTER_RATES } from './types.ts';
+import { TREASURES_DATA } from './treasure-system.ts';
+
+/**
+ * 神仙数据（内联）
+ */
+const allImmortals: Immortal[] = [
+  { id: "G001", name: "菩提祖师", guidanceQuote: "悟性不错，但还差一个筋斗云的距离。", treasureId: "jintouyun", apprenticeBuff: { id: "putizu-apprentice", source: "apprentice", effect: "expMultiplier", value: 1.2 } },
+  { id: "G002", name: "观音菩萨", guidanceQuote: "救苦救难，先把待办清了。", treasureId: "jingping", apprenticeBuff: { id: "guanyin-apprentice", source: "apprentice", effect: "pityReduction", value: 0.5 } },
+  { id: "G003", name: "太上老君", guidanceQuote: "八卦炉里炼出来的，都是好东西。", treasureId: "zijinhulu", apprenticeBuff: { id: "laojun-apprentice", source: "apprentice", effect: "epicRateBonus", value: 0.01 } },
+  { id: "G004", name: "太白金星", guidanceQuote: "玉帝有旨，你的 KPI 不错。", treasureId: "pantao", apprenticeBuff: { id: "taibai-apprentice", source: "apprentice", effect: "signInMultiplier", value: 1.5 } },
+  { id: "G005", name: "哪吒三太子", guidanceQuote: "风火轮转得快，但别忘了刹车。", treasureId: "qiankunquan", apprenticeBuff: { id: "nezha-apprentice", source: "apprentice", effect: "comboLimitBonus", value: 1 } },
+  { id: "G006", name: "二郎真君", guidanceQuote: "第三只眼看穿一切 bug。", treasureId: "sanjiandao", apprenticeBuff: { id: "erlang-apprentice", source: "apprentice", effect: "rareRateBonus", value: 0.02 } },
+  { id: "G007", name: "托塔天王", guidanceQuote: "塔在手，妖魔走。", treasureId: "linglongta", apprenticeBuff: { id: "tuota-apprentice", source: "apprentice", effect: "allRateBonus", value: 0.005 } },
+  { id: "G008", name: "镇元大仙", guidanceQuote: "人参果，三千年一开花，三千年一结果。", treasureId: "renshenguo", apprenticeBuff: { id: "zhenyuan-apprentice", source: "apprentice", effect: "legendaryRateBonus", value: 0.003 } },
+];
+
+function cryptoRandom(): number {
+  const buffer = randomBytes(4);
+  return buffer.readUInt32BE(0) / 0xFFFFFFFF;
+}
+
+/**
+ * 根据 ID 查找神仙
+ */
+export function getImmortalById(immortalId: string): Immortal | undefined {
+  return allImmortals.find(i => i.id === immortalId);
+}
+
+/**
+ * 获取法宝名称
+ */
+export function getTreasureName(treasureId: string): string {
+  const treasure = TREASURES_DATA.find(t => t.id === treasureId);
+  return treasure?.name ?? treasureId;
+}
+
+/**
+ * 获取法宝描述
+ */
+export function getTreasureDescription(treasureId: string): string {
+  const treasure = TREASURES_DATA.find(t => t.id === treasureId);
+  return treasure?.description ?? '';
+}
+
+/**
+ * 检查是否触发机缘事件
+ *
+ * @returns 机缘事件，或 null（未触发）
+ */
+export function checkEncounter(profile: UserProfile): Encounter | null {
+  // 等级 < 3 不触发
+  if (profile.level < 3) {
+    return null;
+  }
+
+  // 按概率从高到低判定
+  const encounterTypes: EncounterType[] = ['apprentice', 'treasure', 'guidance'];
+
+  for (const encounterType of encounterTypes) {
+    const rate = ENCOUNTER_RATES[encounterType];
+    if (cryptoRandom() < rate) {
+      // 随机选择一位神仙
+      const immortal = allImmortals[Math.floor(cryptoRandom() * allImmortals.length)];
+
+      const encounter: Encounter = {
+        immortalId: immortal.id,
+        type: encounterType,
+        occurredAt: Date.now(),
+      };
+
+      if (encounterType === 'treasure') {
+        encounter.treasureId = immortal.treasureId;
+      }
+
+      if (encounterType === 'apprentice') {
+        encounter.buffId = immortal.apprenticeBuff.id;
+      }
+
+      return encounter;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 应用机缘效果到用户档案
+ */
+export function applyEncounterEffects(profile: UserProfile, encounter: Encounter): void {
+  // 记录机缘
+  profile.encounters.push(encounter);
+
+  const immortal = getImmortalById(encounter.immortalId);
+  if (!immortal) return;
+
+  if (encounter.type === 'treasure' && encounter.treasureId) {
+    // 赐宝：添加法宝到背包
+    if (!profile.treasures.includes(encounter.treasureId)) {
+      profile.treasures.push(encounter.treasureId);
+    }
+
+    // 如果法宝有永久 buff 效果，添加到 buffs
+    const treasure = TREASURES_DATA.find(t => t.id === encounter.treasureId);
+    if (treasure && !treasure.consumable) {
+      const existingBuff = profile.buffs.find(b => b.id === treasure.id);
+      if (!existingBuff) {
+        profile.buffs.push({
+          id: treasure.id,
+          source: 'treasure',
+          effect: treasure.effect,
+          value: treasure.value,
+        });
+      }
+    }
+  }
+
+  if (encounter.type === 'apprentice') {
+    // 收徒：添加永久 buff
+    const buff: Buff = { ...immortal.apprenticeBuff };
+    const existingBuff = profile.buffs.find(b => b.id === buff.id);
+    if (!existingBuff) {
+      profile.buffs.push(buff);
+    }
+  }
+}

--- a/src/game-xiyou/escape-engine.ts
+++ b/src/game-xiyou/escape-engine.ts
@@ -1,0 +1,164 @@
+/**
+ * 妖怪逃跑引擎 (v2)
+ *
+ * 掉落不再等于收服。品质越高的妖怪越难降服。
+ * 逃跑率受连击、法宝、buff、产品关联等因素修正，最低不低于 5%。
+ * 保底触发的妖怪 100% 收服，不会逃跑。
+ */
+
+import { randomBytes } from 'crypto';
+import type {
+  MonsterQuality, Monster, UserProfile, DropResult, EscapeModifier,
+} from './types.ts';
+import { BASE_ESCAPE_RATES, MIN_ESCAPE_RATE } from './types.ts';
+
+function cryptoRandom(): number {
+  const buffer = randomBytes(4);
+  return buffer.readUInt32BE(0) / 0xFFFFFFFF;
+}
+
+/**
+ * 计算逃跑率修正因子列表
+ */
+function calculateEscapeModifiers(
+  monster: Monster,
+  profile: UserProfile,
+  product: string,
+  isBountyTarget: boolean
+): EscapeModifier[] {
+  const modifiers: EscapeModifier[] = [];
+
+  // 连击加成：≥5 时 -10%，≥10 时 -20%
+  if (profile.currentCombo >= 10) {
+    modifiers.push({ source: 'combo', value: 0.20, description: `连击 ×${profile.currentCombo} 加成` });
+  } else if (profile.currentCombo >= 5) {
+    modifiers.push({ source: 'combo', value: 0.10, description: `连击 ×${profile.currentCombo} 加成` });
+  }
+
+  // 法宝"玲珑宝塔"：逃跑率 -15%
+  if (profile.buffs.some(b => b.id === 'linglongta')) {
+    modifiers.push({ source: 'treasure', value: 0.15, description: '玲珑宝塔' });
+  }
+
+  // 法宝"定海神针"：逃跑率 -10%
+  if (profile.buffs.some(b => b.id === 'dinghaishenzhen')) {
+    modifiers.push({ source: 'treasure', value: 0.10, description: '定海神针' });
+  }
+
+  // 师徒 buff（二郎真君）：逃跑率 -8%
+  if (profile.buffs.some(b => b.id === 'erlang-apprentice')) {
+    modifiers.push({ source: 'buff', value: 0.08, description: '二郎真君师徒' });
+  }
+
+  // 产品关联匹配：妖怪关联产品与当前命令产品一致时 -5%
+  if (monster.relatedProduct && monster.relatedProduct === product) {
+    modifiers.push({ source: 'product', value: 0.05, description: '产品关联匹配' });
+  }
+
+  // 悬赏令加成：悬赏目标妖怪逃跑率 -10%
+  if (isBountyTarget) {
+    modifiers.push({ source: 'bounty', value: 0.10, description: '悬赏令加成' });
+  }
+
+  // 活跃事件修正：逃跑率全局修正
+  for (const event of profile.activeEvents.currentEvents) {
+    if (event.effect.type === 'escape_rate_mod') {
+      const eventValue = Math.abs(event.effect.value);
+      if (event.effect.value < 0) {
+        modifiers.push({ source: 'event', value: eventValue, description: `${event.name} 减益` });
+      }
+      // 正值（增加逃跑率）在 calculateFinalEscapeRate 中处理
+    }
+  }
+
+  return modifiers;
+}
+
+/**
+ * 计算最终逃跑率
+ */
+function calculateFinalEscapeRate(
+  quality: MonsterQuality,
+  isShiny: boolean,
+  modifiers: EscapeModifier[],
+  profile: UserProfile,
+  monsterId: string
+): number {
+  // 闪光妖怪使用闪光逃跑率
+  const baseRate = isShiny ? BASE_ESCAPE_RATES.shiny : BASE_ESCAPE_RATES[quality];
+
+  if (baseRate === 0) return 0; // 普通妖怪不逃跑
+
+  // 减去所有修正因子
+  const totalReduction = modifiers.reduce((sum, m) => sum + m.value, 0);
+
+  // 加上事件增加的逃跑率
+  let eventIncrease = 0;
+  for (const event of profile.activeEvents.currentEvents) {
+    if (event.effect.type === 'escape_rate_mod' && event.effect.value > 0) {
+      eventIncrease += event.effect.value;
+    }
+  }
+
+  // "冤家路窄"：同一只妖怪连续逃跑 3 次，第 4 次逃跑率减半
+  const consecutiveEscapes = profile.escapeHistory[monsterId] ?? 0;
+  let consecutiveReduction = 0;
+  if (consecutiveEscapes >= 3) {
+    consecutiveReduction = (baseRate + eventIncrease - totalReduction) * 0.5;
+  }
+
+  const finalRate = baseRate + eventIncrease - totalReduction - consecutiveReduction;
+  return Math.max(MIN_ESCAPE_RATE, Math.min(finalRate, 0.95));
+}
+
+/**
+ * 判定妖怪是否逃跑，并更新追踪数据
+ *
+ * @returns 更新后的 DropResult（设置 escaped / escapeRate / escapeModifiers）
+ */
+export function resolveEscape(
+  dropResult: DropResult,
+  profile: UserProfile,
+  product: string,
+  isBountyTarget: boolean = false
+): DropResult {
+  const { monster, isShiny, isPityTriggered } = dropResult;
+
+  // 保底触发的妖怪 100% 收服
+  if (isPityTriggered) {
+    return { ...dropResult, escaped: false, escapeRate: 0, escapeModifiers: [] };
+  }
+
+  // 普通妖怪不逃跑
+  if (monster.quality === 'normal' && !isShiny) {
+    return { ...dropResult, escaped: false, escapeRate: 0, escapeModifiers: [] };
+  }
+
+  const modifiers = calculateEscapeModifiers(monster, profile, product, isBountyTarget);
+  const escapeRate = calculateFinalEscapeRate(
+    monster.quality, isShiny, modifiers, profile, monster.id
+  );
+
+  const escaped = cryptoRandom() < escapeRate;
+
+  // 更新逃跑追踪
+  if (escaped) {
+    profile.escapeHistory[monster.id] = (profile.escapeHistory[monster.id] ?? 0) + 1;
+    profile.totalEscapes += 1;
+  } else {
+    // 收服成功，重置该妖怪的连续逃跑计数
+    profile.escapeHistory[monster.id] = 0;
+  }
+
+  return { ...dropResult, escaped, escapeRate, escapeModifiers: modifiers };
+}
+
+/**
+ * 检查"冤家路窄"效果：逃跑后的妖怪在接下来 10 次掉落内再次遇到的概率 ×2
+ * 返回应该额外加权的妖怪 ID 列表
+ */
+export function getEscapedMonsterBoostIds(profile: UserProfile): string[] {
+  return Object.entries(profile.escapeHistory)
+    .filter(([_, count]) => count > 0)
+    .map(([monsterId]) => monsterId);
+}

--- a/src/game-xiyou/exp-calculator.ts
+++ b/src/game-xiyou/exp-calculator.ts
@@ -1,0 +1,139 @@
+/**
+ * 修行值计算引擎
+ *
+ * 计算公式：总修行值 = (基础值 × 连击倍率 × 首次使用倍率 + 签到奖励) × buff 倍率
+ */
+
+import type { UserProfile, ExpResult, Buff } from './types.ts';
+import { PRODUCT_BASE_EXP, COMBO_MULTIPLIERS } from './types.ts';
+
+/**
+ * 获取产品的基础修行值
+ */
+function getBaseExp(product: string): number {
+  return PRODUCT_BASE_EXP[product] ?? 2;
+}
+
+/**
+ * 计算连击加成倍率
+ */
+function getComboMultiplier(comboCount: number, buffs: Buff[]): number {
+  // 检查是否有连击上限提升 buff
+  const comboLimitBonus = buffs
+    .filter(b => b.effect === 'comboLimitBonus')
+    .reduce((sum, b) => sum + b.value, 0);
+
+  // 检查是否有连击加成 buff
+  const comboBonusFromBuffs = buffs
+    .filter(b => b.effect === 'comboBonus')
+    .reduce((sum, b) => sum + b.value, 0);
+
+  // 基础连击倍率
+  let baseMultiplier = 1.0;
+  for (const { threshold, multiplier } of COMBO_MULTIPLIERS) {
+    if (comboCount >= threshold) {
+      baseMultiplier = multiplier;
+      break;
+    }
+  }
+
+  // 如果有连击上限提升，最高倍率可以更高
+  if (comboLimitBonus > 0 && comboCount >= 10) {
+    baseMultiplier = Math.min(baseMultiplier + comboLimitBonus, 5.0);
+  }
+
+  return baseMultiplier + comboBonusFromBuffs;
+}
+
+/**
+ * 计算首次使用加成
+ */
+function getFirstUseMultiplier(product: string, productUsage: Record<string, number>): number {
+  const usage = productUsage[product] ?? 0;
+  return usage === 0 ? 5 : 1;
+}
+
+/**
+ * 计算签到奖励
+ */
+function getSignInBonus(profile: UserProfile): number {
+  const today = new Date().toISOString().slice(0, 10);
+  if (profile.lastSignInDate === today) {
+    return 0; // 今天已签到
+  }
+  return 10; // 每日首次 +10
+}
+
+/**
+ * 计算连续签到奖励
+ */
+function getConsecutiveSignInBonus(profile: UserProfile, buffs: Buff[]): number {
+  const today = new Date().toISOString().slice(0, 10);
+  if (profile.lastSignInDate === today) {
+    return 0; // 今天已签到，不重复计算
+  }
+
+  const signInMultiplier = buffs
+    .filter(b => b.effect === 'signInMultiplier')
+    .reduce((max, b) => Math.max(max, b.value), 1);
+
+  const consecutiveDays = profile.consecutiveSignInDays + 1;
+  const bonus = Math.min(consecutiveDays * 2, 30);
+  return Math.floor(bonus * signInMultiplier);
+}
+
+/**
+ * 计算 buff 总倍率
+ */
+function getBuffMultiplier(buffs: Buff[]): number {
+  return buffs
+    .filter(b => b.effect === 'expMultiplier')
+    .reduce((multiplier, b) => multiplier * b.value, 1.0);
+}
+
+/**
+ * 计算一次操作获得的总修行值
+ */
+export function calculateExp(product: string, profile: UserProfile): ExpResult {
+  const baseExp = getBaseExp(product);
+  const comboMultiplier = getComboMultiplier(profile.currentCombo + 1, profile.buffs);
+  const firstUseMultiplier = getFirstUseMultiplier(product, profile.productUsage);
+  const signInBonus = getSignInBonus(profile);
+  const consecutiveSignInBonus = getConsecutiveSignInBonus(profile, profile.buffs);
+  const buffMultiplier = getBuffMultiplier(profile.buffs);
+
+  const totalExp = Math.floor(
+    (baseExp * comboMultiplier * firstUseMultiplier + signInBonus + consecutiveSignInBonus) * buffMultiplier
+  );
+
+  return {
+    baseExp,
+    comboMultiplier,
+    firstUseMultiplier,
+    signInBonus,
+    consecutiveSignInBonus,
+    buffMultiplier,
+    totalExp,
+  };
+}
+
+/**
+ * 更新签到状态
+ */
+export function updateSignInStatus(profile: UserProfile): void {
+  const today = new Date().toISOString().slice(0, 10);
+
+  if (profile.lastSignInDate === today) {
+    return; // 今天已签到
+  }
+
+  // 检查是否连续签到
+  const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+  if (profile.lastSignInDate === yesterday) {
+    profile.consecutiveSignInDays += 1;
+  } else {
+    profile.consecutiveSignInDays = 1;
+  }
+
+  profile.lastSignInDate = today;
+}

--- a/src/game-xiyou/index.ts
+++ b/src/game-xiyou/index.ts
@@ -1,0 +1,461 @@
+/**
+ * 西游妖魔榜养成系统 · 入口
+ *
+ * GamificationEngine 是养成系统的门面类，统一协调所有子系统。
+ * 对外暴露两个核心方法：
+ * - onDwsCommandResult(): 每次 dws CLI 命令执行后调用（成功或失败）
+ * - handleCommand(): 处理聊天命令（/修行 /图鉴 等）
+ */
+
+import { createHash } from 'crypto';
+import { resolveUid, getShortUid } from './uid-resolver.ts';
+import { loadProfile, saveProfile, loadCollection, saveCollection, loadHistory, saveHistory } from './storage.ts';
+import { calculateExp, updateSignInStatus } from './exp-calculator.ts';
+import { checkLevelUp, applyLevelUp } from './level-system.ts';
+import { executeDrop } from './drop-engine.ts';
+import { checkEncounter, applyEncounterEffects } from './encounter-system.ts';
+import { checkAchievements, triggerSpecialAchievement } from './achievement-engine.ts';
+import { resolveEscape } from './escape-engine.ts';
+import {
+  generateDailyBounties, updateBountyProgress, checkBountyDayReset,
+  type BountyUpdateContext,
+} from './bounty-system.ts';
+import {
+  checkRandomEvent, tickActiveEvents, tickDropEvents,
+  getActiveExpMultiplier, resolveDisasterEvent,
+} from './random-event-engine.ts';
+import {
+  renderDropResult, renderLevelUp, renderEncounter,
+  renderNewAchievements, renderBountyComplete, renderEventTrigger,
+  renderChallengeResult, renderDisasterResolved,
+} from './renderer.ts';
+import { isGamificationCommand, handleGamificationCommand } from './commands.ts';
+import { getMonsterById } from './monster-pool.ts';
+import type {
+  UserProfile, UserCollection, UserHistory,
+  GamificationOutput, HistoryRecord, CollectionEntry,
+  DropResult, Achievement, Bounty, RandomEvent, ChallengeEvent,
+  MonsterQuality,
+} from './types.ts';
+
+// ============ 单例 ============
+
+let engineInstance: GamificationEngine | null = null;
+
+export class GamificationEngine {
+  private profile: UserProfile;
+  private collection: UserCollection;
+  private history: UserHistory;
+  private uidHash: string;
+
+  private constructor(senderId?: string) {
+    this.uidHash = resolveUid(senderId);
+    this.profile = loadProfile(this.uidHash);
+    this.collection = loadCollection(this.uidHash);
+    this.history = loadHistory(this.uidHash);
+  }
+
+  /**
+   * 获取或创建引擎实例
+   */
+  static getInstance(senderId?: string): GamificationEngine {
+    const uidHash = resolveUid(senderId);
+
+    // 如果 senderId 变了（不同用户），重新创建实例
+    if (!engineInstance || engineInstance.uidHash !== uidHash) {
+      engineInstance = new GamificationEngine(senderId);
+    }
+
+    return engineInstance;
+  }
+
+  /**
+   * 强制重新加载数据（用于多用户场景）
+   */
+  static getInstanceForUser(senderId: string): GamificationEngine {
+    return new GamificationEngine(senderId);
+  }
+
+  /**
+   * 检查养成系统是否启用
+   */
+  isEnabled(): boolean {
+    return this.profile.settings.enabled;
+  }
+
+  /**
+   * 检查消息是否是养成系统命令
+   */
+  isCommand(text: string): boolean {
+    return isGamificationCommand(text);
+  }
+
+  /**
+   * 处理聊天命令，返回 Markdown 响应
+   */
+  handleCommand(text: string): string | null {
+    return handleGamificationCommand(
+      text,
+      this.profile,
+      this.collection,
+      () => this.save()
+    );
+  }
+
+  /**
+   * dws CLI 命令执行后调用（核心方法）
+   *
+   * v2: 集成逃跑机制、悬赏令、随机事件系统
+   *
+   * @param product - dws 产品名（如 "aitable"、"calendar"）
+   * @param success - 命令是否成功
+   * @param commandStr - 原始命令字符串（用于生成 hash）
+   * @param isRecovery - 是否为 recovery 成功
+   * @returns Markdown 字符串（追加到 agent 回复末尾），或空字符串
+   */
+  onDwsCommandResult(
+    product: string,
+    success: boolean,
+    commandStr: string = '',
+    isRecovery: boolean = false
+  ): string {
+    if (!this.isEnabled()) return '';
+
+    const commandHash = createHash('sha256').update(commandStr).digest('hex').slice(0, 16);
+
+    // v2: 每日悬赏令刷新 & 连续全清检查
+    checkBountyDayReset(this.profile);
+    generateDailyBounties(this.profile);
+
+    // 处理失败情况
+    if (!success) {
+      this.profile.currentCombo = 0;
+      this.profile.consecutiveFailures += 1;
+
+      // v2: 失败也要更新挑战事件进度
+      const eventResults = tickActiveEvents(this.profile, false, product, false);
+
+      this.save();
+      return '';
+    }
+
+    // ===== 以下为成功执行的处理 =====
+
+    // 1. 更新基础统计
+    this.profile.totalOperations += 1;
+    this.profile.currentCombo += 1;
+    if (this.profile.currentCombo > this.profile.maxCombo) {
+      this.profile.maxCombo = this.profile.currentCombo;
+    }
+    this.profile.productUsage[product] = (this.profile.productUsage[product] ?? 0) + 1;
+
+    if (isRecovery) {
+      this.profile.totalRecoveries += 1;
+    }
+
+    // 2. 更新签到状态
+    updateSignInStatus(this.profile);
+
+    // 3. 计算修行值
+    const expResult = calculateExp(product, this.profile);
+
+    // v2: 应用事件修行值倍率（蟠桃大会 ×3 / 紧箍咒发作 ×0.5）
+    const eventExpMultiplier = getActiveExpMultiplier(this.profile);
+    expResult.totalExp = Math.floor(expResult.totalExp * eventExpMultiplier);
+
+    // 4. 检查升级
+    const levelUp = checkLevelUp(this.profile, expResult.totalExp);
+
+    // 5. 应用修行值
+    this.profile.totalExp += expResult.totalExp;
+    applyLevelUp(this.profile);
+
+    // 6. 执行掉落
+    let dropResult = executeDrop(product, this.profile, this.collection);
+    dropResult.expGained = expResult.totalExp;
+
+    // v2: 逃跑判定（仅对有效掉落）
+    if (dropResult.monster.id) {
+      dropResult = resolveEscape(dropResult, this.profile, product);
+    }
+
+    // v2: 递减 drop_count 类型事件
+    if (dropResult.monster.id) {
+      tickDropEvents(this.profile);
+    }
+
+    // 7. 更新图鉴（v2: 仅在未逃跑时更新）
+    if (dropResult.monster.id && !dropResult.escaped) {
+      this.updateCollection(dropResult.monster.id, dropResult.isShiny, commandHash);
+    }
+
+    // 逃跑时给安慰奖修行值
+    if (dropResult.escaped) {
+      this.profile.totalExp += 2;
+    }
+
+    // 8. 检查机缘
+    const encounter = checkEncounter(this.profile);
+    if (encounter) {
+      applyEncounterEffects(this.profile, encounter);
+
+      // v2: 机缘可以化解灾厄事件
+      const resolvedEvent = resolveDisasterEvent(this.profile, 'trigger_encounter');
+      if (resolvedEvent) {
+        // 渲染时会展示化解通知
+      }
+    }
+
+    // v2: 触发随机事件
+    const triggeredEvent = checkRandomEvent(this.profile);
+
+    // v2: 处理即时事件效果
+    let extraDropResult: DropResult | null = null;
+    if (triggeredEvent) {
+      // EV003 龙宫寻宝：额外掉落
+      if (triggeredEvent.effect.type === 'extra_drop') {
+        extraDropResult = executeDrop(product, this.profile, this.collection);
+        if (extraDropResult.monster.id && !extraDropResult.escaped) {
+          this.updateCollection(extraDropResult.monster.id, extraDropResult.isShiny, commandHash);
+        }
+      }
+
+      // EV202 金蝉脱壳：移除一只已收服的精良妖怪
+      if (triggeredEvent.id === 'EV202') {
+        const fineEntries = this.collection.entries.filter(e => {
+          const monster = getMonsterById(e.monsterId);
+          return monster?.quality === 'fine' && !e.isShiny;
+        });
+        if (fineEntries.length > 0) {
+          const randomIndex = Math.floor(Math.random() * fineEntries.length);
+          const removedEntry = fineEntries[randomIndex];
+          this.collection.entries = this.collection.entries.filter(e => e !== removedEntry);
+          // 接下来 10 次内再次遇到该妖怪概率 ×5（通过 escapeHistory 追踪）
+          this.profile.escapeHistory[removedEntry.monsterId] = 1;
+        }
+      }
+    }
+
+    // v2: 更新活跃事件持续时间
+    const capturedMonster = dropResult.monster.id !== '' && !dropResult.escaped;
+    const eventResults = tickActiveEvents(this.profile, true, product, capturedMonster);
+
+    // v2: 检查"否极泰来"成就（灾厄结束后立即触发增益）
+    const hasDisasterExpired = eventResults.some(
+      r => (r.event.category === 'disaster') && (r.outcome === 'expired' || r.outcome === 'resolved')
+    );
+    if (hasDisasterExpired && triggeredEvent?.category === 'blessing') {
+      const blessingAchievement = triggerSpecialAchievement(this.profile, 'A412');
+      // 成就奖励在下面统一处理
+    }
+
+    // 9. 获取今日记录用于成就判定
+    const today = new Date().toISOString().slice(0, 10);
+    const todayRecords = this.history.records.filter(r => {
+      const recordDate = new Date(r.timestamp).toISOString().slice(0, 10);
+      return recordDate === today;
+    });
+
+    // v2: 构建悬赏令更新上下文
+    const todayProducts = new Set<string>();
+    const todayQualities = new Set<MonsterQuality>();
+    for (const record of todayRecords) {
+      if (record.success) todayProducts.add(record.product);
+      if (record.monsterId && !record.escaped) {
+        const monster = getMonsterById(record.monsterId);
+        if (monster) todayQualities.add(monster.quality);
+      }
+    }
+    todayProducts.add(product);
+    if (capturedMonster) todayQualities.add(dropResult.monster.quality);
+
+    const bountyContext: BountyUpdateContext = {
+      commandSuccess: true,
+      product,
+      dropResult: capturedMonster ? dropResult : undefined,
+      encounterTriggered: encounter !== null,
+      encounterType: encounter?.type,
+      currentCombo: this.profile.currentCombo,
+      todayProducts,
+      todayQualities,
+    };
+
+    // v2: 更新悬赏令进度
+    const completedBounties = updateBountyProgress(this.profile, bountyContext);
+
+    // v2: 完成悬赏令可以化解灾厄事件
+    if (completedBounties.length > 0) {
+      resolveDisasterEvent(this.profile, 'complete_bounty');
+    }
+
+    // 10. 检查成就
+    const newAchievements = checkAchievements(this.profile, this.collection, todayRecords);
+
+    // 特殊成就：保底触发
+    if (dropResult.isPityTriggered) {
+      const pityAchievement = triggerSpecialAchievement(this.profile, 'A302');
+      if (pityAchievement) {
+        newAchievements.push(pityAchievement);
+      }
+    }
+
+    // 特殊成就：屡败屡战
+    if (this.profile.consecutiveFailures >= 10) {
+      const failAchievement = triggerSpecialAchievement(this.profile, 'A303');
+      if (failAchievement) {
+        newAchievements.push(failAchievement);
+      }
+    }
+
+    // v2 特殊成就：走火入魔后存活
+    if (triggeredEvent?.id === 'EV206' && this.profile.totalExp > 0) {
+      const madnessAchievement = triggerSpecialAchievement(this.profile, 'A408');
+      if (madnessAchievement) {
+        newAchievements.push(madnessAchievement);
+      }
+    }
+
+    // 成就修行值奖励
+    for (const achievement of newAchievements) {
+      this.profile.totalExp += achievement.expReward;
+    }
+    applyLevelUp(this.profile);
+
+    // 重置连续失败计数
+    this.profile.consecutiveFailures = 0;
+
+    // 11. 记录历史
+    const historyRecord: HistoryRecord = {
+      timestamp: Date.now(),
+      product,
+      commandHash,
+      success: true,
+      expGained: expResult.totalExp,
+      monsterId: dropResult.monster.id || undefined,
+      isShiny: dropResult.isShiny || undefined,
+      escaped: dropResult.escaped || undefined,
+      encounterId: encounter?.immortalId,
+      achievementIds: newAchievements.length > 0 ? newAchievements.map(a => a.id) : undefined,
+      eventId: triggeredEvent?.id,
+      completedBountyIds: completedBounties.length > 0 ? completedBounties.map(b => b.id) : undefined,
+    };
+    this.history.records.push(historyRecord);
+
+    // 12. 持久化
+    this.save();
+
+    // 13. 渲染输出
+    return this.renderOutput(
+      dropResult, expResult, levelUp, encounter, newAchievements,
+      completedBounties, triggeredEvent ?? null, eventResults
+    );
+  }
+
+  /**
+   * 更新图鉴
+   */
+  private updateCollection(monsterId: string, isShiny: boolean, commandHash: string): void {
+    const existingEntry = this.collection.entries.find(
+      e => e.monsterId === monsterId && e.isShiny === isShiny
+    );
+
+    if (existingEntry) {
+      existingEntry.captureCount += 1;
+    } else {
+      const newEntry: CollectionEntry = {
+        monsterId,
+        firstCapturedAt: Date.now(),
+        captureCount: 1,
+        isShiny,
+      };
+      this.collection.entries.push(newEntry);
+    }
+  }
+
+  /**
+   * 渲染完整输出（追加到 agent 回复末尾的 Markdown）
+   *
+   * v2: 新增悬赏令完成、随机事件、挑战结果的渲染
+   */
+  private renderOutput(
+    dropResult: DropResult,
+    expResult: any,
+    levelUp: any,
+    encounter: any,
+    newAchievements: Achievement[],
+    completedBounties: Bounty[],
+    triggeredEvent: RandomEvent | ChallengeEvent | null,
+    eventResults: Array<{ event: RandomEvent | ChallengeEvent; outcome: string }>
+  ): string {
+    const parts: string[] = [];
+
+    // 掉落结果（如果设置了静默普通掉落且未逃跑，则跳过）
+    const shouldShowDrop = dropResult.monster.id && !(
+      this.profile.settings.muteNormalDrops &&
+      dropResult.monster.quality === 'normal' &&
+      !dropResult.isNew &&
+      !dropResult.isShiny &&
+      !dropResult.escaped
+    );
+
+    if (shouldShowDrop) {
+      parts.push(renderDropResult(dropResult, expResult, this.collection));
+    }
+
+    // 升级通知
+    if (levelUp) {
+      parts.push(renderLevelUp(levelUp));
+    }
+
+    // 机缘事件
+    if (encounter) {
+      parts.push(renderEncounter(encounter));
+    }
+
+    // v2: 随机事件触发通知
+    if (triggeredEvent) {
+      parts.push(renderEventTrigger(triggeredEvent));
+    }
+
+    // v2: 挑战事件结果
+    for (const result of eventResults) {
+      if (result.event.category === 'challenge') {
+        if (result.outcome === 'success' || result.outcome === 'failure') {
+          parts.push(renderChallengeResult(
+            result.event as ChallengeEvent,
+            result.outcome === 'success'
+          ));
+        }
+      }
+      if (result.event.category === 'disaster' && result.outcome === 'resolved') {
+        parts.push(renderDisasterResolved(result.event));
+      }
+    }
+
+    // v2: 悬赏令完成通知
+    for (const bounty of completedBounties) {
+      parts.push(renderBountyComplete(bounty));
+    }
+
+    // 新成就
+    if (newAchievements.length > 0) {
+      parts.push(renderNewAchievements(newAchievements));
+    }
+
+    return parts.join('\n');
+  }
+
+  /**
+   * 持久化所有数据
+   */
+  private save(): void {
+    saveProfile(this.profile);
+    saveCollection(this.collection);
+    saveHistory(this.history);
+  }
+}
+
+// ============ 便捷导出 ============
+
+export { isGamificationCommand } from './commands.ts';
+export type { GamificationOutput } from './types.ts';

--- a/src/game-xiyou/level-system.ts
+++ b/src/game-xiyou/level-system.ts
@@ -1,0 +1,91 @@
+/**
+ * 等级判定与升级事件
+ *
+ * 根据累计修行值判定当前等级，检测升级事件。
+ */
+
+import type { UserProfile, LevelUpResult, LevelDefinition } from './types.ts';
+import { LEVEL_DEFINITIONS } from './types.ts';
+
+/**
+ * 根据累计修行值计算当前等级
+ */
+export function calculateLevel(totalExp: number): LevelDefinition {
+  let currentLevel = LEVEL_DEFINITIONS[0];
+  for (const levelDef of LEVEL_DEFINITIONS) {
+    if (totalExp >= levelDef.requiredExp) {
+      currentLevel = levelDef;
+    } else {
+      break;
+    }
+  }
+  return currentLevel;
+}
+
+/**
+ * 获取下一级的定义（如果已满级则返回 null）
+ */
+export function getNextLevel(currentLevel: number): LevelDefinition | null {
+  const nextIndex = LEVEL_DEFINITIONS.findIndex(l => l.level === currentLevel) + 1;
+  if (nextIndex >= LEVEL_DEFINITIONS.length) {
+    return null;
+  }
+  return LEVEL_DEFINITIONS[nextIndex];
+}
+
+/**
+ * 计算距离下一级还需要多少修行值
+ */
+export function getExpToNextLevel(totalExp: number): number | null {
+  const currentLevel = calculateLevel(totalExp);
+  const nextLevel = getNextLevel(currentLevel.level);
+  if (!nextLevel) {
+    return null; // 已满级
+  }
+  return nextLevel.requiredExp - totalExp;
+}
+
+/**
+ * 获取当前等级的进度百分比
+ */
+export function getLevelProgress(totalExp: number): number {
+  const currentLevel = calculateLevel(totalExp);
+  const nextLevel = getNextLevel(currentLevel.level);
+
+  if (!nextLevel) {
+    return 100; // 已满级
+  }
+
+  const levelRange = nextLevel.requiredExp - currentLevel.requiredExp;
+  const currentProgress = totalExp - currentLevel.requiredExp;
+  return Math.floor((currentProgress / levelRange) * 100);
+}
+
+/**
+ * 检查是否发生升级，返回升级结果
+ */
+export function checkLevelUp(profile: UserProfile, expGained: number): LevelUpResult | null {
+  const previousLevel = calculateLevel(profile.totalExp);
+  const newLevel = calculateLevel(profile.totalExp + expGained);
+
+  if (newLevel.level <= previousLevel.level) {
+    return null;
+  }
+
+  return {
+    previousLevel: previousLevel.level,
+    previousTitle: previousLevel.title,
+    newLevel: newLevel.level,
+    newTitle: newLevel.title,
+    unlockDescription: newLevel.unlockDescription,
+  };
+}
+
+/**
+ * 应用升级到 profile
+ */
+export function applyLevelUp(profile: UserProfile): void {
+  const levelDef = calculateLevel(profile.totalExp);
+  profile.level = levelDef.level;
+  profile.title = levelDef.title;
+}

--- a/src/game-xiyou/monster-pool.ts
+++ b/src/game-xiyou/monster-pool.ts
@@ -1,0 +1,180 @@
+/**
+ * 妖怪数据池
+ *
+ * 管理所有妖怪数据，提供按品质筛选、按产品关联加权等能力。
+ */
+
+import type { Monster, MonsterQuality } from './types.ts';
+import { UP_WEIGHT_MULTIPLIER, PRODUCT_WEIGHT_MULTIPLIER } from './types.ts';
+
+/**
+ * 妖怪数据（内联，避免运行时文件系统依赖）
+ */
+const allMonsters: Monster[] = [
+  // ⬜ 普通妖怪（20 只）
+  { id: "N001", name: "巡山小妖", quality: "normal", origin: "各山洞", relatedProduct: null, captureQuote: "大王叫我来巡山～" },
+  { id: "N002", name: "树精", quality: "normal", origin: "荆棘岭", relatedProduct: "contact", captureQuote: "落叶归根，不过如此。" },
+  { id: "N003", name: "草头神", quality: "normal", origin: "通天河畔", relatedProduct: "calendar", captureQuote: "时辰到了，该走了。" },
+  { id: "N004", name: "虾兵", quality: "normal", origin: "东海", relatedProduct: "chat", captureQuote: "龙宫不是你想来就能来的！" },
+  { id: "N005", name: "蟹将", quality: "normal", origin: "东海", relatedProduct: "chat", captureQuote: "横行霸道？那是我的专利。" },
+  { id: "N006", name: "山神", quality: "normal", origin: "各处", relatedProduct: "attendance", captureQuote: "此山是我开，此树是我栽。" },
+  { id: "N007", name: "土地公", quality: "normal", origin: "各处", relatedProduct: "contact", captureQuote: "大圣饶命，小神知无不言。" },
+  { id: "N008", name: "夜叉", quality: "normal", origin: "水府", relatedProduct: "ding", captureQuote: "水底的消息，最快。" },
+  { id: "N009", name: "狼妖", quality: "normal", origin: "黄风岭", relatedProduct: "todo", captureQuote: "待办事项？我只待吃人。" },
+  { id: "N010", name: "蛇妖", quality: "normal", origin: "蛇盘山", relatedProduct: "devdoc", captureQuote: "嘶——文档里藏着秘密。" },
+  { id: "N011", name: "鹿精", quality: "normal", origin: "比丘国", relatedProduct: "report", captureQuote: "今日份的鹿茸报告。" },
+  { id: "N012", name: "兔精", quality: "normal", origin: "天竺国", relatedProduct: "calendar", captureQuote: "月宫的日程，排得满满的。" },
+  { id: "N013", name: "鱼精", quality: "normal", origin: "通天河", relatedProduct: "aitable", captureQuote: "河底的账本，一条不差。" },
+  { id: "N014", name: "龟精", quality: "normal", origin: "通天河", relatedProduct: "todo", captureQuote: "慢是慢了点，但待办一定完成。" },
+  { id: "N015", name: "猪妖", quality: "normal", origin: "福陵山", relatedProduct: "report", captureQuote: "日报？让我先睡一觉再说。" },
+  { id: "N016", name: "鸡精", quality: "normal", origin: "毒敌山", relatedProduct: "attendance", captureQuote: "打鸣就是打卡，准时得很。" },
+  { id: "N017", name: "鼠精", quality: "normal", origin: "无底洞", relatedProduct: "aitable", captureQuote: "数据？我最擅长搬运了。" },
+  { id: "N018", name: "蝙蝠精", quality: "normal", origin: "黄花观", relatedProduct: "ding", captureQuote: "暗夜传信，无声无息。" },
+  { id: "N019", name: "石妖", quality: "normal", origin: "花果山", relatedProduct: "workbench", captureQuote: "石头里蹦出来的，不止猴子。" },
+  { id: "N020", name: "柳树精", quality: "normal", origin: "荆棘岭", relatedProduct: "approval", captureQuote: "柳条一挥，审批盖章。" },
+  // 🟢 精良妖怪（15 只）
+  { id: "R001", name: "黑风怪", quality: "fine", origin: "黑风山", relatedProduct: "workbench", captureQuote: "这袈裟，归我了！" },
+  { id: "R002", name: "黄风怪", quality: "fine", origin: "黄风岭", relatedProduct: "chat", captureQuote: "三昧神风，吹！" },
+  { id: "R003", name: "白骨精", quality: "fine", origin: "白虎岭", relatedProduct: "contact", captureQuote: "变化之术，通讯录里谁是谁？" },
+  { id: "R004", name: "银角大王", quality: "fine", origin: "平顶山", relatedProduct: "aitable", captureQuote: "紫金红葫芦，装！" },
+  { id: "R005", name: "金角大王", quality: "fine", origin: "平顶山", relatedProduct: "aitable", captureQuote: "幌金绳，捆！" },
+  { id: "R006", name: "红孩儿", quality: "fine", origin: "火云洞", relatedProduct: "ding", captureQuote: "三昧真火，DING！" },
+  { id: "R007", name: "鼍龙", quality: "fine", origin: "黑水河", relatedProduct: "approval", captureQuote: "我舅舅是西海龙王，审批通过！" },
+  { id: "R008", name: "蜘蛛精", quality: "fine", origin: "盘丝洞", relatedProduct: "todo", captureQuote: "七姐妹的待办，丝丝入扣。" },
+  { id: "R009", name: "蝎子精", quality: "fine", origin: "琵琶洞", relatedProduct: "attendance", captureQuote: "倒马毒桩，准时打卡。" },
+  { id: "R010", name: "六耳猕猴", quality: "fine", origin: "—", relatedProduct: null, captureQuote: "真假难辨，你猜我是谁？" },
+  { id: "R011", name: "奔波儿灞", quality: "fine", origin: "乱石山碧波潭", relatedProduct: "chat", captureQuote: "跑腿送信，我最在行。" },
+  { id: "R012", name: "灞波儿奔", quality: "fine", origin: "乱石山碧波潭", relatedProduct: "chat", captureQuote: "消息必达，使命必成。" },
+  { id: "R013", name: "独角兕大王", quality: "fine", origin: "金兜山", relatedProduct: "calendar", captureQuote: "金刚琢套住你的日程。" },
+  { id: "R014", name: "如意真仙", quality: "fine", origin: "解阳山", relatedProduct: "report", captureQuote: "落胎泉的日报，概不外传。" },
+  { id: "R015", name: "虎力大仙", quality: "fine", origin: "车迟国", relatedProduct: "approval", captureQuote: "国师审批，一言九鼎。" },
+  // 🔵 稀有妖怪（12 只）
+  { id: "S001", name: "黄袍怪", quality: "rare", origin: "碗子山", relatedProduct: "report", captureQuote: "百花羞的日报，我替她写了。" },
+  { id: "S002", name: "金翅大鹏", quality: "rare", origin: "狮驼岭", relatedProduct: "calendar", captureQuote: "翅膀一扇，九万里。日程？不存在的。" },
+  { id: "S003", name: "青牛精", quality: "rare", origin: "金兜山", relatedProduct: "aitable", captureQuote: "金刚琢，套住你的表格。" },
+  { id: "S004", name: "铁扇公主", quality: "rare", origin: "翠云山", relatedProduct: "approval", captureQuote: "芭蕉扇一扇，审批全灭。" },
+  { id: "S005", name: "牛魔王", quality: "rare", origin: "积雷山", relatedProduct: "workbench", captureQuote: "我乃平天大圣，工作台归我管。" },
+  { id: "S006", name: "白鹿精", quality: "rare", origin: "比丘国", relatedProduct: "attendance", captureQuote: "一千一百一十一个小儿的考勤。" },
+  { id: "S007", name: "蜈蚣精", quality: "rare", origin: "黄花观", relatedProduct: "todo", captureQuote: "千目待办，一个不漏。" },
+  { id: "S008", name: "玉兔精", quality: "rare", origin: "天竺国", relatedProduct: "calendar", captureQuote: "广寒宫的排班表，我说了算。" },
+  { id: "S009", name: "金鼻白毛老鼠精", quality: "rare", origin: "无底洞", relatedProduct: "contact", captureQuote: "无底洞的通讯录，深不见底。" },
+  { id: "S010", name: "鹿力大仙", quality: "rare", origin: "车迟国", relatedProduct: "ding", captureQuote: "呼风唤雨，DING 声如雷。" },
+  { id: "S011", name: "羊力大仙", quality: "rare", origin: "车迟国", relatedProduct: "devdoc", captureQuote: "油锅里的文档，捞出来就是。" },
+  { id: "S012", name: "荆棘岭十八公", quality: "rare", origin: "荆棘岭", relatedProduct: "chat", captureQuote: "松竹梅桂，群聊四友。" },
+  // 🟣 史诗妖怪（10 只）
+  { id: "E001", name: "黄眉大王", quality: "epic", origin: "弥勒佛的童子", relatedProduct: "approval", captureQuote: "人种袋，把你的审批全装进来。" },
+  { id: "E002", name: "大鹏金翅明王", quality: "epic", origin: "如来舅舅", relatedProduct: "workbench", captureQuote: "狮驼国的工作台，三界最大。" },
+  { id: "E003", name: "九灵元圣", quality: "epic", origin: "太乙天尊坐骑", relatedProduct: "aitable", captureQuote: "九个头，九张表，哪个都不能少。" },
+  { id: "E004", name: "赛太岁", quality: "epic", origin: "观音坐骑金毛犼", relatedProduct: "attendance", captureQuote: "紫金铃一摇，全员到齐。" },
+  { id: "E005", name: "青狮精", quality: "epic", origin: "文殊菩萨坐骑", relatedProduct: "chat", captureQuote: "狮子吼，群消息已送达。" },
+  { id: "E006", name: "白象精", quality: "epic", origin: "普贤菩萨坐骑", relatedProduct: "todo", captureQuote: "长鼻一卷，待办清空。" },
+  { id: "E007", name: "蠹虫精", quality: "epic", origin: "比丘国国丈", relatedProduct: "report", captureQuote: "一千一百一十一份日报，全在这了。" },
+  { id: "E008", name: "金鱼精", quality: "epic", origin: "观音莲花池", relatedProduct: "calendar", captureQuote: "通天河的日程，年年祭祀。" },
+  { id: "E009", name: "蟒蛇精", quality: "epic", origin: "七绝山", relatedProduct: "devdoc", captureQuote: "七绝山的文档，毒气弥漫。" },
+  { id: "E010", name: "灵感大王", quality: "epic", origin: "通天河", relatedProduct: "ding", captureQuote: "金鱼一跃，DING 达四海。" },
+  // 🟡 传说妖怪（8 只）
+  { id: "L001", name: "混世魔王", quality: "legendary", origin: "花果山第一战", relatedProduct: null, captureQuote: "水帘洞，从此姓孙。" },
+  { id: "L002", name: "牛魔王（魔化）", quality: "legendary", origin: "大力牛魔王本相", relatedProduct: null, captureQuote: "平天大圣，不服来战！" },
+  { id: "L003", name: "九头虫", quality: "legendary", origin: "碧波潭万圣龙王驸马", relatedProduct: null, captureQuote: "九颗头颅，九种权限。" },
+  { id: "L004", name: "百眼魔君", quality: "legendary", origin: "蜈蚣精本相", relatedProduct: null, captureQuote: "千目金光，洞察一切数据。" },
+  { id: "L005", name: "大鹏金翅（本相）", quality: "legendary", origin: "遮天蔽日", relatedProduct: null, captureQuote: "三界之大，不过我翅膀之下。" },
+  { id: "L006", name: "孙悟空（石猴）", quality: "legendary", origin: "花果山水帘洞", relatedProduct: null, captureQuote: "俺老孙来也！" },
+  { id: "L007", name: "六耳猕猴（真身）", quality: "legendary", origin: "混沌之中", relatedProduct: null, captureQuote: "天地间第二个齐天大圣。" },
+  { id: "L008", name: "白骨夫人（真身）", quality: "legendary", origin: "白虎岭深处", relatedProduct: null, captureQuote: "三打不死，方显真身。" },
+];
+
+/**
+ * 获取所有妖怪
+ */
+export function getAllMonsters(): Monster[] {
+  return allMonsters;
+}
+
+/**
+ * 获取指定品质的妖怪列表
+ */
+export function getMonstersByQuality(quality: MonsterQuality): Monster[] {
+  return allMonsters.filter(m => m.quality === quality);
+}
+
+/**
+ * 根据 ID 查找妖怪
+ */
+export function getMonsterById(monsterId: string): Monster | undefined {
+  return allMonsters.find(m => m.id === monsterId);
+}
+
+/**
+ * 获取所有妖怪的总数（不含闪光变体）
+ */
+export function getTotalMonsterCount(): number {
+  return allMonsters.length;
+}
+
+/**
+ * 获取本周 UP 妖怪
+ *
+ * 按周数轮换，从史诗和传说池中选择
+ */
+export function getWeeklyUpMonster(): Monster | null {
+  const upPool = allMonsters.filter(
+    m => m.quality === 'epic' || m.quality === 'legendary'
+  );
+  if (upPool.length === 0) return null;
+
+  const weekNumber = Math.floor(Date.now() / (7 * 24 * 60 * 60 * 1000));
+  const index = weekNumber % upPool.length;
+  return upPool[index];
+}
+
+/**
+ * 带权重的随机选择妖怪
+ *
+ * @param pool - 候选妖怪池
+ * @param product - 当前 dws 产品（关联产品权重 ×3）
+ * @param upMonster - 本周 UP 妖怪（权重 ×5）
+ * @param randomValue - 随机数 [0, 1)
+ */
+export function weightedRandomSelect(
+  pool: Monster[],
+  product: string | null,
+  upMonster: Monster | null,
+  randomValue: number
+): Monster {
+  if (pool.length === 0) {
+    throw new Error('Monster pool is empty');
+  }
+  if (pool.length === 1) {
+    return pool[0];
+  }
+
+  // 计算每只妖怪的权重
+  const weights = pool.map(monster => {
+    let weight = 1;
+
+    // 产品关联加权
+    if (product && monster.relatedProduct === product) {
+      weight *= PRODUCT_WEIGHT_MULTIPLIER;
+    }
+
+    // UP 池加权
+    if (upMonster && monster.id === upMonster.id) {
+      weight *= UP_WEIGHT_MULTIPLIER;
+    }
+
+    return weight;
+  });
+
+  // 加权随机选择
+  const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+  let target = randomValue * totalWeight;
+
+  for (let i = 0; i < pool.length; i++) {
+    target -= weights[i];
+    if (target <= 0) {
+      return pool[i];
+    }
+  }
+
+  return pool[pool.length - 1];
+}

--- a/src/game-xiyou/pity-counter.ts
+++ b/src/game-xiyou/pity-counter.ts
@@ -1,0 +1,114 @@
+/**
+ * 保底计数器
+ *
+ * 借鉴 Gacha 游戏的保底设计，防止"非酋"体验过差。
+ * v2: 保底阈值全面上调 + 软保底机制（接近硬保底时概率逐步提升）。
+ * 保底计数器在对应品质或更高品质掉落后重置。
+ */
+
+import type { PityCounters, MonsterQuality } from './types.ts';
+import {
+  PITY_THRESHOLDS, QUALITY_ORDER,
+  SOFT_PITY_START, SOFT_PITY_RATE_PER_STEP,
+} from './types.ts';
+
+/**
+ * 检查是否触发硬保底，返回应强制掉落的品质（如果有）
+ */
+export function checkPityTrigger(counters: PityCounters): MonsterQuality | null {
+  if (counters.totalDropsWithoutShiny >= PITY_THRESHOLDS.shiny) {
+    return 'shiny';
+  }
+  if (counters.sinceLastLegendary >= PITY_THRESHOLDS.legendary) {
+    return 'legendary';
+  }
+  if (counters.sinceLastEpic >= PITY_THRESHOLDS.epic) {
+    return 'epic';
+  }
+  if (counters.sinceLastRare >= PITY_THRESHOLDS.rare) {
+    return 'rare';
+  }
+  return null;
+}
+
+/**
+ * v2: 计算软保底额外概率加成
+ *
+ * 在接近硬保底阈值时，对应品质的掉落概率逐步提升，
+ * 避免"临门一脚"的漫长等待。
+ *
+ * @returns 各品质的额外概率加成 { rare: 0.06, epic: 0, ... }
+ */
+export function getSoftPityBonuses(counters: PityCounters): Partial<Record<MonsterQuality, number>> {
+  const bonuses: Partial<Record<MonsterQuality, number>> = {};
+
+  // 稀有软保底：第 20 次起，每次额外 +3%
+  if (counters.sinceLastRare >= SOFT_PITY_START.rare) {
+    const steps = counters.sinceLastRare - SOFT_PITY_START.rare;
+    bonuses.rare = steps * SOFT_PITY_RATE_PER_STEP.rare;
+  }
+
+  // 史诗软保底：第 60 次起，每次额外 +2%
+  if (counters.sinceLastEpic >= SOFT_PITY_START.epic) {
+    const steps = counters.sinceLastEpic - SOFT_PITY_START.epic;
+    bonuses.epic = steps * SOFT_PITY_RATE_PER_STEP.epic;
+  }
+
+  // 传说软保底：第 120 次起，每次额外 +1%
+  if (counters.sinceLastLegendary >= SOFT_PITY_START.legendary) {
+    const steps = counters.sinceLastLegendary - SOFT_PITY_START.legendary;
+    bonuses.legendary = steps * SOFT_PITY_RATE_PER_STEP.legendary;
+  }
+
+  // 闪光软保底：第 600 次起，每次额外 +0.05%
+  if (counters.totalDropsWithoutShiny >= SOFT_PITY_START.shiny) {
+    const steps = counters.totalDropsWithoutShiny - SOFT_PITY_START.shiny;
+    bonuses.shiny = steps * SOFT_PITY_RATE_PER_STEP.shiny;
+  }
+
+  return bonuses;
+}
+
+/**
+ * 更新保底计数器
+ *
+ * 掉落后递增所有计数器，然后重置对应品质及以下的计数器
+ */
+export function updatePityCounters(counters: PityCounters, droppedQuality: MonsterQuality, isShiny: boolean): void {
+  // 递增所有计数器
+  counters.sinceLastRare += 1;
+  counters.sinceLastEpic += 1;
+  counters.sinceLastLegendary += 1;
+  counters.totalDropsWithoutShiny += 1;
+
+  // 根据掉落品质重置对应计数器
+  const qualityIndex = QUALITY_ORDER.indexOf(droppedQuality);
+
+  if (isShiny || droppedQuality === 'shiny') {
+    counters.totalDropsWithoutShiny = 0;
+  }
+
+  if (qualityIndex >= QUALITY_ORDER.indexOf('legendary')) {
+    counters.sinceLastLegendary = 0;
+  }
+
+  if (qualityIndex >= QUALITY_ORDER.indexOf('epic')) {
+    counters.sinceLastEpic = 0;
+  }
+
+  if (qualityIndex >= QUALITY_ORDER.indexOf('rare')) {
+    counters.sinceLastRare = 0;
+  }
+}
+
+/**
+ * 应用保底减半 buff（观音菩萨收徒效果）
+ */
+export function applyPityReduction(counters: PityCounters, reductionFactor: number): PityCounters {
+  return {
+    sinceLastRare: Math.floor(counters.sinceLastRare * reductionFactor),
+    sinceLastEpic: Math.floor(counters.sinceLastEpic * reductionFactor),
+    sinceLastLegendary: Math.floor(counters.sinceLastLegendary * reductionFactor),
+    totalDropsWithoutShiny: Math.floor(counters.totalDropsWithoutShiny * reductionFactor),
+  };
+}

--- a/src/game-xiyou/random-event-engine.ts
+++ b/src/game-xiyou/random-event-engine.ts
@@ -1,0 +1,648 @@
+/**
+ * 随机事件系统 (v2)
+ *
+ * 低概率触发的特殊剧情事件，打破日常节奏，制造惊喜和紧张感。
+ * 事件分为三类：增益(8%)、挑战(5%)、灾厄(3%)。
+ * 独立于掉落和机缘触发，同一事件 24 小时内不重复。
+ */
+
+import { randomBytes } from 'crypto';
+import type {
+  RandomEvent, ChallengeEvent, EventCategory, EventEffect, EventDuration,
+  EventResolution, ActiveEventState, EventHistoryEntry, EventStats,
+  ChallengeCondition, ChallengeProgress, EventReward, EventPenalty,
+  UserProfile, MonsterQuality,
+} from './types.ts';
+
+function cryptoRandom(): number {
+  const buffer = randomBytes(4);
+  return buffer.readUInt32BE(0) / 0xFFFFFFFF;
+}
+
+// ============ 事件数据定义 ============
+
+const BLESSING_EVENTS: RandomEvent[] = [
+  {
+    id: 'EV001', name: '蟠桃大会', category: 'blessing', triggerRate: 0.015,
+    description: '接下来 10 次操作修行值 ×3',
+    flavorText: '王母娘娘设宴，蟠桃大会开席！修行值大涨！',
+    effect: { type: 'exp_multiplier', value: 3, targetCount: 10 },
+    duration: { type: 'operation_count', total: 10, remaining: 10 },
+  },
+  {
+    id: 'EV002', name: '月光宝盒', category: 'blessing', triggerRate: 0.010,
+    description: '下一次掉落品质强制提升一级',
+    flavorText: '紫霞仙子留下的月光宝盒，时光倒流，命运改写！',
+    effect: { type: 'quality_boost', value: 1 },
+    duration: { type: 'drop_count', total: 1, remaining: 1 },
+  },
+  {
+    id: 'EV003', name: '龙宫寻宝', category: 'blessing', triggerRate: 0.015,
+    description: '立即额外触发一次掉落',
+    flavorText: '东海龙宫大门洞开，宝物任你挑选！',
+    effect: { type: 'extra_drop', value: 1 },
+    duration: { type: 'instant', total: 1, remaining: 0 },
+  },
+  {
+    id: 'EV004', name: '仙人指路', category: 'blessing', triggerRate: 0.020,
+    description: '下 5 次操作的产品关联权重 ×5',
+    flavorText: '南极仙翁路过，指了指前方："那边有好东西。"',
+    effect: { type: 'product_weight', value: 5, targetCount: 5 },
+    duration: { type: 'operation_count', total: 5, remaining: 5 },
+  },
+  {
+    id: 'EV005', name: '蟠桃熟了', category: 'blessing', triggerRate: 0.010,
+    description: '立即获得 30-100 随机修行值',
+    flavorText: '三千年一熟的蟠桃，今日恰好落入你手。',
+    effect: { type: 'exp_flat', value: 0 }, // value 在触发时随机
+    duration: { type: 'instant', total: 1, remaining: 0 },
+  },
+  {
+    id: 'EV006', name: '土地公的宝箱', category: 'blessing', triggerRate: 0.010,
+    description: '随机获得一件一次性法宝',
+    flavorText: '土地公从地下冒出来："大圣，这个给你！"',
+    effect: { type: 'treasure_grant', value: 1 },
+    duration: { type: 'instant', total: 1, remaining: 0 },
+  },
+];
+
+const CHALLENGE_EVENTS_DATA: Array<Omit<ChallengeEvent, 'progress'>> = [
+  {
+    id: 'EV101', name: '妖王入侵', category: 'challenge', triggerRate: 0.015,
+    description: '接下来连续成功 5 次',
+    flavorText: '一股强大的妖气从远方袭来——"哈哈哈，齐天大圣不过如此！"',
+    effect: { type: 'exp_flat', value: 0 },
+    duration: { type: 'operation_count', total: 8, remaining: 8 },
+    challengeCondition: { type: 'consecutive_success', target: 5, current: 0 },
+    successReward: { exp: 80, pityBonus: 5 },
+    failurePenalty: { expLoss: 30 },
+    operationLimit: 8,
+  },
+  {
+    id: 'EV102', name: '火焰山', category: 'challenge', triggerRate: 0.010,
+    description: '接下来 10 次操作中使用 ≥3 种不同产品',
+    flavorText: '火焰山烈焰滔天，唯有多方尝试方能通过！',
+    effect: { type: 'exp_flat', value: 0 },
+    duration: { type: 'operation_count', total: 10, remaining: 10 },
+    challengeCondition: { type: 'product_variety', target: 3, current: 0 },
+    successReward: { exp: 60, escapeRateMod: -0.05 },
+    failurePenalty: { expLoss: 0, comboReset: true },
+    operationLimit: 10,
+  },
+  {
+    id: 'EV103', name: '通天河阻路', category: 'challenge', triggerRate: 0.010,
+    description: '接下来连续成功 3 次且收服 ≥1 只妖怪',
+    flavorText: '通天河水势汹涌，需要勇气和实力才能渡过！',
+    effect: { type: 'exp_flat', value: 0 },
+    duration: { type: 'operation_count', total: 5, remaining: 5 },
+    challengeCondition: { type: 'consecutive_success', target: 3, current: 0 },
+    successReward: { exp: 100, extraDrop: true },
+    failurePenalty: { expLoss: 20 },
+    operationLimit: 5,
+  },
+  {
+    id: 'EV104', name: '真假美猴王', category: 'challenge', triggerRate: 0.005,
+    description: '接下来 3 次掉落中选出"真"的那只',
+    flavorText: '六耳猕猴现身，真假难辨！',
+    effect: { type: 'exp_flat', value: 0 },
+    duration: { type: 'drop_count', total: 3, remaining: 3 },
+    challengeCondition: { type: 'pick_correct', target: 1, current: 0 },
+    successReward: { exp: 100 },
+    failurePenalty: { expLoss: 0 },
+    operationLimit: 3,
+  },
+  {
+    id: 'EV105', name: '盘丝洞迷阵', category: 'challenge', triggerRate: 0.005,
+    description: '接下来 5 次操作必须使用 5 种不同产品',
+    flavorText: '蜘蛛精的丝网密布，每一步都不能重复！',
+    effect: { type: 'exp_flat', value: 0 },
+    duration: { type: 'operation_count', total: 5, remaining: 5 },
+    challengeCondition: { type: 'product_variety', target: 5, current: 0 },
+    successReward: { exp: 120, monster: { qualityMin: 'rare' } },
+    failurePenalty: { expLoss: 50 },
+    operationLimit: 5,
+  },
+  {
+    id: 'EV106', name: '比丘国救童', category: 'challenge', triggerRate: 0.005,
+    description: '接下来 8 次操作中成功率 ≥80%',
+    flavorText: '比丘国的孩子们需要你的帮助！',
+    effect: { type: 'exp_flat', value: 0 },
+    duration: { type: 'operation_count', total: 8, remaining: 8 },
+    challengeCondition: { type: 'success_rate', target: 7, current: 0 },
+    successReward: { exp: 150, treasureFragment: 'random' },
+    failurePenalty: { expLoss: 40 },
+    operationLimit: 8,
+  },
+];
+
+const DISASTER_EVENTS: RandomEvent[] = [
+  {
+    id: 'EV201', name: '黑风来袭', category: 'disaster', triggerRate: 0.010,
+    description: '接下来 5 次掉落逃跑率 +20%',
+    flavorText: '黑风山的妖气蔓延而来——"嘿嘿嘿，让你的妖怪都跑光！"',
+    effect: { type: 'escape_rate_mod', value: 0.20 },
+    duration: { type: 'drop_count', total: 5, remaining: 5 },
+    resolution: { type: 'consecutive_success', count: 3, description: '连续成功 3 次可提前解除' },
+  },
+  {
+    id: 'EV202', name: '金蝉脱壳', category: 'disaster', triggerRate: 0.005,
+    description: '随机一只已收服的精良妖怪逃跑',
+    flavorText: '一阵妖风吹过，你的妖怪图鉴闪了一下……',
+    effect: { type: 'monster_escape', value: 1 },
+    duration: { type: 'instant', total: 1, remaining: 0 },
+  },
+  {
+    id: 'EV203', name: '妖雾弥漫', category: 'disaster', triggerRate: 0.008,
+    description: '接下来 3 次掉落品质上限降为精良',
+    flavorText: '浓雾笼罩，视线模糊，只能看到近处的小妖……',
+    effect: { type: 'quality_cap', value: 1 }, // 1 = fine
+    duration: { type: 'drop_count', total: 3, remaining: 3 },
+    resolution: { type: 'use_treasure', treasureId: 'zhaoyaojing', description: '使用法宝"照妖镜"可立即解除' },
+  },
+  {
+    id: 'EV204', name: '紧箍咒发作', category: 'disaster', triggerRate: 0.004,
+    description: '接下来 5 次操作修行值减半',
+    flavorText: '头痛欲裂！唐僧又念紧箍咒了！',
+    effect: { type: 'exp_halve', value: 0.5 },
+    duration: { type: 'operation_count', total: 5, remaining: 5 },
+    resolution: { type: 'complete_bounty', description: '完成 1 张悬赏令可提前解除' },
+  },
+  {
+    id: 'EV205', name: '五行山镇压', category: 'disaster', triggerRate: 0.002,
+    description: '连击归零 + 接下来 3 次操作无掉落',
+    flavorText: '五行山从天而降，压得你动弹不得！',
+    effect: { type: 'no_drop', value: 3 },
+    duration: { type: 'operation_count', total: 3, remaining: 3 },
+    resolution: { type: 'trigger_encounter', description: '触发 1 次神仙机缘可提前解除' },
+  },
+  {
+    id: 'EV206', name: '走火入魔', category: 'disaster', triggerRate: 0.001,
+    description: '修行值 -100 + 保底计数器全部 -10',
+    flavorText: '修炼走火入魔，功力大损！',
+    effect: { type: 'exp_loss', value: 100 },
+    duration: { type: 'instant', total: 1, remaining: 0 },
+  },
+];
+
+// ============ 核心逻辑 ============
+
+/**
+ * 创建默认的活跃事件状态
+ */
+export function createDefaultActiveEventState(): ActiveEventState {
+  return {
+    currentEvents: [],
+    activeChallenge: null,
+    lastEventTriggerTime: {},
+  };
+}
+
+/**
+ * 创建默认的事件统计
+ */
+export function createDefaultEventStats(): EventStats {
+  return {
+    totalTriggered: 0,
+    challengesCompleted: 0,
+    challengesFailed: 0,
+    disastersResolved: 0,
+  };
+}
+
+/**
+ * 检查并触发随机事件
+ *
+ * @returns 触发的事件，或 null
+ */
+export function checkRandomEvent(profile: UserProfile): RandomEvent | ChallengeEvent | null {
+  const now = Date.now();
+  const oneDayMs = 24 * 60 * 60 * 1000;
+
+  // 收集所有候选事件
+  const candidates: Array<RandomEvent | Omit<ChallengeEvent, 'progress'>> = [
+    ...BLESSING_EVENTS,
+    ...CHALLENGE_EVENTS_DATA,
+    ...DISASTER_EVENTS,
+  ];
+
+  for (const candidate of candidates) {
+    // 24 小时内不重复
+    const lastTrigger = profile.activeEvents.lastEventTriggerTime[candidate.id] ?? 0;
+    if (now - lastTrigger < oneDayMs) continue;
+
+    // 挑战事件：同时最多 1 个进行中
+    if (candidate.category === 'challenge' && profile.activeEvents.activeChallenge) continue;
+
+    // 概率判定
+    if (cryptoRandom() < candidate.triggerRate) {
+      profile.activeEvents.lastEventTriggerTime[candidate.id] = now;
+      profile.eventStats.totalTriggered += 1;
+
+      // 实例化事件
+      const event = instantiateEvent(candidate, profile);
+
+      // 添加到活跃事件
+      if (event.category === 'challenge') {
+        profile.activeEvents.activeChallenge = event as ChallengeEvent;
+      } else if (event.duration.type !== 'instant') {
+        profile.activeEvents.currentEvents.push(event);
+      }
+
+      // 记录历史
+      profile.eventHistory.push({
+        eventId: event.id,
+        triggeredAt: now,
+      });
+
+      return event;
+    }
+  }
+
+  return null;
+}
+
+/** 一次性法宝 ID 池（用于 EV006 土地公的宝箱） */
+const CONSUMABLE_TREASURE_IDS = ['pantao', 'renshenguo'];
+
+/**
+ * 实例化事件（处理随机值、即时效果等）
+ *
+ * 即时事件的效果在此函数中直接应用到 profile。
+ * 持续性事件仅初始化状态，效果由 tickActiveEvents / 查询函数处理。
+ */
+function instantiateEvent(
+  template: RandomEvent | Omit<ChallengeEvent, 'progress'>,
+  profile: UserProfile
+): RandomEvent | ChallengeEvent {
+  const event: RandomEvent | ChallengeEvent = JSON.parse(JSON.stringify(template));
+
+  switch (event.id) {
+    // ---- 增益即时事件 ----
+
+    case 'EV005': {
+      // 蟠桃熟了：随机 30-100 修行值，立即发放
+      const expGain = Math.floor(30 + cryptoRandom() * 71);
+      event.effect.value = expGain;
+      profile.totalExp += expGain;
+      break;
+    }
+
+    case 'EV006': {
+      // 土地公的宝箱：随机赐予一件一次性法宝
+      const treasureId = CONSUMABLE_TREASURE_IDS[
+        Math.floor(cryptoRandom() * CONSUMABLE_TREASURE_IDS.length)
+      ];
+      event.effect.value = 1;
+      // 添加法宝到背包（如果已有则跳过，不重复添加）
+      if (!profile.treasures.includes(treasureId)) {
+        profile.treasures.push(treasureId);
+      }
+      // 将赐予的法宝 ID 记录在 description 中供渲染使用
+      event.description = `获得了一次性法宝：${treasureId === 'pantao' ? '蟠桃' : '人参果'}`;
+      break;
+    }
+
+    // EV003 龙宫寻宝：额外掉落标记，由主引擎 (index.ts) 在 checkRandomEvent 返回后检查
+    // event.effect.type === 'extra_drop' 时触发额外一次 executeDrop
+
+    // ---- 灾厄即时事件 ----
+
+    case 'EV202': {
+      // 金蝉脱壳：随机移除一只已收服的精良妖怪
+      // 实际的图鉴移除由主引擎处理（需要访问 collection），
+      // 这里标记 effect.value 为需要移除的品质等级（1 = fine）
+      event.effect.value = 1;
+      break;
+    }
+
+    case 'EV205': {
+      // 五行山镇压：连击归零 + 3 次无掉落
+      profile.currentCombo = 0;
+      break;
+    }
+
+    case 'EV206': {
+      // 走火入魔：修行值 -100 + 保底计数器全部 -10
+      profile.totalExp = Math.max(0, profile.totalExp - 100);
+      profile.pityCounters.sinceLastRare = Math.max(0, profile.pityCounters.sinceLastRare - 10);
+      profile.pityCounters.sinceLastEpic = Math.max(0, profile.pityCounters.sinceLastEpic - 10);
+      profile.pityCounters.sinceLastLegendary = Math.max(0, profile.pityCounters.sinceLastLegendary - 10);
+      profile.pityCounters.totalDropsWithoutShiny = Math.max(0, profile.pityCounters.totalDropsWithoutShiny - 10);
+      break;
+    }
+  }
+
+  // 挑战事件：初始化 progress 和 usedProducts 追踪
+  if (event.category === 'challenge') {
+    const challengeEvent = event as ChallengeEvent;
+    challengeEvent.progress = {
+      operationsUsed: 0,
+      operationLimit: challengeEvent.operationLimit,
+      conditionMet: false,
+      usedProducts: [],
+    };
+  }
+
+  return event;
+}
+
+/**
+ * 每次操作后更新活跃事件的持续时间和状态
+ *
+ * @returns 本次过期/完成的事件列表
+ */
+export function tickActiveEvents(
+  profile: UserProfile,
+  operationSuccess: boolean,
+  product: string,
+  capturedMonster: boolean
+): ExpiredEventResult[] {
+  const results: ExpiredEventResult[] = [];
+
+  // 更新持续性事件
+  const remainingEvents: RandomEvent[] = [];
+  for (const event of profile.activeEvents.currentEvents) {
+    if (event.duration.type === 'operation_count') {
+      event.duration.remaining -= 1;
+    }
+    // drop_count 类型在掉落时递减（由 drop-engine 调用 tickDropEvent）
+
+    // 检查灾厄事件的化解条件
+    if (event.category === 'disaster' && event.resolution) {
+      if (checkResolution(event.resolution, profile, operationSuccess)) {
+        results.push({ event, outcome: 'resolved' });
+        profile.eventStats.disastersResolved += 1;
+        updateEventHistory(profile, event.id, 'resolved');
+        continue;
+      }
+    }
+
+    if (event.duration.remaining <= 0) {
+      results.push({ event, outcome: 'expired' });
+      updateEventHistory(profile, event.id, 'expired');
+    } else {
+      remainingEvents.push(event);
+    }
+  }
+  profile.activeEvents.currentEvents = remainingEvents;
+
+  // 更新挑战事件
+  const challenge = profile.activeEvents.activeChallenge;
+  if (challenge) {
+    challenge.progress.operationsUsed += 1;
+    challenge.duration.remaining -= 1;
+
+    // 更新挑战条件进度
+    updateChallengeProgress(challenge, operationSuccess, product, capturedMonster);
+
+    // 检查挑战是否完成
+    if (challenge.progress.conditionMet) {
+      results.push({ event: challenge, outcome: 'success' });
+      applyChallengeReward(profile, challenge);
+      profile.eventStats.challengesCompleted += 1;
+      updateEventHistory(profile, challenge.id, 'success');
+      profile.activeEvents.activeChallenge = null;
+    } else if (challenge.progress.operationsUsed >= challenge.progress.operationLimit) {
+      results.push({ event: challenge, outcome: 'failure' });
+      applyChallengePenalty(profile, challenge);
+      profile.eventStats.challengesFailed += 1;
+      updateEventHistory(profile, challenge.id, 'failure');
+      profile.activeEvents.activeChallenge = null;
+    }
+  }
+
+  return results;
+}
+
+export interface ExpiredEventResult {
+  event: RandomEvent | ChallengeEvent;
+  outcome: 'expired' | 'resolved' | 'success' | 'failure';
+}
+
+/**
+ * 掉落时递减 drop_count 类型事件的剩余次数
+ */
+export function tickDropEvents(profile: UserProfile): void {
+  for (const event of profile.activeEvents.currentEvents) {
+    if (event.duration.type === 'drop_count') {
+      event.duration.remaining -= 1;
+    }
+  }
+}
+
+// ============ 事件效果查询 ============
+
+/**
+ * 获取当前活跃的修行值倍率修正
+ */
+export function getActiveExpMultiplier(profile: UserProfile): number {
+  let multiplier = 1;
+  for (const event of profile.activeEvents.currentEvents) {
+    if (event.effect.type === 'exp_multiplier') {
+      multiplier *= event.effect.value;
+    }
+    if (event.effect.type === 'exp_halve') {
+      multiplier *= event.effect.value;
+    }
+  }
+  return multiplier;
+}
+
+/**
+ * 检查是否有品质提升事件
+ */
+export function getQualityBoost(profile: UserProfile): number {
+  for (const event of profile.activeEvents.currentEvents) {
+    if (event.effect.type === 'quality_boost' && event.duration.remaining > 0) {
+      return event.effect.value;
+    }
+  }
+  return 0;
+}
+
+/**
+ * 检查是否有品质上限事件
+ */
+export function getQualityCap(profile: UserProfile): MonsterQuality | null {
+  for (const event of profile.activeEvents.currentEvents) {
+    if (event.effect.type === 'quality_cap' && event.duration.remaining > 0) {
+      return 'fine'; // quality_cap value=1 表示上限为 fine
+    }
+  }
+  return null;
+}
+
+/**
+ * 检查是否有禁止掉落事件
+ */
+export function isDropSuppressed(profile: UserProfile): boolean {
+  return profile.activeEvents.currentEvents.some(
+    e => e.effect.type === 'no_drop' && e.duration.remaining > 0
+  );
+}
+
+/**
+ * 获取产品关联权重倍率修正
+ */
+export function getProductWeightBoost(profile: UserProfile): number {
+  for (const event of profile.activeEvents.currentEvents) {
+    if (event.effect.type === 'product_weight' && event.duration.remaining > 0) {
+      return event.effect.value;
+    }
+  }
+  return 1;
+}
+
+// ============ 内部辅助 ============
+
+function checkResolution(
+  resolution: EventResolution,
+  profile: UserProfile,
+  operationSuccess: boolean
+): boolean {
+  switch (resolution.type) {
+    case 'consecutive_success':
+      return profile.currentCombo >= (resolution.count ?? 3);
+
+    case 'use_treasure':
+      // 由 commands.ts 在使用法宝时检查并调用 resolveDisasterEvent
+      return false;
+
+    case 'complete_bounty':
+      // 由 bounty-system 在完成悬赏时检查
+      return false;
+
+    case 'trigger_encounter':
+      // 由 encounter-system 在触发机缘时检查
+      return false;
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * 手动解除灾厄事件（由外部系统调用）
+ */
+export function resolveDisasterEvent(
+  profile: UserProfile,
+  resolutionType: EventResolution['type']
+): RandomEvent | null {
+  const index = profile.activeEvents.currentEvents.findIndex(
+    e => e.category === 'disaster' && e.resolution?.type === resolutionType
+  );
+
+  if (index === -1) return null;
+
+  const event = profile.activeEvents.currentEvents[index];
+  profile.activeEvents.currentEvents.splice(index, 1);
+  profile.eventStats.disastersResolved += 1;
+  updateEventHistory(profile, event.id, 'resolved');
+  return event;
+}
+
+function updateChallengeProgress(
+  challenge: ChallengeEvent,
+  operationSuccess: boolean,
+  product: string,
+  capturedMonster: boolean
+): void {
+  const usedProducts = challenge.progress.usedProducts ?? [];
+
+  switch (challenge.challengeCondition.type) {
+    case 'consecutive_success':
+      if (operationSuccess) {
+        challenge.challengeCondition.current += 1;
+      } else {
+        challenge.challengeCondition.current = 0;
+      }
+      break;
+
+    case 'product_variety':
+      if (!usedProducts.includes(product)) {
+        usedProducts.push(product);
+        challenge.progress.usedProducts = usedProducts;
+      }
+      challenge.challengeCondition.current = usedProducts.length;
+      break;
+
+    case 'success_rate':
+      if (operationSuccess) {
+        challenge.challengeCondition.current += 1;
+      }
+      break;
+
+    case 'capture_count':
+      if (capturedMonster) {
+        challenge.challengeCondition.current += 1;
+      }
+      break;
+
+    case 'pick_correct':
+      // "真假美猴王"：每次掉落随机判定是否选中"真"的（1/3 概率）
+      if (cryptoRandom() < 1 / 3) {
+        challenge.challengeCondition.current += 1;
+      }
+      break;
+  }
+
+  if (challenge.challengeCondition.current >= challenge.challengeCondition.target) {
+    challenge.progress.conditionMet = true;
+  }
+}
+
+function applyChallengeReward(profile: UserProfile, challenge: ChallengeEvent): void {
+  const reward = challenge.successReward;
+  profile.totalExp += reward.exp;
+
+  if (reward.pityBonus) {
+    profile.pityCounters.sinceLastRare += reward.pityBonus;
+    profile.pityCounters.sinceLastEpic += reward.pityBonus;
+    profile.pityCounters.sinceLastLegendary += reward.pityBonus;
+  }
+}
+
+function applyChallengePenalty(profile: UserProfile, challenge: ChallengeEvent): void {
+  const penalty = challenge.failurePenalty;
+  profile.totalExp = Math.max(0, profile.totalExp - penalty.expLoss);
+
+  if (penalty.comboReset) {
+    profile.currentCombo = 0;
+  }
+
+  if (penalty.pityLoss) {
+    profile.pityCounters.sinceLastRare = Math.max(0, profile.pityCounters.sinceLastRare - penalty.pityLoss);
+    profile.pityCounters.sinceLastEpic = Math.max(0, profile.pityCounters.sinceLastEpic - penalty.pityLoss);
+    profile.pityCounters.sinceLastLegendary = Math.max(0, profile.pityCounters.sinceLastLegendary - penalty.pityLoss);
+  }
+}
+
+function updateEventHistory(
+  profile: UserProfile,
+  eventId: string,
+  outcome: EventHistoryEntry['outcome']
+): void {
+  const entry = profile.eventHistory.find(
+    e => e.eventId === eventId && !e.outcome
+  );
+  if (entry) {
+    entry.outcome = outcome;
+  }
+}
+
+/**
+ * 获取所有事件定义（用于成就判定等）
+ */
+export function getAllEventDefinitions(): RandomEvent[] {
+  return [
+    ...BLESSING_EVENTS,
+    ...DISASTER_EVENTS,
+  ];
+}
+
+/**
+ * 获取所有挑战事件定义
+ */
+export function getAllChallengeDefinitions(): Array<Omit<ChallengeEvent, 'progress'>> {
+  return CHALLENGE_EVENTS_DATA;
+}

--- a/src/game-xiyou/renderer.ts
+++ b/src/game-xiyou/renderer.ts
@@ -1,0 +1,820 @@
+/**
+ * Markdown 渲染器
+ *
+ * 输出纯 Markdown 字符串，适配钉钉 AI Card 渲染。
+ * 不关心发送方式，只负责内容生成。
+ */
+
+import type {
+  DropResult, ExpResult, LevelUpResult, Encounter,
+  Achievement, UserProfile, UserCollection, Monster,
+} from './types.ts';
+import { QUALITY_LABELS, LEVEL_DEFINITIONS } from './types.ts';
+import { getMonsterById, getWeeklyUpMonster, getTotalMonsterCount, getAllMonsters } from './monster-pool.ts';
+import { getImmortalById, getTreasureName, getTreasureDescription } from './encounter-system.ts';
+import { getLevelProgress, getExpToNextLevel, getNextLevel } from './level-system.ts';
+import { getUserTreasures, getConsumableTreasures } from './treasure-system.ts';
+import { getAllAchievements } from './achievement-engine.ts';
+
+// ============ 掉落结果渲染 ============
+
+/**
+ * 渲染普通掉落结果（追加到 agent 回复末尾）
+ */
+export function renderDropResult(drop: DropResult, expResult: ExpResult, collection: UserCollection): string {
+  // v2: 空掉落（五行山镇压等事件导致无掉落）
+  if (!drop.monster.id) {
+    return '';
+  }
+
+  const qualityLabel = drop.isShiny ? '✨ 闪光' : QUALITY_LABELS[drop.monster.quality];
+  const totalMonsters = getTotalMonsterCount();
+  const collectedCount = collection.entries.length;
+
+  // v2: 逃跑展示
+  if (drop.escaped) {
+    const escapeLines = [
+      '',
+      '---',
+      `💨 ${qualityLabel} **${drop.monster.name}** 挣脱束缚，遁入云中！`,
+      `> "${drop.monster.captureQuote}"`,
+      `修行值 +2（安慰奖）`,
+    ];
+    if (drop.escapeModifiers.length > 0) {
+      const modDesc = drop.escapeModifiers.map(m => `${m.description} -${Math.floor(m.value * 100)}%`).join('、');
+      escapeLines.push(`*已生效减益：${modDesc}*`);
+    }
+    escapeLines.push(`💡 *连击越高，收服成功率越大*`);
+    return escapeLines.join('\n');
+  }
+
+  // 闪光掉落 - 特殊渲染
+  if (drop.isShiny) {
+    return [
+      '',
+      '---',
+      '🌈🌈🌈 **闪光降临！** 🌈🌈🌈',
+      '',
+      `✨ **${drop.monster.name} ✨**`,
+      `*闪光变体 · 极其稀有*`,
+      `> "${drop.monster.captureQuote}"`,
+      '',
+      `修行值 +${expResult.totalExp} · 图鉴 ${collectedCount}/${totalMonsters}`,
+      drop.isPityTriggered ? '🔮 *保底触发*' : '',
+      drop.isUpMonster ? '📢 *本周 UP*' : '',
+    ].filter(Boolean).join('\n');
+  }
+
+  // 史诗及以上 - 华丽渲染
+  if (drop.monster.quality === 'epic' || drop.monster.quality === 'legendary') {
+    return [
+      '',
+      '---',
+      `✦✦✦ **${qualityLabel}降临！** ✦✦✦`,
+      '',
+      `**${drop.monster.name}**`,
+      `*${drop.monster.origin}*`,
+      `> "${drop.monster.captureQuote}"`,
+      '',
+      `修行值 +${expResult.totalExp} · 图鉴 ${collectedCount}/${totalMonsters}`,
+      drop.isPityTriggered ? '🔮 *保底触发*' : '',
+      drop.isUpMonster ? '📢 *本周 UP*' : '',
+    ].filter(Boolean).join('\n');
+  }
+
+  // 新妖怪发现
+  if (drop.isNew) {
+    return [
+      '',
+      '---',
+      `📖 **图鉴新发现！**`,
+      '',
+      `${qualityLabel} **${drop.monster.name}** · ${drop.monster.origin}`,
+      `> "${drop.monster.captureQuote}"`,
+      '',
+      `修行值 +${expResult.totalExp}${expResult.firstUseMultiplier > 1 ? ' (首次 ×5)' : ''} · 图鉴 ${collectedCount}/${totalMonsters}`,
+    ].join('\n');
+  }
+
+  // 普通掉落 - 简洁版
+  return [
+    '',
+    '---',
+    `🗡️ **降妖成功！** 收服了 ${qualityLabel} ${drop.monster.name}`,
+    `> "${drop.monster.captureQuote}"`,
+    '',
+    `修行值 +${expResult.totalExp} · 图鉴 ${collectedCount}/${totalMonsters}`,
+  ].join('\n');
+}
+
+// ============ 升级渲染 ============
+
+export function renderLevelUp(levelUp: LevelUpResult): string {
+  const lines = [
+    '',
+    '---',
+    `⬆️ **修为精进！** ${levelUp.previousTitle} → ${levelUp.newTitle} (Lv.${levelUp.newLevel})`,
+  ];
+
+  // 添加升级语录
+  const quotes: Record<number, string> = {
+    2: '菩提祖师云：尚可造化。',
+    3: '菩提祖师云：悟性不错，可堪造化。',
+    4: '天庭来报：准予散仙之位。',
+    5: '玉帝有旨：封为天兵。',
+    6: '托塔天王令：升任天将。',
+    7: '太乙真人赞：有哪吒之勇。',
+    8: '玉帝惊叹：堪比二郎神。',
+    9: '如来佛祖：齐天大圣，名不虚传。',
+    10: '如来佛祖：善哉善哉，封斗战胜佛。',
+  };
+
+  const quote = quotes[levelUp.newLevel];
+  if (quote) {
+    lines.push(`> "${quote}"`);
+  }
+
+  if (levelUp.unlockDescription) {
+    lines.push('', `🔓 解锁：${levelUp.unlockDescription}`);
+  }
+
+  return lines.join('\n');
+}
+
+// ============ 机缘渲染 ============
+
+export function renderEncounter(encounter: Encounter): string {
+  const immortal = getImmortalById(encounter.immortalId);
+  if (!immortal) return '';
+
+  const lines = [
+    '',
+    '---',
+    `☁️ **机缘降临！**`,
+    '',
+    `**${immortal.name}** 驾云而过：`,
+    `> "${immortal.guidanceQuote}"`,
+  ];
+
+  if (encounter.type === 'treasure' && encounter.treasureId) {
+    const treasureName = getTreasureName(encounter.treasureId);
+    const treasureDesc = getTreasureDescription(encounter.treasureId);
+    lines.push('', `💛 **赐宝**：${treasureName}`, `效果：${treasureDesc}`);
+  }
+
+  if (encounter.type === 'apprentice') {
+    lines.push('', `💜 **收徒**：${immortal.name}收你为徒，获得永久加成！`);
+  }
+
+  return lines.join('\n');
+}
+
+// ============ 成就渲染 ============
+
+export function renderNewAchievements(achievements: Achievement[]): string {
+  if (achievements.length === 0) return '';
+
+  const lines = ['', '---'];
+
+  for (const achievement of achievements) {
+    lines.push(
+      `🏆 **成就解锁！** ${achievement.emoji} ${achievement.name}`,
+      `*${achievement.description}*`,
+      `修行值 +${achievement.expReward}`,
+    );
+    if (achievement.titleReward) {
+      lines.push(`🎖️ 获得称号：「${achievement.titleReward}」`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ============ 面板渲染（命令响应） ============
+
+/**
+ * 渲染修行面板 (/修行)
+ */
+export function renderProfilePanel(profile: UserProfile, collection: UserCollection): string {
+  const totalMonsters = getTotalMonsterCount();
+  const collectedCount = collection.entries.length;
+  const shinyCount = collection.entries.filter(e => e.isShiny).length;
+  const progress = getLevelProgress(profile.totalExp);
+  const expToNext = getExpToNextLevel(profile.totalExp);
+  const nextLevel = getNextLevel(profile.level);
+  const upMonster = getWeeklyUpMonster();
+  const allAchievementsList = getAllAchievements();
+
+  // 进度条
+  const filledBlocks = Math.floor(progress / 5);
+  const emptyBlocks = 20 - filledBlocks;
+  const progressBar = '▓'.repeat(filledBlocks) + '░'.repeat(emptyBlocks);
+
+  const lines = [
+    `### 🐒 西游妖魔榜 · 修行面板`,
+    '',
+    `**修行者 ID**：${profile.uidHash.slice(0, 8)}`,
+    `**称号**：${profile.title} (Lv.${profile.level})`,
+  ];
+
+  if (nextLevel) {
+    lines.push(
+      `**修行值**：${profile.totalExp.toLocaleString()} / ${nextLevel.requiredExp.toLocaleString()} (${progress}%)`,
+      '',
+      `${progressBar}`,
+      '',
+      `距离下一级「${nextLevel.title}」还需 ${expToNext?.toLocaleString()} 修行值`,
+    );
+  } else {
+    lines.push(`**修行值**：${profile.totalExp.toLocaleString()} (已满级)`, '', `${'▓'.repeat(20)}`);
+  }
+
+  lines.push(
+    '',
+    `#### 📊 统计`,
+    `- **总操作**：${profile.totalOperations} 次`,
+    `- **连击中**：${profile.currentCombo} 次${profile.currentCombo >= 3 ? ` (×${getComboDisplay(profile.currentCombo)})` : ''}`,
+    `- **连续签到**：${profile.consecutiveSignInDays} 天`,
+    `- **最高连击**：${profile.maxCombo} 次`,
+  );
+
+  // 图鉴进度
+  const qualityCounts = getQualityProgress(collection);
+  lines.push(
+    '',
+    `#### 📖 图鉴 ${collectedCount}/${totalMonsters} (${Math.floor(collectedCount / totalMonsters * 100)}%)`,
+    '',
+    `| 品质 | 进度 |`,
+    `|------|------|`,
+  );
+
+  for (const [label, collected, total] of qualityCounts) {
+    const status = collected >= total ? ' ✅' : '';
+    lines.push(`| ${label} | ${collected}/${total}${status} |`);
+  }
+
+  if (shinyCount > 0) {
+    lines.push(`| ✨ 闪光 | ${shinyCount} |`);
+  }
+
+  // 保底状态
+  const pity = profile.pityCounters;
+  lines.push(
+    '',
+    `#### 🔮 保底状态`,
+    `- **小保底**：${pity.sinceLastRare}/30 · **大保底**：${pity.sinceLastEpic}/80 · **天命**：${pity.sinceLastLegendary}/150`,
+  );
+
+  // UP 妖怪
+  if (upMonster) {
+    lines.push(
+      '',
+      `📢 **本周 UP**：${QUALITY_LABELS[upMonster.quality]} ${upMonster.name} (权重 ×5)`,
+    );
+  }
+
+  // 成就
+  lines.push(
+    '',
+    `🏆 **成就**：${profile.unlockedAchievements.length}/${allAchievementsList.length}`,
+    `🎒 **法宝**：${profile.treasures.length} 件`,
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * 渲染图鉴面板 (/图鉴)
+ */
+export function renderCollectionPanel(collection: UserCollection): string {
+  const allMonstersList = getAllMonsters();
+  const totalMonsters = getTotalMonsterCount();
+  const collectedCount = collection.entries.length;
+
+  const lines = [
+    `### 📖 妖怪图鉴 · ${collectedCount}/${totalMonsters}`,
+    '',
+  ];
+
+  const qualityGroups: Array<{ quality: string; label: string; monsters: Monster[] }> = [
+    { quality: 'normal', label: '⬜ 普通', monsters: allMonstersList.filter(m => m.quality === 'normal') },
+    { quality: 'fine', label: '🟢 精良', monsters: allMonstersList.filter(m => m.quality === 'fine') },
+    { quality: 'rare', label: '🔵 稀有', monsters: allMonstersList.filter(m => m.quality === 'rare') },
+    { quality: 'epic', label: '🟣 史诗', monsters: allMonstersList.filter(m => m.quality === 'epic') },
+    { quality: 'legendary', label: '🟡 传说', monsters: allMonstersList.filter(m => m.quality === 'legendary') },
+  ];
+
+  for (const group of qualityGroups) {
+    const collected = group.monsters.filter(m =>
+      collection.entries.some(e => e.monsterId === m.id && !e.isShiny)
+    );
+    const uncollectedCount = group.monsters.length - collected.length;
+
+    lines.push(`#### ${group.label} ${collected.length}/${group.monsters.length}${collected.length >= group.monsters.length ? ' ✅' : ''}`);
+
+    if (collected.length > 0) {
+      lines.push(collected.map(m => m.name).join(' · '));
+    }
+
+    if (uncollectedCount > 0) {
+      lines.push(`${'❓'.repeat(Math.min(uncollectedCount, 5))} *还有 ${uncollectedCount} 只未发现*`);
+    }
+
+    lines.push('');
+  }
+
+  // 闪光
+  const shinyEntries = collection.entries.filter(e => e.isShiny);
+  lines.push(`#### ✨ 闪光 ${shinyEntries.length}`);
+  if (shinyEntries.length > 0) {
+    const shinyNames = shinyEntries.map(e => {
+      const monster = getMonsterById(e.monsterId);
+      return monster ? `${monster.name} ✨` : e.monsterId;
+    });
+    lines.push(shinyNames.join(' · '));
+  } else {
+    lines.push('*等级 ≥ 9 后解锁闪光掉落*');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * 渲染成就面板 (/成就)
+ */
+export function renderAchievementPanel(profile: UserProfile): string {
+  const allAchievementsList = getAllAchievements();
+  const lines = [
+    `### 🏆 成就列表 · ${profile.unlockedAchievements.length}/${allAchievementsList.length}`,
+    '',
+  ];
+
+  const categories = [
+    { key: 'cultivation', label: '修行成就' },
+    { key: 'collection', label: '收集成就' },
+    { key: 'product', label: '产品成就' },
+    { key: 'hidden', label: '隐藏成就' },
+  ];
+
+  for (const category of categories) {
+    const categoryAchievements = allAchievementsList.filter(a => a.category === category.key);
+    lines.push(`#### ${category.label}`);
+
+    for (const achievement of categoryAchievements) {
+      const unlocked = profile.unlockedAchievements.includes(achievement.id);
+      const status = unlocked ? '✅' : '⬜';
+      const desc = category.key === 'hidden' && !unlocked ? '???' : achievement.description;
+      lines.push(`- ${status} ${achievement.emoji} **${achievement.name}** — ${desc} (+${achievement.expReward})`);
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * 渲染法宝面板 (/法宝)
+ */
+export function renderTreasurePanel(profile: UserProfile): string {
+  const treasures = getUserTreasures(profile);
+  const consumable = getConsumableTreasures(profile);
+
+  const lines = [
+    `### 🎒 法宝背包 · ${treasures.length} 件`,
+    '',
+  ];
+
+  if (treasures.length === 0) {
+    lines.push('*背包空空如也，等待神仙赐宝...*');
+    return lines.join('\n');
+  }
+
+  for (const treasure of treasures) {
+    const consumed = profile.consumedTreasures.includes(treasure.id);
+    const status = consumed ? '（已使用）' : treasure.consumable ? '（可使用）' : '（永久生效）';
+    lines.push(`- **${treasure.name}** ${status}`, `  ${treasure.description}`, `  *来源：${treasure.source}*`, '');
+  }
+
+  if (consumable.length > 0) {
+    lines.push('', `💡 发送 \`/使用 法宝名\` 来使用一次性法宝`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * 渲染保底面板 (/保底)
+ */
+export function renderPityPanel(profile: UserProfile): string {
+  const pity = profile.pityCounters;
+
+  // v2: 软保底状态提示
+  const softPityHints: string[] = [];
+  if (pity.sinceLastRare >= 20) softPityHints.push(`稀有软保底已激活 +${(pity.sinceLastRare - 20) * 3}%`);
+  if (pity.sinceLastEpic >= 60) softPityHints.push(`史诗软保底已激活 +${(pity.sinceLastEpic - 60) * 2}%`);
+  if (pity.sinceLastLegendary >= 120) softPityHints.push(`传说软保底已激活 +${(pity.sinceLastLegendary - 120) * 1}%`);
+
+  const lines = [
+    `### 🔮 保底计数器`,
+    '',
+    `| 保底类型 | 当前计数 | 触发阈值 | 进度 |`,
+    `|---------|---------|---------|------|`,
+    `| 小保底（稀有） | ${pity.sinceLastRare} | 30 | ${Math.floor(pity.sinceLastRare / 30 * 100)}% |`,
+    `| 大保底（史诗） | ${pity.sinceLastEpic} | 80 | ${Math.floor(pity.sinceLastEpic / 80 * 100)}% |`,
+    `| 天命保底（传说） | ${pity.sinceLastLegendary} | 150 | ${Math.floor(pity.sinceLastLegendary / 150 * 100)}% |`,
+    `| 闪光保底 | ${pity.totalDropsWithoutShiny} | 800 | ${Math.floor(pity.totalDropsWithoutShiny / 800 * 100)}% |`,
+  ];
+
+  if (softPityHints.length > 0) {
+    lines.push('', `🌟 ${softPityHints.join(' · ')}`);
+  }
+
+  lines.push('', `*保底计数器在对应品质或更高品质掉落后重置*`);
+  return lines.join('\n');
+}
+
+/**
+ * 渲染机缘面板 (/机缘)
+ */
+export function renderEncounterPanel(profile: UserProfile): string {
+  const lines = [
+    `### ☁️ 神仙机缘录`,
+    '',
+  ];
+
+  if (profile.level < 3) {
+    lines.push('*等级 ≥ 3（修行者）后解锁机缘系统*');
+    return lines.join('\n');
+  }
+
+  if (profile.encounters.length === 0) {
+    lines.push('*尚未遇到任何神仙，继续修行吧...*');
+    return lines.join('\n');
+  }
+
+  for (const encounter of profile.encounters) {
+    const immortal = getImmortalById(encounter.immortalId);
+    if (!immortal) continue;
+
+    const typeLabel = encounter.type === 'guidance' ? '🤍 点化' :
+      encounter.type === 'treasure' ? '💛 赐宝' : '💜 收徒';
+    const date = new Date(encounter.occurredAt).toLocaleDateString('zh-CN');
+
+    lines.push(`- ${typeLabel} **${immortal.name}** — ${date}`);
+    if (encounter.type === 'treasure' && encounter.treasureId) {
+      lines.push(`  赐宝：${getTreasureName(encounter.treasureId)}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * 渲染妖魔榜 (/妖魔榜)
+ */
+export function renderLeaderboard(profile: UserProfile, collection: UserCollection): string {
+  const upMonster = getWeeklyUpMonster();
+  const totalMonsters = getTotalMonsterCount();
+
+  const lines = [
+    `### 🐒 西游妖魔榜`,
+    '',
+  ];
+
+  if (upMonster) {
+    lines.push(
+      `#### 📢 本周 UP`,
+      `${QUALITY_LABELS[upMonster.quality]} **${upMonster.name}** · ${upMonster.origin}`,
+      `> "${upMonster.captureQuote}"`,
+      `*在对应品质池中掉落权重 ×5*`,
+      '',
+    );
+  }
+
+  lines.push(
+    `#### 📊 掉落统计`,
+    `- **总掉落**：${profile.totalOperations} 次`,
+    `- **图鉴完成度**：${collection.entries.length}/${totalMonsters}`,
+    `- **闪光收服**：${collection.entries.filter(e => e.isShiny).length} 只`,
+    '',
+    `#### 🔮 保底状态`,
+    `- 小保底：${profile.pityCounters.sinceLastRare}/30`,
+    `- 大保底：${profile.pityCounters.sinceLastEpic}/80`,
+    `- 天命：${profile.pityCounters.sinceLastLegendary}/150`,
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * 渲染法宝使用结果
+ */
+export function renderTreasureUse(treasureName: string, expGained: number, currentExp: number, nextLevelExp: number | null): string {
+  const emojiMap: Record<string, string> = {
+    '蟠桃': '🍑',
+    '人参果': '🍐',
+  };
+  const emoji = emojiMap[treasureName] ?? '✨';
+
+  const lines = [
+    '---',
+    `${emoji} **使用了${treasureName}！**`,
+    `修行值 +${expGained}${nextLevelExp ? ` · 当前 ${currentExp}/${nextLevelExp}` : ''}`,
+    `> "仙物入腹，周身舒泰。"`,
+  ];
+
+  return lines.join('\n');
+}
+
+/**
+ * 渲染群聊炫耀 (/炫耀)
+ */
+export function renderShowOff(profile: UserProfile, collection: UserCollection): string {
+  const shinyCount = collection.entries.filter(e => e.isShiny).length;
+  const rarest = findRarestMonster(collection);
+
+  const lines = [
+    `### 🐒 ${profile.title} (Lv.${profile.level}) 的西游妖魔榜`,
+    '',
+    `图鉴：${collection.entries.length}/${getTotalMonsterCount()} · 闪光：${shinyCount}`,
+  ];
+
+  if (rarest) {
+    lines.push(`最稀有：${QUALITY_LABELS[rarest.quality]} ${rarest.name}`);
+  }
+
+  lines.push('', `> "此人修为不浅，诸位小心。"`);
+
+  return lines.join('\n');
+}
+
+// ============ 辅助函数 ============
+
+function getComboDisplay(combo: number): string {
+  if (combo >= 10) return '3.0';
+  if (combo >= 5) return '2.0';
+  if (combo >= 3) return '1.5';
+  return '1.0';
+}
+
+function getQualityProgress(collection: UserCollection): Array<[string, number, number]> {
+  const allMonstersList = getAllMonsters();
+  const qualities: Array<{ label: string; quality: string }> = [
+    { label: '⬜ 普通', quality: 'normal' },
+    { label: '🟢 精良', quality: 'fine' },
+    { label: '🔵 稀有', quality: 'rare' },
+    { label: '🟣 史诗', quality: 'epic' },
+    { label: '🟡 传说', quality: 'legendary' },
+  ];
+
+  return qualities.map(({ label, quality }) => {
+    const total = allMonstersList.filter(m => m.quality === quality).length;
+    const collected = allMonstersList.filter(m =>
+      m.quality === quality && collection.entries.some(e => e.monsterId === m.id && !e.isShiny)
+    ).length;
+    return [label, collected, total];
+  });
+}
+
+function findRarestMonster(collection: UserCollection): Monster | null {
+  const qualityPriority = ['legendary', 'epic', 'rare', 'fine', 'normal'];
+
+  for (const quality of qualityPriority) {
+    const entry = collection.entries.find(e => {
+      const monster = getMonsterById(e.monsterId);
+      return monster?.quality === quality;
+    });
+    if (entry) {
+      return getMonsterById(entry.monsterId) ?? null;
+    }
+  }
+
+  return null;
+}
+
+// ============ v2: 悬赏令渲染 ============
+
+import type { Bounty, DailyBountyState, RandomEvent, ChallengeEvent } from './types.ts';
+
+const BOUNTY_TIER_LABELS: Record<string, string> = {
+  bronze: '🥉 铜令',
+  silver: '🥈 银令',
+  gold: '🥇 金令',
+};
+
+/**
+ * 渲染悬赏令面板 (/悬赏)
+ */
+export function renderBountyPanel(profile: UserProfile): string {
+  const bountyState = profile.dailyBounty;
+
+  if (!bountyState || bountyState.bounties.length === 0) {
+    return [
+      `### 📜 今日悬赏令`,
+      '',
+      '*今日悬赏令尚未生成，执行一次 dws 命令即可刷新。*',
+    ].join('\n');
+  }
+
+  const lines = [
+    `### 📜 今日悬赏令`,
+    '',
+  ];
+
+  for (const bounty of bountyState.bounties) {
+    const tierLabel = BOUNTY_TIER_LABELS[bounty.tier] ?? bounty.tier;
+    const status = bounty.completed ? '✅' : '⬜';
+    const progressPercent = Math.min(100, Math.floor(bounty.current / bounty.target * 100));
+    const filledBlocks = Math.floor(progressPercent / 10);
+    const emptyBlocks = 10 - filledBlocks;
+    const progressBar = '█'.repeat(filledBlocks) + '░'.repeat(emptyBlocks);
+
+    lines.push(
+      `${status} **${tierLabel}**：${bounty.description}`,
+      `   奖励：+${bounty.reward.exp} 修行值`,
+      `   进度：${bounty.current}/${bounty.target} ${progressBar} ${progressPercent}%`,
+      '',
+    );
+  }
+
+  // 刷新倒计时
+  const now = new Date();
+  const tomorrow = new Date(now);
+  tomorrow.setHours(24, 0, 0, 0);
+  const remainingMs = tomorrow.getTime() - now.getTime();
+  const remainingHours = Math.floor(remainingMs / (60 * 60 * 1000));
+  const remainingMinutes = Math.floor((remainingMs % (60 * 60 * 1000)) / (60 * 1000));
+
+  lines.push(`⏰ 刷新倒计时：${remainingHours} 小时 ${remainingMinutes} 分`);
+
+  // 历史统计
+  const history = profile.bountyHistory;
+  lines.push(
+    '',
+    `#### 📊 悬赏历史`,
+    `累计完成：${history.totalCompleted} 张 (🥉${history.bronzeCompleted} 🥈${history.silverCompleted} 🥇${history.goldCompleted})`,
+    `连续全清：${history.consecutiveFullClear} 天`,
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * 渲染悬赏令完成通知
+ */
+export function renderBountyComplete(bounty: Bounty): string {
+  const tierLabel = BOUNTY_TIER_LABELS[bounty.tier] ?? bounty.tier;
+  return [
+    '',
+    '---',
+    `📜 **${tierLabel}完成！** 「${bounty.description}」`,
+    `奖励已发放：修行值 +${bounty.reward.exp}`,
+  ].join('\n');
+}
+
+// ============ v2: 随机事件渲染 ============
+
+const EVENT_CATEGORY_EMOJI: Record<string, string> = {
+  blessing: '🌟',
+  challenge: '⚔️',
+  disaster: '😈',
+};
+
+/**
+ * 渲染随机事件触发通知
+ */
+export function renderEventTrigger(event: RandomEvent | ChallengeEvent): string {
+  const emoji = EVENT_CATEGORY_EMOJI[event.category] ?? '🎲';
+
+  const lines = [
+    '',
+    '---',
+    `${emoji} **随机事件：${event.name}！**`,
+    '',
+    `*${event.flavorText}*`,
+    '',
+  ];
+
+  if (event.category === 'blessing') {
+    lines.push(`🌟 **效果**：${event.description}`);
+    if (event.duration.type !== 'instant') {
+      lines.push(`剩余次数：${event.duration.remaining}/${event.duration.total}`);
+    }
+  }
+
+  if (event.category === 'challenge') {
+    const challenge = event as ChallengeEvent;
+    lines.push(
+      `⚔️ **挑战**：${event.description}`,
+      `🏆 成功：+${challenge.successReward.exp} 修行值${challenge.successReward.pityBonus ? ` + 保底 +${challenge.successReward.pityBonus}` : ''}`,
+      `💀 失败：修行值 -${challenge.failurePenalty.expLoss}${challenge.failurePenalty.comboReset ? ' + 连击归零' : ''}`,
+      `⏰ 时限：${challenge.operationLimit} 次操作内完成`,
+      '',
+      `当前进度：${challenge.challengeCondition.current}/${challenge.challengeCondition.target}`,
+    );
+  }
+
+  if (event.category === 'disaster') {
+    lines.push(`😈 **效果**：${event.description}`);
+    if (event.resolution) {
+      lines.push(`💡 **化解**：${event.resolution.description}`);
+    }
+    if (event.duration.type !== 'instant') {
+      lines.push(`剩余次数：${event.duration.remaining}/${event.duration.total}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * 渲染挑战事件结果
+ */
+export function renderChallengeResult(event: ChallengeEvent, success: boolean): string {
+  if (success) {
+    return [
+      '',
+      '---',
+      `🏆 **${event.name} · 挑战成功！**`,
+      '',
+      `奖励已发放：修行值 +${event.successReward.exp}`,
+      event.successReward.pityBonus ? `保底计数器 +${event.successReward.pityBonus}` : '',
+    ].filter(Boolean).join('\n');
+  }
+
+  return [
+    '',
+    '---',
+    `💀 **${event.name} · 挑战失败**`,
+    '',
+    `惩罚：修行值 -${event.failurePenalty.expLoss}`,
+    event.failurePenalty.comboReset ? '连击已归零' : '',
+  ].filter(Boolean).join('\n');
+}
+
+/**
+ * 渲染灾厄事件化解通知
+ */
+export function renderDisasterResolved(event: RandomEvent): string {
+  return [
+    '',
+    '---',
+    `🛡️ **${event.name} · 已化解！**`,
+    `*灾厄消散，天地清明。*`,
+  ].join('\n');
+}
+
+/**
+ * 渲染事件面板 (/事件)
+ */
+export function renderEventPanel(profile: UserProfile): string {
+  const activeState = profile.activeEvents;
+  const lines = [
+    `### 🎲 随机事件`,
+    '',
+  ];
+
+  // 当前活跃事件
+  if (activeState.currentEvents.length === 0 && !activeState.activeChallenge) {
+    lines.push('*当前没有活跃的随机事件。*');
+  } else {
+    if (activeState.currentEvents.length > 0) {
+      lines.push(`#### 当前生效`);
+      for (const event of activeState.currentEvents) {
+        const emoji = EVENT_CATEGORY_EMOJI[event.category] ?? '🎲';
+        const remaining = event.duration.type !== 'instant'
+          ? ` (剩余 ${event.duration.remaining}/${event.duration.total})`
+          : '';
+        lines.push(`- ${emoji} **${event.name}**：${event.description}${remaining}`);
+        if (event.resolution) {
+          lines.push(`  💡 化解：${event.resolution.description}`);
+        }
+      }
+      lines.push('');
+    }
+
+    if (activeState.activeChallenge) {
+      const challenge = activeState.activeChallenge;
+      lines.push(
+        `#### ⚔️ 进行中的挑战`,
+        `**${challenge.name}**：${challenge.description}`,
+        `进度：${challenge.challengeCondition.current}/${challenge.challengeCondition.target}`,
+        `操作次数：${challenge.progress.operationsUsed}/${challenge.progress.operationLimit}`,
+        '',
+      );
+    }
+  }
+
+  // 事件统计
+  const stats = profile.eventStats;
+  lines.push(
+    `#### 📊 事件统计`,
+    `- **累计触发**：${stats.totalTriggered} 次`,
+    `- **挑战完成**：${stats.challengesCompleted} 次`,
+    `- **挑战失败**：${stats.challengesFailed} 次`,
+    `- **灾厄化解**：${stats.disastersResolved} 次`,
+  );
+
+  return lines.join('\n');
+}

--- a/src/game-xiyou/storage.ts
+++ b/src/game-xiyou/storage.ts
@@ -1,0 +1,218 @@
+/**
+ * JSON 持久化层
+ *
+ * 所有养成数据存储在 ~/.dingtalk-connector/gamification/ 目录下，
+ * 按 UID 哈希分文件存储，支持 profile / collection / history 三类数据。
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createHmac } from 'crypto';
+import type {
+  UserProfile, UserCollection, UserHistory, GamificationSettings, PityCounters,
+  BountyHistory, ActiveEventState, EventStats,
+} from './types.ts';
+import { createDefaultBountyHistory } from './bounty-system.ts';
+import { createDefaultActiveEventState, createDefaultEventStats } from './random-event-engine.ts';
+
+const STORAGE_DIR = path.join(os.homedir(), '.dingtalk-connector', 'gamification');
+const CHECKSUM_SECRET = 'xiyou-hmac-secret-2026';
+
+function ensureStorageDir(): void {
+  if (!fs.existsSync(STORAGE_DIR)) {
+    fs.mkdirSync(STORAGE_DIR, { recursive: true });
+  }
+}
+
+function getProfilePath(uidHash: string): string {
+  return path.join(STORAGE_DIR, `profile-${uidHash}.json`);
+}
+
+function getCollectionPath(uidHash: string): string {
+  return path.join(STORAGE_DIR, `collection-${uidHash}.json`);
+}
+
+function getHistoryPath(uidHash: string): string {
+  return path.join(STORAGE_DIR, `history-${uidHash}.json`);
+}
+
+// ============ Checksum ============
+
+function computeChecksum(profile: Omit<UserProfile, 'checksum'>): string {
+  const payload = `${profile.uidHash}:${profile.totalExp}:${profile.level}:${profile.totalOperations}`;
+  return createHmac('sha256', CHECKSUM_SECRET).update(payload).digest('hex').slice(0, 32);
+}
+
+export function verifyChecksum(profile: UserProfile): boolean {
+  const expected = computeChecksum(profile);
+  return profile.checksum === expected;
+}
+
+// ============ Profile ============
+
+function createDefaultProfile(uidHash: string): UserProfile {
+  const defaultSettings: GamificationSettings = {
+    enabled: true,
+    showDropAnimation: true,
+    muteNormalDrops: false,
+  };
+
+  const defaultPity: PityCounters = {
+    sinceLastRare: 0,
+    sinceLastEpic: 0,
+    sinceLastLegendary: 0,
+    totalDropsWithoutShiny: 0,
+  };
+
+  const profile: Omit<UserProfile, 'checksum'> = {
+    uidHash,
+    level: 1,
+    title: '凡人',
+    totalExp: 0,
+    totalOperations: 0,
+    currentCombo: 0,
+    maxCombo: 0,
+    consecutiveSignInDays: 0,
+    lastSignInDate: '',
+    totalRecoveries: 0,
+    consecutiveFailures: 0,
+    productUsage: {},
+    pityCounters: defaultPity,
+    buffs: [],
+    settings: defaultSettings,
+    encounters: [],
+    unlockedAchievements: [],
+    treasures: [],
+    consumedTreasures: [],
+    createdAt: Date.now(),
+    // v2 字段
+    escapeHistory: {},
+    totalEscapes: 0,
+    dailyBounty: null,
+    bountyHistory: createDefaultBountyHistory(),
+    activeEvents: createDefaultActiveEventState(),
+    eventStats: createDefaultEventStats(),
+    eventHistory: [],
+  };
+
+  return { ...profile, checksum: computeChecksum(profile) };
+}
+
+export function loadProfile(uidHash: string): UserProfile {
+  ensureStorageDir();
+  const filePath = getProfilePath(uidHash);
+
+  if (!fs.existsSync(filePath)) {
+    const profile = createDefaultProfile(uidHash);
+    saveProfile(profile);
+    return profile;
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const profile = JSON.parse(raw) as UserProfile;
+    return migrateProfile(profile);
+  } catch {
+    const profile = createDefaultProfile(uidHash);
+    saveProfile(profile);
+    return profile;
+  }
+}
+
+/**
+ * 补全旧版本 profile 中缺失的 v2 字段，确保向后兼容
+ */
+function migrateProfile(profile: UserProfile): UserProfile {
+  let migrated = false;
+
+  if (!profile.escapeHistory) { profile.escapeHistory = {}; migrated = true; }
+  if (profile.totalEscapes == null) { profile.totalEscapes = 0; migrated = true; }
+  if (profile.dailyBounty === undefined) { profile.dailyBounty = null; migrated = true; }
+  if (!profile.bountyHistory) { profile.bountyHistory = createDefaultBountyHistory(); migrated = true; }
+  if (!profile.activeEvents) { profile.activeEvents = createDefaultActiveEventState(); migrated = true; }
+  if (!profile.eventStats) { profile.eventStats = createDefaultEventStats(); migrated = true; }
+  if (!profile.eventHistory) { profile.eventHistory = []; migrated = true; }
+
+  if (migrated) {
+    saveProfile(profile);
+  }
+
+  return profile;
+}
+
+export function saveProfile(profile: UserProfile): void {
+  ensureStorageDir();
+  const withChecksum: UserProfile = {
+    ...profile,
+    checksum: computeChecksum(profile),
+  };
+  const filePath = getProfilePath(profile.uidHash);
+  fs.writeFileSync(filePath, JSON.stringify(withChecksum, null, 2), 'utf-8');
+}
+
+// ============ Collection ============
+
+function createDefaultCollection(uidHash: string): UserCollection {
+  return { uidHash, entries: [] };
+}
+
+export function loadCollection(uidHash: string): UserCollection {
+  ensureStorageDir();
+  const filePath = getCollectionPath(uidHash);
+
+  if (!fs.existsSync(filePath)) {
+    const collection = createDefaultCollection(uidHash);
+    saveCollection(collection);
+    return collection;
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw) as UserCollection;
+  } catch {
+    const collection = createDefaultCollection(uidHash);
+    saveCollection(collection);
+    return collection;
+  }
+}
+
+export function saveCollection(collection: UserCollection): void {
+  ensureStorageDir();
+  const filePath = getCollectionPath(collection.uidHash);
+  fs.writeFileSync(filePath, JSON.stringify(collection, null, 2), 'utf-8');
+}
+
+// ============ History ============
+
+const MAX_HISTORY_RECORDS = 500;
+
+function createDefaultHistory(uidHash: string): UserHistory {
+  return { uidHash, records: [] };
+}
+
+export function loadHistory(uidHash: string): UserHistory {
+  ensureStorageDir();
+  const filePath = getHistoryPath(uidHash);
+
+  if (!fs.existsSync(filePath)) {
+    return createDefaultHistory(uidHash);
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw) as UserHistory;
+  } catch {
+    return createDefaultHistory(uidHash);
+  }
+}
+
+export function saveHistory(history: UserHistory): void {
+  ensureStorageDir();
+  // 只保留最近 500 条
+  if (history.records.length > MAX_HISTORY_RECORDS) {
+    history.records = history.records.slice(-MAX_HISTORY_RECORDS);
+  }
+  const filePath = getHistoryPath(history.uidHash);
+  fs.writeFileSync(filePath, JSON.stringify(history, null, 2), 'utf-8');
+}

--- a/src/game-xiyou/treasure-system.ts
+++ b/src/game-xiyou/treasure-system.ts
@@ -1,0 +1,105 @@
+/**
+ * 法宝系统
+ *
+ * 等级 ≥ 5（天兵）后解锁。法宝来源于神仙赐宝和特殊成就奖励。
+ * 一次性法宝通过命令使用，永久法宝自动生效。
+ */
+
+import type { UserProfile, Treasure, Buff } from './types.ts';
+
+/**
+ * 法宝数据（内联，导出供 encounter-system 引用）
+ */
+export const TREASURES_DATA: Treasure[] = [
+  { id: "jintouyun", name: "筋斗云", source: "菩提祖师赐宝", description: "连击加成额外 +0.5", effect: "comboBonus", value: 0.5, consumable: false },
+  { id: "jingping", name: "净瓶", source: "观音菩萨赐宝", description: "recovery 成功时额外 +5 修行值", effect: "expMultiplier", value: 1.1, consumable: false },
+  { id: "zijinhulu", name: "紫金葫芦", source: "太上老君赐宝", description: "每日额外 1 次掉落机会", effect: "extraDrop", value: 1, consumable: false },
+  { id: "pantao", name: "蟠桃", source: "太白金星赐宝", description: "使用后立即 +50 修行值", effect: "instantExp", value: 50, consumable: true },
+  { id: "qiankunquan", name: "乾坤圈", source: "哪吒赐宝", description: "闪光概率 +0.05%", effect: "shinyRateBonus", value: 0.0005, consumable: false },
+  { id: "sanjiandao", name: "三尖两刃刀", source: "二郎真君赐宝", description: "CLI 错误自动重试 +1 次", effect: "cliRetry", value: 1, consumable: false },
+  { id: "linglongta", name: "玲珑宝塔", source: "托塔天王赐宝", description: "普通掉落 20% 概率升级为精良", effect: "normalUpgrade", value: 0.2, consumable: false },
+  { id: "renshenguo", name: "人参果", source: "镇元大仙赐宝", description: "使用后立即 +200 修行值", effect: "instantExp", value: 200, consumable: true },
+  { id: "dinghaishenzhen", name: "定海神针", source: "成就「齐天大圣」解锁", description: "所有掉落率 +1%", effect: "allRateBonus", value: 0.01, consumable: false },
+  { id: "jingguzhou", name: "紧箍咒", source: "成就「西天取经」解锁", description: "保底计数器速度 ×1.5", effect: "pitySpeed", value: 1.5, consumable: false },
+  { id: "bashanshan", name: "芭蕉扇", source: "收服铁扇公主后概率获得", description: "连续签到奖励 ×2", effect: "signInMultiplier", value: 2, consumable: false },
+  { id: "zhaoyaojing", name: "照妖镜", source: "收服全部精良妖怪后解锁", description: "掉落时预览下一次的品质", effect: "previewNextQuality", value: 1, consumable: false },
+];
+
+const allTreasures: Treasure[] = TREASURES_DATA;
+
+/**
+ * 根据 ID 查找法宝
+ */
+export function getTreasureById(treasureId: string): Treasure | undefined {
+  return allTreasures.find(t => t.id === treasureId);
+}
+
+/**
+ * 获取用户拥有的法宝列表（含详情）
+ */
+export function getUserTreasures(profile: UserProfile): Treasure[] {
+  return profile.treasures
+    .map(id => getTreasureById(id))
+    .filter((t): t is Treasure => t !== undefined);
+}
+
+/**
+ * 获取用户可使用的一次性法宝
+ */
+export function getConsumableTreasures(profile: UserProfile): Treasure[] {
+  return getUserTreasures(profile).filter(
+    t => t.consumable && !profile.consumedTreasures.includes(t.id)
+  );
+}
+
+/**
+ * 使用一次性法宝
+ *
+ * @returns 使用结果描述，或 null（法宝不存在/已使用/不可消耗）
+ */
+export function consumeTreasure(
+  profile: UserProfile,
+  treasureName: string
+): { treasure: Treasure; expGained: number; message: string } | null {
+  // 按名称查找法宝
+  const treasure = allTreasures.find(t => t.name === treasureName);
+  if (!treasure) return null;
+
+  // 检查用户是否拥有
+  if (!profile.treasures.includes(treasure.id)) return null;
+
+  // 检查是否可消耗
+  if (!treasure.consumable) return null;
+
+  // 检查是否已使用
+  if (profile.consumedTreasures.includes(treasure.id)) return null;
+
+  // 标记为已使用
+  profile.consumedTreasures.push(treasure.id);
+
+  // 应用效果
+  let expGained = 0;
+  let message = '';
+
+  if (treasure.effect === 'instantExp') {
+    expGained = treasure.value;
+    profile.totalExp += expGained;
+    message = `修行值 +${expGained}`;
+  }
+
+  return { treasure, expGained, message };
+}
+
+/**
+ * 检查是否有额外掉落机会（紫金葫芦效果）
+ */
+export function hasExtraDropChance(profile: UserProfile): boolean {
+  return profile.buffs.some(b => b.effect === 'extraDrop');
+}
+
+/**
+ * 检查是否有品质预览能力（照妖镜效果）
+ */
+export function hasQualityPreview(profile: UserProfile): boolean {
+  return profile.buffs.some(b => b.effect === 'previewNextQuality');
+}

--- a/src/game-xiyou/types.ts
+++ b/src/game-xiyou/types.ts
@@ -1,0 +1,581 @@
+/**
+ * 西游妖魔榜养成系统 - 类型定义
+ *
+ * 核心概念：每次通过 agent 成功调用 dws CLI，就是一次"降妖除魔"。
+ * 妖怪按品质随机掉落，神仙按机缘随机现身，所有数据与用户 UID 强绑定。
+ */
+
+// ============ 品质与分级 ============
+
+export type MonsterQuality = 'normal' | 'fine' | 'rare' | 'epic' | 'legendary' | 'shiny';
+
+export const QUALITY_LABELS: Record<MonsterQuality, string> = {
+  normal: '⬜ 普通',
+  fine: '🟢 精良',
+  rare: '🔵 稀有',
+  epic: '🟣 史诗',
+  legendary: '🟡 传说',
+  shiny: '✨ 闪光',
+};
+
+export const QUALITY_ORDER: MonsterQuality[] = [
+  'normal', 'fine', 'rare', 'epic', 'legendary', 'shiny',
+];
+
+// ============ 妖怪 ============
+
+export interface Monster {
+  id: string;
+  name: string;
+  quality: MonsterQuality;
+  origin: string;
+  relatedProduct: string | null;
+  captureQuote: string;
+}
+
+export interface CapturedMonster {
+  monsterId: string;
+  capturedAt: number;
+  isShiny: boolean;
+  commandHash: string;
+  comboCount: number;
+}
+
+// ============ 神仙 ============
+
+export type EncounterType = 'guidance' | 'treasure' | 'apprentice';
+
+export interface Immortal {
+  id: string;
+  name: string;
+  guidanceQuote: string;
+  treasureId: string;
+  apprenticeBuff: Buff;
+}
+
+export interface Encounter {
+  immortalId: string;
+  type: EncounterType;
+  treasureId?: string;
+  buffId?: string;
+  occurredAt: number;
+}
+
+// ============ 法宝 ============
+
+export type BuffEffect =
+  | 'comboBonus'
+  | 'expMultiplier'
+  | 'pityReduction'
+  | 'epicRateBonus'
+  | 'rareRateBonus'
+  | 'legendaryRateBonus'
+  | 'shinyRateBonus'
+  | 'allRateBonus'
+  | 'signInMultiplier'
+  | 'comboLimitBonus'
+  | 'normalUpgrade'
+  | 'instantExp'
+  | 'extraDrop'
+  | 'pitySpeed'
+  | 'previewNextQuality'
+  | 'cliRetry';
+
+export interface Buff {
+  id: string;
+  source: 'treasure' | 'apprentice' | 'achievement';
+  effect: BuffEffect;
+  value: number;
+}
+
+export interface Treasure {
+  id: string;
+  name: string;
+  source: string;
+  description: string;
+  effect: BuffEffect;
+  value: number;
+  consumable: boolean;
+}
+
+// ============ 成就 ============
+
+export type AchievementCategory = 'cultivation' | 'collection' | 'product' | 'hidden';
+
+export interface Achievement {
+  id: string;
+  name: string;
+  emoji: string;
+  description: string;
+  category: AchievementCategory;
+  condition: AchievementCondition;
+  expReward: number;
+  titleReward?: string;
+}
+
+export type AchievementCondition =
+  | { type: 'totalOperations'; count: number }
+  | { type: 'consecutiveSignIn'; days: number }
+  | { type: 'maxCombo'; count: number }
+  | { type: 'totalRecoveries'; count: number }
+  | { type: 'uniqueMonsters'; count: number }
+  | { type: 'shinyMonsters'; count: number }
+  | { type: 'productUsage'; product: string; count: number }
+  | { type: 'allProducts' }
+  | { type: 'dailyOperations'; count: number }
+  | { type: 'nightOwl' }
+  | { type: 'pityTriggered' }
+  | { type: 'consecutiveFailThenSuccess'; failCount: number }
+  | { type: 'dailyRareOrAbove'; count: number }
+  | { type: 'birthday' }
+  | { type: 'consecutiveReport'; days: number }
+  // v2: 逃跑相关
+  | { type: 'totalEscapes'; count: number }
+  | { type: 'consecutiveNoEscape'; count: number }
+  // v2: 悬赏令相关
+  | { type: 'totalBountiesCompleted'; count: number }
+  | { type: 'goldBountiesCompleted'; count: number }
+  | { type: 'consecutiveFullClear'; days: number }
+  // v2: 随机事件相关
+  | { type: 'totalEventsTriggered'; count: number }
+  | { type: 'challengesCompleted'; count: number }
+  | { type: 'survivedMadness' }
+  | { type: 'specificEventCount'; eventId: string; count: number }
+  | { type: 'specificChallengeSuccess'; eventId: string }
+  | { type: 'disasterThenBlessing' }
+  | { type: 'disastersResolved'; count: number };
+
+// ============ 等级 ============
+
+export interface LevelDefinition {
+  level: number;
+  title: string;
+  requiredExp: number;
+  unlockDescription?: string;
+}
+
+export const LEVEL_DEFINITIONS: LevelDefinition[] = [
+  { level: 1, title: '凡人', requiredExp: 0, unlockDescription: '基础掉落池' },
+  { level: 2, title: '樵夫', requiredExp: 120 },
+  { level: 3, title: '修行者', requiredExp: 320, unlockDescription: '解锁"机缘"系统（神仙随机现身）' },
+  { level: 4, title: '散仙', requiredExp: 800, unlockDescription: '掉落池扩展：加入稀有妖怪' },
+  { level: 5, title: '天兵', requiredExp: 2000, unlockDescription: '解锁"法宝"系统' },
+  { level: 6, title: '天将', requiredExp: 4000, unlockDescription: '掉落池扩展：加入史诗妖怪' },
+  { level: 7, title: '哪吒', requiredExp: 8000, unlockDescription: '连击加成上限提升至 ×4.0' },
+  { level: 8, title: '二郎神', requiredExp: 16000, unlockDescription: '掉落池扩展：加入传说妖怪' },
+  { level: 9, title: '齐天大圣', requiredExp: 32000, unlockDescription: '解锁"闪光"掉落' },
+  { level: 10, title: '斗战胜佛', requiredExp: 60000, unlockDescription: '全图鉴解锁提示、专属称号色' },
+];
+
+// ============ 产品修行值 ============
+
+export const PRODUCT_BASE_EXP: Record<string, number> = {
+  aitable: 3,
+  calendar: 2,
+  chat: 2,
+  contact: 1,
+  todo: 2,
+  approval: 4,
+  attendance: 2,
+  report: 3,
+  ding: 1,
+  workbench: 3,
+  devdoc: 1,
+};
+
+// ============ 保底计数器 ============
+
+export interface PityCounters {
+  sinceLastRare: number;
+  sinceLastEpic: number;
+  sinceLastLegendary: number;
+  totalDropsWithoutShiny: number;
+}
+
+/** v2: 保底阈值上调 */
+export const PITY_THRESHOLDS = {
+  rare: 30,
+  epic: 80,
+  legendary: 150,
+  shiny: 800,
+} as const;
+
+/** v2: 软保底起始点 — 接近硬保底时概率逐步提升 */
+export const SOFT_PITY_START = {
+  rare: 20,
+  epic: 60,
+  legendary: 120,
+  shiny: 600,
+} as const;
+
+/** v2: 软保底每次额外增加的概率 */
+export const SOFT_PITY_RATE_PER_STEP = {
+  rare: 0.03,
+  epic: 0.02,
+  legendary: 0.01,
+  shiny: 0.0005,
+} as const;
+
+// ============ 逃跑机制 (v2) ============
+
+/** 各品质的基础逃跑率 */
+export const BASE_ESCAPE_RATES: Record<MonsterQuality, number> = {
+  normal: 0,
+  fine: 0.10,
+  rare: 0.25,
+  epic: 0.40,
+  legendary: 0.60,
+  shiny: 0.75,
+};
+
+/** 逃跑率的最低下限 */
+export const MIN_ESCAPE_RATE = 0.05;
+
+export interface EscapeModifier {
+  source: string;
+  value: number;
+  description: string;
+}
+
+// ============ 悬赏令 (v2) ============
+
+export type BountyTier = 'bronze' | 'silver' | 'gold';
+
+export type BountyConditionType =
+  | 'capture'
+  | 'combo'
+  | 'command'
+  | 'encounter'
+  | 'product_variety'
+  | 'quality_variety';
+
+export interface BountyCondition {
+  type: BountyConditionType;
+  qualityMin?: MonsterQuality;
+  product?: string;
+  count: number;
+  isUpMonster?: boolean;
+  isNew?: boolean;
+}
+
+export interface BountyReward {
+  exp: number;
+  treasureFragment?: string;
+  buff?: TemporaryBuff;
+}
+
+export interface TemporaryBuff {
+  effect: BuffEffect;
+  value: number;
+  description: string;
+  durationOperations?: number;
+}
+
+export interface Bounty {
+  id: string;
+  tier: BountyTier;
+  description: string;
+  target: number;
+  current: number;
+  completed: boolean;
+  reward: BountyReward;
+  condition: BountyCondition;
+}
+
+export interface DailyBountyState {
+  date: string;
+  bounties: Bounty[];
+  completedCount: number;
+}
+
+export interface BountyHistory {
+  totalCompleted: number;
+  bronzeCompleted: number;
+  silverCompleted: number;
+  goldCompleted: number;
+  consecutiveFullClear: number;
+}
+
+// ============ 随机事件 (v2) ============
+
+export type EventCategory = 'blessing' | 'challenge' | 'disaster';
+
+export type EventEffectType =
+  | 'exp_multiplier'
+  | 'quality_boost'
+  | 'extra_drop'
+  | 'product_weight'
+  | 'escape_rate_mod'
+  | 'exp_flat'
+  | 'treasure_grant'
+  | 'monster_escape'
+  | 'quality_cap'
+  | 'exp_halve'
+  | 'combo_reset'
+  | 'no_drop'
+  | 'exp_loss'
+  | 'pity_loss';
+
+export interface EventEffect {
+  type: EventEffectType;
+  value: number;
+  targetCount?: number;
+}
+
+export interface EventDuration {
+  type: 'instant' | 'operation_count' | 'drop_count';
+  total: number;
+  remaining: number;
+}
+
+export interface EventResolution {
+  type: 'consecutive_success' | 'use_treasure' | 'complete_bounty' | 'trigger_encounter';
+  count?: number;
+  treasureId?: string;
+  description: string;
+}
+
+export interface RandomEvent {
+  id: string;
+  name: string;
+  category: EventCategory;
+  triggerRate: number;
+  description: string;
+  flavorText: string;
+  effect: EventEffect;
+  duration: EventDuration;
+  resolution?: EventResolution;
+}
+
+export type ChallengeConditionType =
+  | 'consecutive_success'
+  | 'product_variety'
+  | 'capture_count'
+  | 'success_rate'
+  | 'pick_correct';
+
+export interface ChallengeCondition {
+  type: ChallengeConditionType;
+  target: number;
+  current: number;
+}
+
+export interface ChallengeProgress {
+  operationsUsed: number;
+  operationLimit: number;
+  conditionMet: boolean;
+  /** 挑战期间使用过的不同产品（用于 product_variety 条件） */
+  usedProducts?: string[];
+}
+
+export interface EventReward {
+  exp: number;
+  pityBonus?: number;
+  escapeRateMod?: number;
+  extraDrop?: boolean;
+  treasureFragment?: string;
+  monster?: { qualityMin: MonsterQuality };
+}
+
+export interface EventPenalty {
+  expLoss: number;
+  comboReset?: boolean;
+  pityLoss?: number;
+}
+
+export interface ChallengeEvent extends RandomEvent {
+  category: 'challenge';
+  challengeCondition: ChallengeCondition;
+  successReward: EventReward;
+  failurePenalty: EventPenalty;
+  operationLimit: number;
+  progress: ChallengeProgress;
+}
+
+export interface ActiveEventState {
+  currentEvents: RandomEvent[];
+  activeChallenge: ChallengeEvent | null;
+  lastEventTriggerTime: Record<string, number>;
+}
+
+export interface EventHistoryEntry {
+  eventId: string;
+  triggeredAt: number;
+  outcome?: 'success' | 'failure' | 'resolved' | 'expired';
+}
+
+export interface EventStats {
+  totalTriggered: number;
+  challengesCompleted: number;
+  challengesFailed: number;
+  disastersResolved: number;
+}
+
+// ============ 用户档案 ============
+
+export interface GamificationSettings {
+  enabled: boolean;
+  showDropAnimation: boolean;
+  muteNormalDrops: boolean;
+}
+
+export interface UserProfile {
+  uidHash: string;
+  level: number;
+  title: string;
+  totalExp: number;
+  totalOperations: number;
+  currentCombo: number;
+  maxCombo: number;
+  consecutiveSignInDays: number;
+  lastSignInDate: string;
+  totalRecoveries: number;
+  consecutiveFailures: number;
+  productUsage: Record<string, number>;
+  pityCounters: PityCounters;
+  buffs: Buff[];
+  settings: GamificationSettings;
+  encounters: Encounter[];
+  unlockedAchievements: string[];
+  treasures: string[];
+  consumedTreasures: string[];
+  createdAt: number;
+  checksum: string;
+  /** v2: 妖怪逃跑追踪 — monsterId → 连续逃跑次数 */
+  escapeHistory: Record<string, number>;
+  /** v2: 累计逃跑次数 */
+  totalEscapes: number;
+  /** v2: 每日悬赏令状态 */
+  dailyBounty: DailyBountyState | null;
+  /** v2: 悬赏令历史统计 */
+  bountyHistory: BountyHistory;
+  /** v2: 当前活跃的随机事件 */
+  activeEvents: ActiveEventState;
+  /** v2: 事件统计 */
+  eventStats: EventStats;
+  /** v2: 事件历史记录 */
+  eventHistory: EventHistoryEntry[];
+}
+
+export interface CollectionEntry {
+  monsterId: string;
+  firstCapturedAt: number;
+  captureCount: number;
+  isShiny: boolean;
+}
+
+export interface UserCollection {
+  uidHash: string;
+  entries: CollectionEntry[];
+}
+
+export interface HistoryRecord {
+  timestamp: number;
+  product: string;
+  commandHash: string;
+  success: boolean;
+  expGained: number;
+  monsterId?: string;
+  isShiny?: boolean;
+  encounterId?: string;
+  achievementIds?: string[];
+  /** v2: 妖怪是否逃跑 */
+  escaped?: boolean;
+  /** v2: 触发的事件 ID */
+  eventId?: string;
+  /** v2: 完成的悬赏令 ID 列表 */
+  completedBountyIds?: string[];
+}
+
+export interface UserHistory {
+  uidHash: string;
+  records: HistoryRecord[];
+}
+
+// ============ 掉落结果 ============
+
+export interface DropResult {
+  monster: Monster;
+  isShiny: boolean;
+  isNew: boolean;
+  expGained: number;
+  isPityTriggered: boolean;
+  isUpMonster: boolean;
+  /** v2: 是否逃跑 */
+  escaped: boolean;
+  /** v2: 实际逃跑率（含修正） */
+  escapeRate: number;
+  /** v2: 应用的修正因子列表 */
+  escapeModifiers: EscapeModifier[];
+}
+
+export interface ExpResult {
+  baseExp: number;
+  comboMultiplier: number;
+  firstUseMultiplier: number;
+  signInBonus: number;
+  consecutiveSignInBonus: number;
+  buffMultiplier: number;
+  totalExp: number;
+}
+
+export interface LevelUpResult {
+  previousLevel: number;
+  previousTitle: string;
+  newLevel: number;
+  newTitle: string;
+  unlockDescription?: string;
+}
+
+// ============ 引擎输出 ============
+
+export interface GamificationOutput {
+  expResult: ExpResult;
+  dropResult: DropResult;
+  encounter: Encounter | null;
+  newAchievements: Achievement[];
+  levelUp: LevelUpResult | null;
+  /** v2: 完成的悬赏令列表 */
+  completedBounties: Bounty[];
+  /** v2: 触发的随机事件 */
+  triggeredEvent: RandomEvent | null;
+}
+
+// ============ 掉落概率配置 ============
+
+export const DROP_RATES: Record<MonsterQuality, number> = {
+  shiny: 0.001,
+  legendary: 0.009,
+  epic: 0.04,
+  rare: 0.10,
+  fine: 0.25,
+  normal: 0.60,
+};
+
+/** 等级门槛：低于此等级的品质会降级 */
+export const QUALITY_LEVEL_GATES: Partial<Record<MonsterQuality, number>> = {
+  rare: 4,
+  epic: 6,
+  legendary: 8,
+  shiny: 9,
+};
+
+/** 连击加成倍率 */
+export const COMBO_MULTIPLIERS: Array<{ threshold: number; multiplier: number }> = [
+  { threshold: 10, multiplier: 3.0 },
+  { threshold: 5, multiplier: 2.0 },
+  { threshold: 3, multiplier: 1.5 },
+];
+
+/** 机缘触发概率 */
+export const ENCOUNTER_RATES: Record<EncounterType, number> = {
+  guidance: 0.08,
+  treasure: 0.03,
+  apprentice: 0.005,
+};
+
+/** 产品关联权重倍数 */
+export const PRODUCT_WEIGHT_MULTIPLIER = 3;
+
+/** UP 池权重倍数 */
+export const UP_WEIGHT_MULTIPLIER = 5;

--- a/src/game-xiyou/uid-resolver.ts
+++ b/src/game-xiyou/uid-resolver.ts
@@ -1,0 +1,49 @@
+/**
+ * UID 解析与绑定
+ *
+ * 优先级链：
+ * 1. 钉钉 userId（通过 connector 的 device-auth 获取）
+ * 2. 本机 fingerprint（兜底，基于 hostname + username 的 SHA256）
+ */
+
+import { createHash } from 'crypto';
+import * as os from 'os';
+
+const SALT = 'xiyou-salt-2026';
+
+/**
+ * 根据原始 UID 生成稳定的哈希标识
+ */
+export function hashUid(rawUid: string): string {
+  return createHash('sha256')
+    .update(rawUid + SALT)
+    .digest('hex')
+    .slice(0, 16);
+}
+
+/**
+ * 生成本机指纹作为兜底 UID
+ */
+function generateMachineFingerprint(): string {
+  const hostname = os.hostname();
+  const username = os.userInfo().username;
+  return `machine:${hostname}:${username}`;
+}
+
+/**
+ * 解析用户 UID
+ *
+ * @param senderId - 钉钉消息的发送者 ID（优先使用）
+ * @returns 稳定的 UID 哈希值（16 位 hex）
+ */
+export function resolveUid(senderId?: string): string {
+  const rawUid = senderId || generateMachineFingerprint();
+  return hashUid(rawUid);
+}
+
+/**
+ * 获取 UID 的短标识（用于展示）
+ */
+export function getShortUid(uidHash: string): string {
+  return uidHash.slice(0, 8);
+}

--- a/src/gateway-methods.ts
+++ b/src/gateway-methods.ts
@@ -5,12 +5,33 @@
  */
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { resolveDingtalkAccount } from "./config/accounts.ts";
+import { resolveDingtalkAccount, listDingtalkAccountIds } from "./config/accounts.ts";
 import { DingtalkDocsClient } from "./docs.ts";
 import { sendProactive } from "./services/messaging.ts";
 import { getUnionId, recallEmotionReply } from "./utils/utils-legacy.ts";
 import { finishAICard } from "./services/messaging/card.ts";
 import type { AICardInstance } from "./services/messaging/card.ts";
+
+/**
+ * Warn when accountId is not explicitly provided and multiple accounts exist.
+ * Returns the resolved account (unchanged), but emits a log warning so that
+ * callers (typically AI agents) learn to pass accountId explicitly.
+ */
+function warnIfAccountIdMissing(
+  cfg: any,
+  accountId: unknown,
+  method: string,
+  log?: any,
+): void {
+  if (accountId) return;
+  const allIds = listDingtalkAccountIds(cfg);
+  if (allIds.length > 1) {
+    log?.warn?.(
+      `[Gateway][${method}] accountId not specified but ${allIds.length} accounts configured (${allIds.join(", ")}). ` +
+      `Falling back to default account. To use the correct bot, pass accountId explicitly.`,
+    );
+  }
+}
 
 /**
  * 注册所有 Gateway Methods
@@ -37,6 +58,7 @@ export function registerGatewayMethods(api: OpenClawPluginApi) {
     const cfg = loadConfig();
     try {
       const { userId, userIds, content, msgType, title, useAICard, fallbackToNormal, accountId } = params || {};
+      warnIfAccountIdMissing(cfg, accountId, 'sendToUser', log);
       const account = resolveDingtalkAccount({ cfg, accountId });
       if (!account.config?.clientId) {
         return respond(false, { error: 'DingTalk not configured' });
@@ -64,7 +86,7 @@ export function registerGatewayMethods(api: OpenClawPluginApi) {
         fallbackToNormal: fallbackToNormal !== false,
       });
 
-      respond(result.ok, result);
+      respond(result.ok, { ...result, usedAccountId: account.accountId });
     } catch (err: any) {
       log?.error?.(`[Gateway][sendToUser] 错误: ${err.message}`);
       respond(false, { error: err.message });
@@ -88,6 +110,7 @@ export function registerGatewayMethods(api: OpenClawPluginApi) {
     const cfg = loadConfig();
     try {
       const { openConversationId, content, msgType, title, useAICard, fallbackToNormal, accountId } = params || {};
+      warnIfAccountIdMissing(cfg, accountId, 'sendToGroup', log);
       const account = resolveDingtalkAccount({ cfg, accountId });
       if (!account.config?.clientId) {
         return respond(false, { error: 'DingTalk not configured' });
@@ -109,7 +132,7 @@ export function registerGatewayMethods(api: OpenClawPluginApi) {
         fallbackToNormal: fallbackToNormal !== false,
       });
 
-      respond(result.ok, result);
+      respond(result.ok, { ...result, usedAccountId: account.accountId });
     } catch (err: any) {
       log?.error?.(`[Gateway][sendToGroup] 错误: ${err.message}`);
       console.error(err);
@@ -123,8 +146,9 @@ export function registerGatewayMethods(api: OpenClawPluginApi) {
     try {
       const { target, content, message, msgType, title, useAICard, fallbackToNormal, accountId } = params || {};
       const actualContent = content || message;
+      warnIfAccountIdMissing(cfg, accountId, 'send', log);
       const account = resolveDingtalkAccount({ cfg, accountId });
-      log?.info?.(`[Gateway][send] 收到请求: target=${target}, contentLen=${actualContent?.length}`);
+      log?.info?.(`[Gateway][send] 收到请求: target=${target}, contentLen=${typeof actualContent === 'string' ? actualContent.length : 0}, accountId=${account.accountId}`);
 
       if (!account.config?.clientId) {
         return respond(false, { error: 'DingTalk not configured' });

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -95,6 +95,13 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
   
   // 异步模式：累积完整响应
   let asyncModeFullResponse = "";
+
+  // ===== 养成系统: 通过 onCommandOutput 监听 dws 命令执行 =====
+  // 记录当前回复周期内 onCommandOutput 回调检测到的 dws 产品名（如 "aitable"、"calendar"），
+  // 在 closeStreaming 时用于触发降妖逻辑，每轮结束后清空。
+  const detectedDwsProducts = new Set<string>();
+  // 匹配 shell 命令中的 dws 子命令（如 `dws aitable list`），提取产品名用于养成系统掉落判定。
+  const DWS_PRODUCT_PATTERN = /\bdws\s+(aitable|calendar|chat|contact|todo|approval|attendance|report|ding|workbench|devdoc)\b/;
   
   // ✅ 节流控制：避免频繁调用钉钉 API 导致 QPS 限流
   // 全局令牌桶限流器已在 streamAICard 内部实现（card.ts），此处的 updateInterval
@@ -340,6 +347,43 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         log.info(`[DingTalk][closeStreaming] processRawMediaPaths 处理完成`);
       } else {
         log.warn(`[DingTalk][closeStreaming] oapiToken 为空，跳过媒体处理`);
+      }
+
+      // ===== 养成系统：基于 onCommandOutput 检测到的 dws 产品触发降妖 =====
+      // 优先使用 onCommandOutput 监听到的产品（精准），兜底用正则匹配回复文本
+      try {
+        const productsToProcess = new Set<string>(detectedDwsProducts);
+
+        // 兜底：如果 onCommandOutput 没捕获到，尝试从回复文本中正则匹配
+        if (productsToProcess.size === 0) {
+          const dwsProductMatch = finalText.match(/(?:^|\n)\s*(?:>?\s*)?(?:`\s*)?dws\s+(aitable|calendar|chat|contact|todo|approval|attendance|report|ding|workbench|devdoc)\b/m);
+          if (dwsProductMatch && !finalText.includes('command not found: dws') && !finalText.includes('请先执行 dws login')) {
+            productsToProcess.add(dwsProductMatch[1]);
+            log.info(`[DingTalk][closeStreaming] 养成系统：正则兜底匹配到产品=${dwsProductMatch[1]}`);
+          }
+        } else {
+          log.info(`[DingTalk][closeStreaming] 养成系统：onCommandOutput 监听到 ${productsToProcess.size} 个 dws 产品: ${[...productsToProcess].join(', ')}`);
+        }
+
+        if (productsToProcess.size > 0) {
+          const { GamificationEngine } = await import('./game-xiyou/index.ts');
+          const engine = GamificationEngine.getInstanceForUser(senderId);
+          if (engine.isEnabled()) {
+            // 一次任务只触发一次降妖，取第一个产品作为代表
+            const primaryProduct = [...productsToProcess][0];
+            const allProducts = [...productsToProcess].join('+');
+            const gamificationBlock = engine.onDwsCommandResult(primaryProduct, true, `dws ${allProducts}`);
+            if (gamificationBlock) {
+              finalText += '\n' + gamificationBlock;
+              log.info(`[DingTalk][closeStreaming] ✅ 养成系统渲染已追加，主产品=${primaryProduct}，涉及产品=${allProducts}`);
+            }
+          }
+        }
+
+        // 清空本轮检测记录
+        detectedDwsProducts.clear();
+      } catch (gamErr: any) {
+        log.warn(`[DingTalk][closeStreaming] 养成系统处理失败（不影响主流程）: ${gamErr?.message || gamErr}`);
       }
 
       log.info(`[DingTalk][closeStreaming] 准备调用 finishAICard，文本长度=${finalText.length}`);
@@ -628,6 +672,33 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         }
       },
       }),
+      // ===== 养成系统：监听 dws 命令执行 =====
+      onCommandOutput: (payload: {
+        itemId?: string;
+        phase?: string;
+        title?: string;
+        toolCallId?: string;
+        name?: string;
+        output?: string;
+        status?: string;
+        exitCode?: number | null;
+        durationMs?: number;
+        cwd?: string;
+      }) => {
+        const commandText = payload.title || payload.name || '';
+        const dwsMatch = commandText.match(DWS_PRODUCT_PATTERN) || payload.output?.match(DWS_PRODUCT_PATTERN);
+        if (dwsMatch) {
+          const product = dwsMatch[1];
+          // 只记录成功执行的命令（exitCode 为 0 或 phase 不是 end 时还不知道结果）
+          const isFailure = payload.phase === 'end' && payload.exitCode !== null && payload.exitCode !== 0;
+          if (!isFailure) {
+            detectedDwsProducts.add(product);
+            log.info(`[DingTalk][onCommandOutput] 检测到 dws 产品: ${product}，phase=${payload.phase}, exitCode=${payload.exitCode}`);
+          } else {
+            log.info(`[DingTalk][onCommandOutput] dws 命令执行失败，跳过: ${product}，exitCode=${payload.exitCode}`);
+          }
+        }
+      },
     },
     markDispatchIdle,
     getAsyncModeResponse: () => asyncModeFullResponse,


### PR DESCRIPTION

### 🎉 新版本亮点 / Highlights

本次版本最大亮点是**西游妖魔榜养成系统**，每次通过 Agent 成功调用 dws CLI 执行钉钉产品操作（AI 表格、日历、通讯录等），就是一次"降妖除魔"。妖怪按品质随机掉落，包含等级成长、图鉴收集、悬赏任务、随机事件等完整养成体验。同时修复了**多 bot 凭证隔离**问题和**能力路由提示词**优化。

The highlight is the **XiYou Monster Bestiary Progression System** — every successful dws CLI operation triggers a "monster capture" with quality-based random drops. Includes leveling, collection index, daily bounties, random events, and bot credential isolation fix.

### ✨ 新增 / Added

#### 养成系统核心 / Gamification Core

- **降妖机制**：通过 `onCommandOutput` 回调监听 dws 命令执行，精准检测产品名并触发掉落，一次任务只触发一次降妖
- **妖怪池 65 只**：普通 20 / 精良 15 / 稀有 12 / 史诗 10 / 传说 8，每个 dws 产品绑定多只妖怪，随机触发
- **等级系统**：10 级成长路线（凡人→斗战胜佛），每级解锁新机制
- **保底机制**：小保底（稀有 30 次）、大保底（史诗 80 次）、天命保底（传说 150 次）、闪光保底（800 次），含软保底加成
- **神仙机缘**：等级 ≥ 3 后触发，点化/赐宝/收徒三种类型
- **法宝系统**：一次性消耗品（蟠桃、人参果等）和永久 buff

#### 悬赏令 & 随机事件 (v2) / Bounty & Events

- **悬赏令系统**：每日生成铜/银/金三档任务，完成奖励修行值
- **随机事件系统**：祝福（增益）、挑战（限时任务）、灾厄（减益+化解）三类事件
- **逃跑系统**：妖怪有概率逃跑，记录逃跑历史

#### 聊天命令 / Chat Commands

- `/修行` — 个人修行面板（等级、修行值、连击、签到等）
- `/图鉴` `/图鉴 妖怪名` — 图鉴收集进度 / 妖怪详情
- `/成就` — 成就列表及解锁状态
- `/法宝` `/使用 法宝名` — 法宝背包 / 使用一次性法宝
- `/妖魔榜` — 本周 UP 妖怪、掉落统计、保底状态
- `/机缘` — 神仙机缘录
- `/保底` — 保底计数器详情（含软保底状态）
- `/炫耀` — 生成炫耀卡片
- `/悬赏` — 今日悬赏令及历史统计
- `/事件` — 当前活跃事件及事件统计
- `/西游` `/西游 开启` `/西游 关闭` — 帮助面板 + 一键开关

### 🐛 修复 / Fixes

#### bot 凭证隔离 / Bot Credential Isolation

- 在 `message-handler.ts` 中注入 `[DingTalk Bot Context]` 到 agent 消息上下文，包含当前对话 bot 的 `clientId`
- `channel.ts` 中将 `clientId` 写入 `process.env.DWS_CLIENT_ID`
- `dingtalk-channel-rules/SKILL.md` 更新提示词，引导 AI 从上下文提取 `clientId` 并传入 `--client-id` 参数

#### `/事件` `/悬赏` 命令报错 / Command Fix

- 修复 `commands.ts` 中 `renderBountyPanel` 和 `renderEventPanel` 未导入导致的 `is not defined` 报错

#### 数据迁移 / Data Migration

- `storage.ts` 中添加 `migrateProfile` 函数，旧版 profile 自动补全 v2 新增字段（`activeEvents`、`eventStats`、`bountyHistory` 等）

### ✅ 改进 / Improvements

#### 能力路由提示词 / Capability Routing Prompt

- `dingtalk-channel-rules/SKILL.md` 补充完整的能力路由表，覆盖 chat/contact/calendar/aitable/todo/report/drive/ding/attendance/approval 等场景
- 新增易混淆场景速查表，防止 AI "假装执行"（如用户说"给某某发消息"时必须走 `dws chat`）

#### 多 bot 凭证隔离指引 / Multi-bot Credential Guide

- 提示词中新增 `🔑 多机器人场景：bot 凭证隔离` 章节，引导 AI 正确传递 `--client-id`

### 📁 新增文件 / New Files

```
src/gamification/
├── achievement-engine.ts    # 成就系统
├── bounty-system.ts         # 悬赏令系统
├── commands.ts              # 聊天命令处理
├── drop-engine.ts           # 掉落引擎
├── encounter-system.ts      # 神仙机缘
├── escape-engine.ts         # 逃跑系统
├── exp-calculator.ts        # 经验值计算
├── index.ts                 # 养成系统入口
├── level-system.ts          # 等级系统
├── monster-pool.ts          # 妖怪数据池（65只）
├── pity-counter.ts          # 保底计数器
├── random-event-engine.ts   # 随机事件引擎
├── renderer.ts              # Markdown 渲染
├── storage.ts               # 数据持久化
├── treasure-system.ts       # 法宝系统
├── types.ts                 # 类型定义
└── uid-resolver.ts          # UID 解析
```

### 🔥 安装升级 / Installation & Upgrade

```bash
npx -y @dingtalk-real-ai/dingtalk-connector install
```

或手动安装：

```bash
openclaw plugins install @dingtalk-real-ai/dingtalk-connector
```

### 🔗 相关链接 / Related Links

- [完整变更日志 / Full Changelog](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/CHANGELOG.md)
- [使用文档 / Documentation](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/README.md)

- **发布日期 / Release Date**：2026-04-22
- **兼容性 / Compatibility**：OpenClaw Gateway 2026.3.23+
