### PR TITLE
feat: disable xiyou gamification system by default

### DIFF
--- a/src/game-xiyou/storage.ts
+++ b/src/game-xiyou/storage.ts
@@ -53,7 +53,7 @@ export function verifyChecksum(profile: UserProfile): boolean {
 
 function createDefaultProfile(uidHash: string): UserProfile {
   const defaultSettings: GamificationSettings = {
-    enabled: true,
+    enabled: false,
     showDropAnimation: true,
     muteNormalDrops: false,
   };


### PR DESCRIPTION
- 关闭西游养成系统默认开启，改为默认关闭
- 用户可通过 /西游 命令手动开启