### PR TITLE
fix: proactive media APIs use wrong token type (HTTP 500) + non-streaming fallback skips file markers

### DIFF
--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -562,6 +562,17 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         if (info?.kind === "final") {
           log.info(`[DingTalk][deliver] 降级到非流式发送，文本长度=${text.length}, isTextMode=${isTextMode}, groupReplyMode=${groupReplyMode}`);
           try {
+            // 处理文件/视频/音频标记：上传媒体并通过 proactive API 发送
+            const oapiToken = await getOapiAccessToken(account.config as DingtalkConfig);
+            if (oapiToken) {
+              const fallbackTarget: AICardTarget = isDirect
+                ? { type: 'user', userId: senderId }
+                : { type: 'group', openConversationId: conversationId };
+              text = await processVideoMarkers(text, '', account.config as DingtalkConfig, oapiToken, log, true, fallbackTarget);
+              text = await processAudioMarkers(text, '', account.config as DingtalkConfig, oapiToken, log, true, fallbackTarget);
+              text = await processFileMarkers(text, '', account.config as DingtalkConfig, oapiToken, log, true, fallbackTarget);
+            }
+
             for (const chunk of core.channel.text.chunkTextWithMode(
               text,
               textChunkLimit,

--- a/src/services/media.ts
+++ b/src/services/media.ts
@@ -420,7 +420,7 @@ export async function processVideoMarkers(
 
       // 5. 发送视频消息
       if (useProactiveApi && target) {
-        await sendVideoProactive(config, target, videoMediaId, picMediaId, metadata, log);
+        await sendVideoProactive(config, target, videoMediaId, picMediaId, metadata, log, oapiToken || undefined);
       } else {
         await sendVideoMessage(config, sessionWebhook, fileName, videoUploadResult.downloadUrl, log, metadata);
       }
@@ -576,7 +576,7 @@ export async function processAudioMarkers(
 
       // 发送音频消息
       if (useProactiveApi && target) {
-        await sendAudioProactive(config, target, fileName, uploadResult.downloadUrl, log, audioDurationMs ?? undefined);
+        await sendAudioProactive(config, target, fileName, uploadResult.downloadUrl, log, audioDurationMs ?? undefined, oapiToken || undefined);
       } else {
         await sendAudioMessage(config, sessionWebhook, fileName, uploadResult.downloadUrl, log, audioDurationMs ?? undefined);
       }
@@ -679,7 +679,7 @@ export async function processFileMarkers(
 
       // 发送文件消息（钉钉 API 统一要求带 @ 前缀的 mediaId）
       if (useProactiveApi && target) {
-        await sendFileProactive(config, target, fileInfo, uploadResult.mediaId, log);
+        await sendFileProactive(config, target, fileInfo, uploadResult.mediaId, log, oapiToken || undefined);
       } else {
         await sendFileMessage(config, sessionWebhook, fileInfo, uploadResult.mediaId, log);
       }
@@ -762,9 +762,10 @@ export async function sendVideoProactive(
   picMediaId: string,
   metadata?: { duration: number; width: number; height: number },
   log?: any,
+  oapiToken?: string,
 ): Promise<void> {
   try {
-    const token = await (await import('../utils/index.ts')).getAccessToken(config);
+    const token = oapiToken || await (await import('../utils/index.ts')).getAccessToken(config);
     const { DINGTALK_API } = await import('../utils/index.ts');
 
     // 钉钉普通消息 API 的视频消息格式
@@ -865,9 +866,10 @@ export async function sendAudioProactive(
   mediaId: string,
   log?: any,
   durationMs?: number,
+  oapiToken?: string,
 ): Promise<void> {
   try {
-    const token = await (await import('../utils/index.ts')).getAccessToken(config);
+    const token = oapiToken || await (await import('../utils/index.ts')).getAccessToken(config);
     const { DINGTALK_API } = await import('../utils/index.ts');
 
     // 钉钉普通消息 API 的音频消息格式
@@ -960,9 +962,10 @@ export async function sendFileProactive(
   fileInfo: FileInfo,
   mediaId: string,
   log?: any,
+  oapiToken?: string,
 ): Promise<void> {
   try {
-    const token = await (await import('../utils/index.ts')).getAccessToken(config);
+    const token = oapiToken || await (await import('../utils/index.ts')).getAccessToken(config);
     const { DINGTALK_API } = await import('../utils/index.ts');
 
     // 钉钉普通消息 API 的文件消息格式
@@ -1097,16 +1100,16 @@ export async function processRawMediaPaths(
         
         if (target) {
           // 视频消息需要原始 mediaId（带 @）
-          await sendVideoProactive(config, target, uploadResult.mediaId, fileName, log, metadata);
+          await sendVideoProactive(config, target, uploadResult.mediaId, fileName, log, metadata, oapiToken);
         }
         statusMessages.push(`✅ 视频已发送: ${fileName}`);
       } else if (mediaType === 'voice') {
         // 提取音频时长
         const durationMs = await extractAudioDuration(filePath, log);
-        
+
         if (target) {
           // 音频消息使用下载链接
-          await sendAudioProactive(config, target, fileName, uploadResult.downloadUrl, log, durationMs ?? undefined);
+          await sendAudioProactive(config, target, fileName, uploadResult.downloadUrl, log, durationMs ?? undefined, oapiToken);
         }
         statusMessages.push(`✅ 音频已发送: ${fileName}`);
       } else {
@@ -1116,9 +1119,9 @@ export async function processRawMediaPaths(
           fileName: fileName,
           fileType: ext,
         };
-        
+
         if (target) {
-          await sendFileProactive(config, target, fileInfo, uploadResult.mediaId, log);
+          await sendFileProactive(config, target, fileInfo, uploadResult.mediaId, log, oapiToken);
         }
         statusMessages.push(`✅ 文件已发送: ${fileName}`);
       }


### PR DESCRIPTION
## Summary

Fix two critical bugs that prevent file/video/audio messages from being sent via proactive APIs (batchSend/groupSend).

### Bug 1: Wrong token type in proactive media APIs (Root Cause)

`sendFileProactive`, `sendVideoProactive`, and `sendAudioProactive` internally call `getAccessToken(config)` which obtains an **OAuth2 v1.0 token** via `POST api.dingtalk.com/v1.0/oauth2/accessToken`. However, the proactive messaging APIs (`/v1.0/robot/oToMessages/batchSend` and `/v1.0/robot/groupMessages/send`) **reject this token with HTTP 500**.

The correct token is the **OAPI token** obtained via `oapi.dingtalk.com/gettoken` (already available as `oapiToken` in all callers). The upload step already uses `oapiToken`, so the send step should use the same token.

**Confirmed in v0.8.20-beta.8**: This bug is still present.

**Reproduction**:
1. Configure a DingTalk robot with file sending capability
2. Send a file using `[DINGTALK_FILE]` marker in streaming mode
3. File uploads successfully (uses oapiToken), but `batchSend` returns HTTP 500 (uses OAuth2 v1.0 token)

### Bug 2: Non-streaming fallback path skips media marker processing

When `streamingEnabled=true` but AI Card creation fails, the `deliver` function falls back to non-streaming `sendMessage`. This path does **not** call `processFileMarkers`/`processVideoMarkers`/`processAudioMarkers`, so `[DINGTALK_FILE]`/`[DINGTALK_VIDEO]`/`[DINGTALK_AUDIO]` markers are sent as raw text to the user instead of being processed into file cards.

## Changes

### `src/services/media.ts` (14 lines changed)

1. **`sendFileProactive`**: Add `oapiToken?: string` parameter, use `oapiToken || getAccessToken(config)` for backward compatibility
2. **`sendVideoProactive`**: Same fix
3. **`sendAudioProactive`**: Same fix
4. **`processFileMarkers`**: Pass `oapiToken` to `sendFileProactive` call
5. **`processVideoMarkers`**: Pass `oapiToken` to `sendVideoProactive` call
6. **`processAudioMarkers`**: Pass `oapiToken` to `sendAudioProactive` call
7. **`processRawMediaPaths`**: Pass `oapiToken` to all proactive calls

### `src/reply-dispatcher.ts` (11 lines added)

1. **`deliver` non-streaming fallback**: Before calling `sendMessage`, process video/audio/file markers via `processVideoMarkers`/`processAudioMarkers`/`processFileMarkers` with `useProactiveApi=true` and the correct `target`.

## Test Plan

- [x] Send a file (xlsx/pdf) via proactive API in a 1:1 chat → should receive file card (not HTTP 500)
- [x] Send a file via proactive API in a group chat → should receive file card
- [x] Trigger non-streaming fallback (disable AI Card creation) → file markers should be processed, not sent as raw text
- [x] Test video/audio markers work in both streaming and non-streaming paths
- [x] Verify backward compatibility: proactive APIs still work when `oapiToken` is not provided (falls back to `getAccessToken`)