### PR TITLE
feat:支持使用自定义的AI卡片模版

### DIFF
--- a/docs/USER_FEEDBACK.md
+++ b/docs/USER_FEEDBACK.md
@@ -1,0 +1,211 @@
+# feat: 支持自定义 AI 卡片模板 & 用户反馈记录到 Session
+
+## Summary
+
+- 支持自定义钉钉 AI 卡片模板，通过配置项指定 `cardTemplateId`、`cardTemplateKey` 替换内置模板，使不同业务场景可以使用各自的卡片样式
+- 新增 TOPIC_CARD Stream 回调处理器，接收用户点赞/点踩操作并更新卡片状态
+- 卡片回调的 actionId 和变量名支持自定义配置（`cardLikeActionId`、`cardDislikeActionId`、`cardFeedbackStatusKey`），适配不同卡片模板的按钮定义
+- 用户反馈（点赞/点踩）自动记录到 OpenClaw session JSONL 文件，供会话统计插件消费
+- 单聊和群聊场景均已实测验证通过
+
+## 变更内容
+
+### 1. 自定义 AI 卡片模板支持（af86a20）
+
+**问题**：之前 AI 卡片模板 ID 硬编码为 `02fcf2f4-5e02-4a85-b672-46d1f715543e.schema`，内容字段名固定为 `msgContent`，无法使用自定义卡片模板。
+
+**方案**：新增 5 个可选配置项（均有默认值，不影响已有配置），将模板 ID、内容字段名、回调按钮 ID 全部参数化。
+
+#### 新增配置项
+
+| 配置项 | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `cardTemplateId` | `string` | `02fcf2f4-...schema` | AI 卡片模板 ID |
+| `cardTemplateKey` | `string` | `msgContent` | 卡片内容 Markdown 变量名 |
+| `cardLikeActionId` | `string` | `ai_res_like` | 点赞按钮的回调 actionId |
+| `cardDislikeActionId` | `string` | `ai_res_dislike` | 点踩按钮的回调 actionId |
+| `cardFeedbackStatusKey` | `string` | `like` | 卡片中表示赞踩状态的变量名 |
+
+配置位置：`openclaw.json` 中的 `dingtalk-connector` 插件配置。支持两种配置模式：
+
+**单账号模式**（直接在插件顶层配置）：
+
+```json
+{
+  "dingtalk-connector": {
+    "clientId": "xxx",
+    "clientSecret": "xxx",
+    "cardTemplateId": "your-custom-template-id.schema",
+    "cardTemplateKey": "content",
+    "cardLikeActionId": "thumbs_up",
+    "cardDislikeActionId": "thumbs_down",
+    "cardFeedbackStatusKey": "feedbackStatus"
+  }
+}
+```
+
+**多账号模式**（在 `accounts[].config` 中配置，可按账号设置不同模板）：
+
+```json
+{
+  "dingtalk-connector": {
+    "accounts": [
+      {
+        "clientId": "xxx",
+        "clientSecret": "xxx",
+        "config": {
+          "cardTemplateId": "your-custom-template-id.schema",
+          "cardTemplateKey": "content"
+        }
+      }
+    ]
+  }
+}
+```
+
+#### 代码变更
+
+- **`src/services/messaging/card.ts`**：将硬编码的 `AI_CARD_TEMPLATE_ID` 改为 `DEFAULT_AI_CARD_TEMPLATE_ID`，`createAICardForTarget`、`streamAICard`、`finishAICard` 均从 config 读取 `cardTemplateId` 和 `cardTemplateKey`
+- **`src/config/schema.ts`**：在 `DingtalkSharedConfigShape` 中新增 5 个 optional 字段
+- **`openclaw.plugin.json`**：在顶层和 accounts 两处 JSON Schema 中注册新字段
+- **`src/core/message-handler.ts`**：移除本文件中重复定义的 `AI_CARD_TEMPLATE_ID` 和 `AICardStatus` 常量（已统一到 `card.ts`）
+- **`src/reply-dispatcher.ts`**：非 QPS 错误时保留 sendFallbackErrorMessage 兜底逻辑，确保用户始终能收到反馈
+
+#### TOPIC_CARD 回调处理器
+
+在 `src/core/connection.ts` 中新增 TOPIC_CARD Stream 回调监听器：
+
+- 解析回调数据（支持 content 二次 JSON 解析）
+- 从 `cardPrivateData.actionIds` 判断是点赞还是点踩
+- 根据配置的 `cardLikeActionId`/`cardDislikeActionId`/`cardFeedbackStatusKey` 构造响应
+- 点踩时解析 `dislike_reason` 和 `custom_dislike_reason` 参数
+- 通过 `socketCallBackResponse` 响应回调（finally 块保证无论异常都响应，避免钉钉超时重试）
+
+### 2. 用户反馈记录到 Session（c46fa86）
+
+**问题**：用户的点赞/点踩行为仅在卡片上生效，无法在会话历史中留存，统计插件无法获取用户满意度数据。
+
+**方案**：新增 card-session 内存映射注册表，在卡片创建时注册 `cardInstanceId → sessionKey` 映射，在回调触发时查找映射并将反馈追加到 session JSONL 文件。
+
+#### 数据流
+
+```
+卡片创建(reply-dispatcher.ts) → registerCardSession(cardInstanceId, sessionKey)
+                                         ↓ (内存 Map)
+用户点赞/踩(connection.ts)    → recordFeedbackToSession(outTrackId, like, userId)
+                                         ↓
+                               查找 sessions.json → 定位 JSONL 文件
+                                         ↓
+                               appendFile → session JSONL
+```
+
+#### JSONL 条目格式
+
+统计插件通过 `type === "custom" && customType === "user-feedback"` 过滤反馈条目。
+
+**点赞：**
+
+```json
+{
+  "type": "custom",
+  "customType": "user-feedback",
+  "data": {
+    "like": 1,
+    "userId": "194584",
+    "cardInstanceId": "card_1777440689892_pwm21ymr",
+    "source": "dingtalk-card"
+  },
+  "id": "12bbd507",
+  "parentId": null,
+  "timestamp": "2026-04-29T05:31:41.309Z"
+}
+```
+
+**点踩（含原因）：**
+
+```json
+{
+  "type": "custom",
+  "customType": "user-feedback",
+  "data": {
+    "like": -1,
+    "userId": "194584",
+    "cardInstanceId": "card_1777440689892_pwm21ymr",
+    "source": "dingtalk-card",
+    "dislikeReasons": ["回答不准确", "太啰嗦"],
+    "customDislikeReason": "没有给出具体代码"
+  },
+  "id": "c80d4b7c",
+  "parentId": null,
+  "timestamp": "2026-04-29T05:32:24.593Z"
+}
+```
+
+> `like` 字段为数字类型：`1` = 点赞，`-1` = 点踩。
+
+#### 重复反馈
+
+用户可以反复点赞或点踩同一张卡片，每次操作追加新条目。**统计时以同一 `(cardInstanceId, userId)` 的最后一条为准**（群聊中多用户可对同一卡片独立反馈）。
+
+#### 核心模块
+
+- **`src/services/card-session-registry.ts`**（新增）：内存注册表（`Map<cardInstanceId, {sessionKey, agentId}>`，24h TTL + 30min 自动清理）+ `recordFeedbackToSession()` 异步写入
+- **`src/reply-dispatcher.ts`**：新增 `sessionKey` 参数，在两处卡片创建路径调用 `registerCardSession()`
+- **`src/core/message-handler.ts`**：将已有 `sessionKey` 变量传递给 `createDingtalkReplyDispatcher()`
+- **`src/core/connection.ts`**：在 TOPIC_CARD 回调中 fire-and-forget 调用 `recordFeedbackToSession()`
+
+## 文件变更
+
+| 文件 | 变更类型 | 说明 |
+|------|----------|------|
+| `openclaw.plugin.json` | 修改 | 新增 5 个卡片配置项 JSON Schema |
+| `src/config/schema.ts` | 修改 | 新增 5 个 optional 配置字段 |
+| `src/core/connection.ts` | 修改 | 新增 TOPIC_CARD 回调处理器 + 反馈记录调用 |
+| `src/core/message-handler.ts` | 修改 | 移除重复常量 + 传递 sessionKey |
+| `src/reply-dispatcher.ts` | 修改 | 支持 sessionKey 参数 + 注册卡片映射 |
+| `src/services/messaging/card.ts` | 修改 | 模板 ID 和内容字段名参数化 |
+| `src/services/card-session-registry.ts` | **新增** | 卡片-会话映射注册表 + 反馈写入 |
+| `tests/card-feedback/card-feedback.test.ts` | **新增** | 13 个单元测试（注册表 + 反馈写入） |
+| `tests/card-feedback/card-callback.test.ts` | **新增** | 11 个单元测试（TOPIC_CARD 回调解析） |
+| `tests/card-feedback/card-contentkey.test.ts` | **新增** | 4 个单元测试（自定义模板 contentKey） |
+| `docs/USER_FEEDBACK.md` | **新增** | 反馈功能文档（含 PR 描述 + 统计消费指南） |
+
+## 测试
+
+- 单元测试：28 个测试全部通过（`vitest run tests/card-feedback/`）
+  - 注册/查找/覆盖
+  - TTL 过期清理
+  - 点赞/点踩写入验证
+  - 点踩原因字段验证
+  - 异常路径（空 outTrackId、未知卡片、sessions.json 不存在、sessionKey 不存在、sessionFile 已删除）
+  - TOPIC_CARD 回调（actionId 解析、自定义 actionId、点踩原因、解析失败）
+  - card.ts 自定义 contentKey 替换路径（默认/自定义模板的 staticMsgContent 写入行为）
+- 集成测试：
+  - 单聊（admin agent）：点赞/点踩反馈正确记录到 session JSONL
+  - 群聊（main agent）：点赞/点踩反馈正确记录到 session JSONL
+- 构建：`npx tsdown` 通过
+
+## 注意事项
+
+- 所有新增配置项均为 optional 且有默认值，**完全向后兼容**，不影响使用内置模板的已有部署
+- 内存映射表在进程重启后清空，重启前创建的卡片如收到反馈将无法定位 session（日志输出 warn 提示）
+- 反馈写入为 fire-and-forget 异步操作，不阻塞卡片回调响应
+
+## 重要约束与已知限制
+
+### OpenClaw Session JSONL 直写耦合
+
+反馈写入功能通过 `appendFile` 直接写入 `~/.openclaw/agents/{agentId}/sessions/*.jsonl`，这是插件对 OpenClaw 私有目录的约定写入：
+
+- **目录约定**：依赖 `~/.openclaw/agents/{agentId}/sessions/sessions.json` 的存在和 schema
+- **文件格式约定**：追加的每行为符合 OpenClaw session JSONL schema 的 JSON 对象（`type: "custom"`, `customType: "user-feedback"`）
+- **并发安全**：反馈写入通常发生在会话活跃期结束后（用户先看到回复再点赞/踩），与 OpenClaw session writer 并发冲突概率极低，但快速连点场景下理论上存在竞争
+- **中期计划**：OpenClaw 提供 custom-event API 后将切换为标准 API 调用，解除直写耦合
+
+### 24h TTL 限制
+
+卡片注册表（`cardSessionMap`）使用 24 小时 TTL，超过 24h 的卡片映射会被自动清理。这意味着：
+
+- **机器人重启后**的反馈不会落库（内存 Map 清空）
+- **卡片超过 24h 后**的反馈不会落库（映射已过期清理）
+- 上述场景下日志会输出 warn 提示，但不影响卡片本身的赞踩动画效果

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -233,6 +233,21 @@
           "ackText": {
             "type": "string"
           },
+          "cardTemplateId": {
+            "type": "string"
+          },
+          "cardTemplateKey": {
+            "type": "string"
+          },
+          "cardLikeActionId": {
+            "type": "string"
+          },
+          "cardDislikeActionId": {
+            "type": "string"
+          },
+          "cardLikeVar": {
+            "type": "string"
+          },
           "endpoint": {
             "type": "string"
           },
@@ -456,6 +471,21 @@
                   "type": "boolean"
                 },
                 "ackText": {
+                  "type": "string"
+                },
+                "cardTemplateId": {
+                  "type": "string"
+                },
+                "cardTemplateKey": {
+                  "type": "string"
+                },
+                "cardLikeActionId": {
+                  "type": "string"
+                },
+                "cardDislikeActionId": {
+                  "type": "string"
+                },
+                "cardLikeVar": {
                   "type": "string"
                 },
                 "endpoint": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -233,6 +233,21 @@
           "ackText": {
             "type": "string"
           },
+          "cardTemplateId": {
+            "type": "string"
+          },
+          "cardTemplateKey": {
+            "type": "string"
+          },
+          "cardLikeActionId": {
+            "type": "string"
+          },
+          "cardDislikeActionId": {
+            "type": "string"
+          },
+          "cardFeedbackStatusKey": {
+            "type": "string"
+          },
           "endpoint": {
             "type": "string"
           },
@@ -456,6 +471,21 @@
                   "type": "boolean"
                 },
                 "ackText": {
+                  "type": "string"
+                },
+                "cardTemplateId": {
+                  "type": "string"
+                },
+                "cardTemplateKey": {
+                  "type": "string"
+                },
+                "cardLikeActionId": {
+                  "type": "string"
+                },
+                "cardDislikeActionId": {
+                  "type": "string"
+                },
+                "cardFeedbackStatusKey": {
                   "type": "string"
                 },
                 "endpoint": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:unit": "vitest run tests/gateway-methods.unit.test.ts",
     "test:integration": "vitest run tests/gateway-methods.unit.test.ts",
     "test:all": "vitest run",
+    "test:feedback": "tsx tests/simulate-dingtalk.ts --verify-feedback",
     "test:watch": "vitest watch",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage --exclude tests/gateway-methods.test.ts",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -29,6 +29,7 @@ import { normalizeDingtalkTarget, looksLikeDingtalkId } from "./targets.ts";
 import { dingtalkOnboardingAdapter } from "./onboarding.ts";
 import { monitorDingtalkProvider } from "./core/provider.ts";
 import { sendTextToDingTalk, sendMediaToDingTalk } from "./services/messaging/index.ts";
+import { registerCardSession, guessSessionKeyByTarget } from "./services/card-session-registry.ts";
 import type { ResolvedDingtalkAccount, DingtalkConfig } from "./types/index.ts";
 
 /** Channel identifier used across the plugin. Single source of truth. */
@@ -341,6 +342,28 @@ export const dingtalkPlugin: ChannelPlugin<ResolvedDingtalkAccount> = {
         text,
         replyToId,
       });
+
+      // --- 注册 outbound 创建的 AI Card 到 session 映射 ---
+      // outbound.sendText 路径无法获得 sessionKey（SDK 接口不传递），
+      // 通过已注册条目的 target 模式匹配来推断正确的 sessionKey。
+      if (result.cardInstanceId) {
+        try {
+          const match = await guessSessionKeyByTarget(to);
+          if (match) {
+            registerCardSession(result.cardInstanceId, {
+              sessionKey: match.sessionKey,
+              agentId: match.agentId,
+              createdAt: Date.now(),
+            });
+            console.warn(`[DingTalk][outbound.sendText] 已注册 outbound 卡片: cardInstanceId=${result.cardInstanceId}, sessionKey=${match.sessionKey}`);
+          } else {
+            console.warn(`[DingTalk][outbound.sendText] 无法推断 sessionKey，outbound 卡片未注册: cardInstanceId=${result.cardInstanceId}, target=${to}`);
+          }
+        } catch (regErr: any) {
+          console.warn(`[DingTalk][outbound.sendText] 注册卡片异常（不影响发送）: ${regErr?.message || regErr}`);
+        }
+      }
+
       return {
         channel: CHANNEL_ID,
         messageId: result.processQueryKey ?? result.cardInstanceId ?? "unknown",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -80,6 +80,11 @@ const DingtalkSharedConfigShape = {
   groupSessionScope: GroupSessionScopeSchema,
   asyncMode: z.boolean().optional(),
   ackText: z.string().optional(),
+  cardTemplateId: z.string().optional(), // Custom AI Card template ID (default: built-in template)
+  cardTemplateKey: z.string().optional(), // Content variable name in the card template (default: "msgContent")
+  cardLikeActionId: z.string().optional(), // Like button callback action ID (default: "ai_res_like")
+  cardDislikeActionId: z.string().optional(), // Dislike button callback action ID (default: "ai_res_dislike")
+  cardLikeVar: z.string().optional(), // Card variable name to set on like/dislike (default: "like")
   endpoint: z.string().optional(), // DWClient gateway endpoint
   debug: z.boolean().optional(), // DWClient debug mode
   enableMediaUpload: z.boolean().optional(),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -80,6 +80,11 @@ const DingtalkSharedConfigShape = {
   groupSessionScope: GroupSessionScopeSchema,
   asyncMode: z.boolean().optional(),
   ackText: z.string().optional(),
+  cardTemplateId: z.string().optional(), // Custom AI Card template ID (default: built-in template)
+  cardTemplateKey: z.string().optional(), // Content variable name in the card template (default: "msgContent")
+  cardLikeActionId: z.string().optional(), // Like button callback action ID (default: "ai_res_like")
+  cardDislikeActionId: z.string().optional(), // Dislike button callback action ID (default: "ai_res_dislike")
+  cardFeedbackStatusKey: z.string().optional(), // Card variable name to set on like/dislike (default: "like")
   endpoint: z.string().optional(), // DWClient gateway endpoint
   debug: z.boolean().optional(), // DWClient debug mode
   enableMediaUpload: z.boolean().optional(),

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -629,6 +629,89 @@ export async function monitorSingleAccount(
       }
     });
 
+    // Register card callback handler (handles card interactions like thumbs up/down)
+    const TOPIC_CARD = dingtalkStreamModule.TOPIC_CARD;
+    if (TOPIC_CARD) {
+      client.registerCallbackListener(TOPIC_CARD, async (res: any) => {
+        const messageId = res.headers?.messageId;
+        logger.info(`[DingTalk][CardCallback] 收到卡片回调，messageId=${messageId || "N/A"}`);
+
+        // 解析回调数据
+        let callbackData: any = {};
+        try {
+          callbackData = JSON.parse(res.data);
+        } catch (err: any) {
+          logger.error(`[DingTalk][CardCallback] ❌ 解析回调数据失败：${err.message}`);
+          if (messageId) {
+            client.socketCallBackResponse(messageId, {});
+          }
+          return;
+        }
+
+        // callbackData.content 是 JSON 字符串，需要二次解析
+        let parsedContent: any = {};
+        try {
+          const rawContent = callbackData?.content;
+          parsedContent = typeof rawContent === "string" ? JSON.parse(rawContent) : (rawContent ?? {});
+        } catch (contentErr: any) {
+          logger.warn(`[DingTalk][CardCallback] ⚠️ content 二次解析失败，降级为空对象：${contentErr.message}`);
+          parsedContent = {};
+        }
+
+        const actionIds: string[] = Array.isArray(parsedContent?.cardPrivateData?.actionIds)
+          ? parsedContent.cardPrivateData.actionIds
+          : [];
+        const params = parsedContent?.cardPrivateData?.params ?? {};
+        const userId = callbackData.userId ?? "";
+        const outTrackId = callbackData.outTrackId ?? "";
+        logger.info(`[DingTalk][CardCallback] outTrackId=${outTrackId}, userId=${userId}, actionIds=${JSON.stringify(actionIds)}`);
+        logger.debug(`[DingTalk][CardCallback] 回调数据：${JSON.stringify(callbackData).substring(0, 500)}`);
+
+        // 从配置读取回调 actionId 和变量名（支持自定义模板）
+        const likeActionId = account.config.cardLikeActionId || "ai_res_like";
+        const dislikeActionId = account.config.cardDislikeActionId || "ai_res_dislike";
+        const likeVar = account.config.cardLikeVar || "like";
+
+        // 构造响应（参考官方 card_callback_handler 示例格式）
+        const response: Record<string, any> = {
+          cardUpdateOptions: {
+            updateCardDataByKey: true,
+            updatePrivateDataByKey: true,
+          },
+          cardData: { cardParamMap: {} },
+          userPrivateData: { cardParamMap: {} },
+        };
+
+        try {
+          if (actionIds.includes(likeActionId)) {
+            logger.info(`[DingTalk][CardCallback] 👍 用户 ${userId} 点赞了 ${outTrackId}`);
+            response.cardData.cardParamMap[likeVar] = 1;
+          } else if (actionIds.includes(dislikeActionId)) {
+            const reasons = Array.isArray(params.dislike_reason)
+              ? params.dislike_reason.join("、")
+              : String(params.dislike_reason ?? "");
+            const custom = params.custom_dislike_reason ?? "";
+            logger.info(`[DingTalk][CardCallback] 👎 用户 ${userId} 点踩了 ${outTrackId}，原因：${reasons}${custom ? `，补充：${custom}` : ""}`);
+            response.cardData.cardParamMap[likeVar] = -1;
+            response.cardData.cardParamMap.submitted = "true";
+          } else {
+            logger.info(`[DingTalk][CardCallback] 未知 actionIds=${JSON.stringify(actionIds)}，按默认处理`);
+          }
+        } catch (bizErr: any) {
+          logger.error(`[DingTalk][CardCallback] ❌ 处理业务逻辑异常：${bizErr.message}`);
+        } finally {
+          // 确保无论业务逻辑是否异常，都响应回调（避免钉钉侧超时重试）
+          if (messageId) {
+            client.socketCallBackResponse(messageId, response);
+            logger.info(`[DingTalk][CardCallback] ✅ 已响应卡片回调`);
+          }
+        }
+      });
+      logger.info(`[DingTalk] ✅ 已注册 TOPIC_CARD 卡片回调监听器`);
+    } else {
+      logger.warn(`[DingTalk] ⚠️ dingtalk-stream 模块未导出 TOPIC_CARD，卡片回调不可用`);
+    }
+
     // 清理定时器
     const cleanup = () => {
       clearInterval(statsInterval);

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -18,6 +18,7 @@ import type { ResolvedDingtalkAccount } from "../types/index.ts";
 import {
   checkAndMarkDingtalkMessage,
 } from "../utils/utils-legacy.ts";
+import { recordFeedbackToSession } from "../services/card-session-registry.ts";
 
 // ============ 类型定义 ============
 
@@ -686,6 +687,10 @@ export async function monitorSingleAccount(
           if (actionIds.includes(likeActionId)) {
             logger.info(`[DingTalk][CardCallback] 👍 用户 ${userId} 点赞了 ${outTrackId}`);
             response.cardData.cardParamMap[likeVar] = 1;
+            // 将点赞反馈记录到 session
+            recordFeedbackToSession({ outTrackId, like: 1, userId, logger }).catch(err => {
+              logger.warn(`[DingTalk][CardCallback] 记录点赞反馈失败: ${err?.message ?? err}`);
+            });
           } else if (actionIds.includes(dislikeActionId)) {
             const reasons = Array.isArray(params.dislike_reason)
               ? params.dislike_reason.join("、")
@@ -694,6 +699,12 @@ export async function monitorSingleAccount(
             logger.info(`[DingTalk][CardCallback] 👎 用户 ${userId} 点踩了 ${outTrackId}，原因：${reasons}${custom ? `，补充：${custom}` : ""}`);
             response.cardData.cardParamMap[likeVar] = -1;
             response.cardData.cardParamMap.submitted = "true";
+            // 将点踩反馈记录到 session
+            const dislikeReasons = Array.isArray(params.dislike_reason) ? params.dislike_reason : [];
+            const customDislikeReason = params.custom_dislike_reason ?? undefined;
+            recordFeedbackToSession({ outTrackId, like: -1, userId, dislikeReasons, customDislikeReason, logger }).catch(err => {
+              logger.warn(`[DingTalk][CardCallback] 记录点踩反馈失败: ${err?.message ?? err}`);
+            });
           } else {
             logger.info(`[DingTalk][CardCallback] 未知 actionIds=${JSON.stringify(actionIds)}，按默认处理`);
           }

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -18,6 +18,7 @@ import type { ResolvedDingtalkAccount } from "../types/index.ts";
 import {
   checkAndMarkDingtalkMessage,
 } from "../utils/utils-legacy.ts";
+import { recordFeedbackToSession } from "../services/card-session-registry.ts";
 
 // ============ 类型定义 ============
 
@@ -512,6 +513,14 @@ export async function monitorSingleAccount(
       const onAbort = async () => {
         logger.info(`Abort signal received, stopping...`);
         stop();
+        // 注销 TOPIC_CARD 监听器
+        if (TOPIC_CARD && cardCallbackListener) {
+          try {
+            client.deregisterCallbackListener?.(TOPIC_CARD, cardCallbackListener);
+          } catch {
+            // deregisterCallbackListener 可能不存在，忽略
+          }
+        }
         try {
           // 只在连接已建立时才断开
           if (client.socket && client.socket.readyState === 1) {
@@ -681,9 +690,112 @@ export async function monitorSingleAccount(
       }
     });
 
-    // 清理定时器
+    // Register card callback handler (handles card interactions like thumbs up/down)
+    const TOPIC_CARD = dingtalkStreamModule.TOPIC_CARD;
+    let cardCallbackListener: ((res: any) => Promise<void>) | null = null;
+    if (TOPIC_CARD) {
+      cardCallbackListener = async (res: any) => {
+        const messageId = res.headers?.messageId;
+        console.warn(`[DingTalk][CardCallback] 收到卡片回调，messageId=${messageId || "N/A"}`);
+
+        // 解析回调数据
+        let callbackData: any = {};
+        try {
+          callbackData = JSON.parse(res.data);
+        } catch (err: any) {
+          logger.error(`[DingTalk][CardCallback] ❌ 解析回调数据失败：${err.message}`);
+          if (messageId) {
+            client.socketCallBackResponse(messageId, { success: false });
+          }
+          return;
+        }
+
+        // callbackData.content 是 JSON 字符串，需要二次解析
+        let parsedContent: any = {};
+        try {
+          const rawContent = callbackData?.content;
+          parsedContent = typeof rawContent === "string" ? JSON.parse(rawContent) : (rawContent ?? {});
+        } catch (contentErr: any) {
+          logger.warn(`[DingTalk][CardCallback] ⚠️ content 二次解析失败，降级为空对象：${contentErr.message}`);
+          parsedContent = {};
+        }
+
+        const actionIds: string[] = Array.isArray(parsedContent?.cardPrivateData?.actionIds)
+          ? parsedContent.cardPrivateData.actionIds
+          : [];
+        const params = parsedContent?.cardPrivateData?.params ?? {};
+        const userId = callbackData.userId ?? "";
+        const outTrackId = callbackData.outTrackId ?? "";
+        console.warn(`[DingTalk][CardCallback] outTrackId=${outTrackId}, userId=${userId}, actionIds=${JSON.stringify(actionIds)}`);
+        logger.debug(`[DingTalk][CardCallback] 回调数据：${JSON.stringify(callbackData).substring(0, 500)}`);
+
+        // 从配置读取回调 actionId 和变量名（支持自定义模板）
+        const likeActionId = account.config.cardLikeActionId || "ai_res_like";
+        const dislikeActionId = account.config.cardDislikeActionId || "ai_res_dislike";
+        const likeVar = account.config.cardFeedbackStatusKey || "like";
+
+        // 构造响应（参考官方 card_callback_handler 示例格式）
+        const response: Record<string, any> = {
+          cardUpdateOptions: {
+            updateCardDataByKey: true,
+            updatePrivateDataByKey: true,
+          },
+          cardData: { cardParamMap: {} },
+          userPrivateData: { cardParamMap: {} },
+        };
+
+        try {
+          if (actionIds.includes(likeActionId)) {
+            console.warn(`[DingTalk][CardCallback] 👍 用户 ${userId} 点赞了 ${outTrackId}`);
+            response.cardData.cardParamMap[likeVar] = 1;
+            // 将点赞反馈记录到 session
+            recordFeedbackToSession({ outTrackId, like: 1, userId, logger }).catch(err => {
+              logger.warn(`[DingTalk][CardCallback] 记录点赞反馈失败: ${err?.message ?? err}`);
+            });
+          } else if (actionIds.includes(dislikeActionId)) {
+            const reasons = Array.isArray(params.dislike_reason)
+              ? params.dislike_reason.join("、")
+              : String(params.dislike_reason ?? "");
+            const custom = params.custom_dislike_reason ?? "";
+            console.warn(`[DingTalk][CardCallback] 👎 用户 ${userId} 点踩了 ${outTrackId}，原因：${reasons}${custom ? `，补充：${custom}` : ""}`);
+            response.cardData.cardParamMap[likeVar] = -1;
+            response.cardData.cardParamMap.submitted = "true";
+            // 将点踩反馈记录到 session
+            const dislikeReasons = Array.isArray(params.dislike_reason) ? params.dislike_reason : [];
+            const customDislikeReason = params.custom_dislike_reason ?? undefined;
+            recordFeedbackToSession({ outTrackId, like: -1, userId, dislikeReasons, customDislikeReason, logger }).catch(err => {
+              logger.warn(`[DingTalk][CardCallback] 记录点踩反馈失败: ${err?.message ?? err}`);
+            });
+          } else {
+            console.warn(`[DingTalk][CardCallback] ⚠️ 未知 actionIds=${JSON.stringify(actionIds)}，期望的 like="${likeActionId}" / dislike="${dislikeActionId}"。如使用自定义卡片模板，请确保模板中的 actionId 与 openclaw.json 中 cardLikeActionId/cardDislikeActionId 一致`);
+          }
+        } catch (bizErr: any) {
+          logger.error(`[DingTalk][CardCallback] ❌ 处理业务逻辑异常：${bizErr.message}`);
+        } finally {
+          // 确保无论业务逻辑是否异常，都响应回调（避免钉钉侧超时重试）
+          if (messageId) {
+            client.socketCallBackResponse(messageId, response);
+            console.warn(`[DingTalk][CardCallback] ✅ 已响应卡片回调，messageId=${messageId}`);
+          }
+        }
+      };
+      client.registerCallbackListener(TOPIC_CARD, cardCallbackListener);
+      logger.info(`[DingTalk] ✅ 已注册 TOPIC_CARD 卡片回调监听器`);
+    } else {
+      logger.warn(`[DingTalk] ⚠️ dingtalk-stream 模块未导出 TOPIC_CARD，卡片回调不可用`);
+    }
+
+    // 清理定时器和监听器
     const cleanup = () => {
       clearInterval(statsInterval);
+      // 注销 TOPIC_CARD 监听器，避免 monitorSingleAccount 重入时叠加
+      if (TOPIC_CARD && cardCallbackListener) {
+        try {
+          client.deregisterCallbackListener?.(TOPIC_CARD, cardCallbackListener);
+        } catch {
+          // deregisterCallbackListener 可能不存在，忽略
+        }
+      }
       stop();
     };
 
@@ -716,6 +828,14 @@ export async function monitorSingleAccount(
       const enhancedCleanup = () => {
         cleanupKeepAlive();
         clearInterval(statsInterval);
+        // 注销 TOPIC_CARD 监听器
+        if (TOPIC_CARD && cardCallbackListener) {
+          try {
+            client.deregisterCallbackListener?.(TOPIC_CARD, cardCallbackListener);
+          } catch {
+            // deregisterCallbackListener 可能不存在，忽略
+          }
+        }
         stop();
       };
 

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -63,18 +63,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-// ============ 常量 ============
-
-const AI_CARD_TEMPLATE_ID = '02fcf2f4-5e02-4a85-b672-46d1f715543e.schema';
-
-const AICardStatus = {
-  PROCESSING: '1',
-  INPUTING: '2',
-  FINISHED: '3',
-  EXECUTING: '4',
-  FAILED: '5',
-} as const;
-
 // ============ 会话级别消息队列 ============
 
 /**

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -1461,6 +1461,7 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
       sessionWebhook: data.sessionWebhook,
       asyncMode,
       preCreatedCard: params.preCreatedCard,
+      sessionKey,
     });
 
     // ===== 注入当前 bot 的 clientId（用于 dws CLI --client-id 参数） =====

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -67,18 +67,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-// ============ 常量 ============
-
-const AI_CARD_TEMPLATE_ID = '02fcf2f4-5e02-4a85-b672-46d1f715543e.schema';
-
-const AICardStatus = {
-  PROCESSING: '1',
-  INPUTING: '2',
-  FINISHED: '3',
-  EXECUTING: '4',
-  FAILED: '5',
-} as const;
-
 // ============ 会话级别消息队列 ============
 
 /**
@@ -1477,6 +1465,7 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
       sessionWebhook: data.sessionWebhook,
       asyncMode,
       preCreatedCard: params.preCreatedCard,
+      sessionKey,
     });
 
     // ===== 注入当前 bot 的 clientId（用于 dws CLI --client-id 参数） =====

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -47,6 +47,7 @@ import {
   processAudioMarkers,
   uploadAndReplaceFileMarkers,
 } from "./services/media/index.ts";
+import { registerCardSession } from "./services/card-session-registry.ts";
 
 
 export type CreateDingtalkReplyDispatcherParams = {
@@ -62,6 +63,8 @@ export type CreateDingtalkReplyDispatcherParams = {
   asyncMode?: boolean;
   /** 队列繁忙时预先创建的 AI Card，startStreaming 时直接复用而非新建 */
   preCreatedCard?: AICardInstance;
+  /** OpenClaw session key，用于卡片反馈追溯到 session */
+  sessionKey?: string;
 };
 
 export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatcherParams) {
@@ -238,6 +241,10 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         log.info(`[DingTalk][startStreaming] 复用预创建 AI Card，cardInstanceId=${preCreatedCard.cardInstanceId}`);
         currentCardTarget = preCreatedCard as any;
         accumulatedText = "";
+        // 注册 card → session 映射，供卡片回调追溯反馈
+        if (params.sessionKey) {
+          registerCardSession(preCreatedCard.cardInstanceId, { sessionKey: params.sessionKey, agentId, createdAt: Date.now() });
+        }
         return;
       }
 
@@ -260,6 +267,10 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
 
         if (card) {
           log.info(`[DingTalk][startStreaming] ✅ AI Card 创建成功`);
+          // 注册 card → session 映射，供卡片回调追溯反馈
+          if (params.sessionKey) {
+            registerCardSession(card.cardInstanceId, { sessionKey: params.sessionKey, agentId, createdAt: Date.now() });
+          }
         } else {
           log.warn(`[DingTalk][startStreaming] AI Card 创建返回 null，静默降级到普通消息模式`);
         }

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -253,7 +253,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         const card = await createAICardForTarget(
           account.config as DingtalkConfig,
           target,
-          log
+          log,
         );
         currentCardTarget = card as any;
         accumulatedText = "";
@@ -699,7 +699,8 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
                 );
               } else {
                 log.error(`[DingTalk][onPartialReply] ❌ AI Card 更新失败：${err.message}`);
-                await sendFallbackErrorMessage('sendMessage', err.message);
+                // 非 QPS 错误也不立即降级，等待下一次 partial 更新重试，
+                // 最终回复通过 closeStreaming / finishAICard 兜底。
               }
             }
           } else {

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -52,6 +52,7 @@ import {
   emptyGroupReplyLogHint,
   groupChatLacksVisibleRepliesAutomatic,
 } from "./utils/empty-reply.ts";
+import { registerCardSession } from "./services/card-session-registry.ts";
 
 
 export type CreateDingtalkReplyDispatcherParams = {
@@ -67,6 +68,8 @@ export type CreateDingtalkReplyDispatcherParams = {
   asyncMode?: boolean;
   /** 队列繁忙时预先创建的 AI Card，startStreaming 时直接复用而非新建 */
   preCreatedCard?: AICardInstance;
+  /** OpenClaw session key，用于卡片反馈追溯到 session */
+  sessionKey?: string;
 };
 
 export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatcherParams) {
@@ -97,6 +100,8 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
   // AI Card 状态管理
   let currentCardTarget: AICardTarget | null = null;
   let accumulatedText = "";
+  // 标记 preCreatedCard 是否已被使用，防止后续 turn 重复复用已完成的卡片
+  let preCreatedCardConsumed = false;
   const deliveredFinalTexts = new Set<string>();
 
   /** 本轮是否已向用户发出过可见回复（final / 流式更新 / 错误兜底等） */
@@ -245,11 +250,18 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
 
       // 若队列繁忙时已预先创建了 Card（显示排队 ACK 文案），直接复用，无需新建
       // 这样用户看到的是同一条消息从 ACK 文案更新为最终结果，而不是多出一条消息
-      if (preCreatedCard) {
+      // ⚠️ 只复用一次：closeStreaming 后再次进入 startStreaming 时不能重复复用已完成的卡片
+      if (preCreatedCard && !preCreatedCardConsumed) {
+        preCreatedCardConsumed = true;
         log.info(`[DingTalk][startStreaming] 复用预创建 AI Card，cardInstanceId=${preCreatedCard.cardInstanceId}`);
         currentCardTarget = preCreatedCard as any;
         accumulatedText = "";
         outboundUserVisibleThisTurn = true;
+        // 注册 card → session 映射，供卡片回调追溯反馈
+        if (params.sessionKey) {
+          registerCardSession(preCreatedCard.cardInstanceId, { sessionKey: params.sessionKey, agentId, createdAt: Date.now() });
+          log.warn(`[DingTalk][CardSession] 已注册预创建卡片映射: cardInstanceId=${preCreatedCard.cardInstanceId}, sessionKey=${params.sessionKey}`);
+        }
         return;
       }
 
@@ -265,24 +277,30 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         const card = await createAICardForTarget(
           account.config as DingtalkConfig,
           target,
-          log
+          log,
         );
         currentCardTarget = card as any;
         accumulatedText = "";
 
         if (card) {
           log.info(`[DingTalk][startStreaming] ✅ AI Card 创建成功`);
+          // 注册 card → session 映射，供卡片回调追溯反馈
+          if (params.sessionKey) {
+            registerCardSession(card.cardInstanceId, { sessionKey: params.sessionKey, agentId, createdAt: Date.now() });
+            log.warn(`[DingTalk][CardSession] 已注册新建卡片映射: cardInstanceId=${card.cardInstanceId}, sessionKey=${params.sessionKey}`);
+          }
         } else {
           log.warn(`[DingTalk][startStreaming] AI Card 创建返回 null，静默降级到普通消息模式`);
         }
       } catch (error: any) {
         log.error(`[DingTalk][startStreaming] ❌ AI Card 创建失败：${error?.message || String(error)}，静默降级到普通消息模式`);
         currentCardTarget = null;
-      } finally {
-        // 创建完成后清空 Promise，允许下次重新创建
-        cardCreationPromise = null;
       }
-    })();
+    })().finally(() => {
+      // ✅ 确保所有路径（preCreatedCard / 新建 / 异常 / asyncMode / streamingDisabled）都清空 promise，
+      // 允许后续 turn 的 startStreaming 重新创建卡片
+      cardCreationPromise = null;
+    });
 
     return cardCreationPromise;
   };

--- a/src/services/card-session-registry.ts
+++ b/src/services/card-session-registry.ts
@@ -1,0 +1,180 @@
+/**
+ * Card-to-Session 映射注册表
+ *
+ * 维护 cardInstanceId (outTrackId) → session 信息的内存映射，
+ * 使卡片回调（点赞/点踩）能够定位到对应的 session JSONL 文件并追加反馈条目。
+ */
+
+import { readFile, appendFile, access } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+// ============ 类型定义 ============
+
+export interface CardSessionInfo {
+  sessionKey: string;
+  agentId: string;
+  createdAt: number;
+}
+
+export interface RecordFeedbackParams {
+  outTrackId: string;
+  like: 1 | -1;
+  userId: string;
+  dislikeReasons?: string[];
+  customDislikeReason?: string;
+  logger?: { info?: (...args: any[]) => void; warn?: (...args: any[]) => void; error?: (...args: any[]) => void };
+}
+
+// ============ 内存注册表 ============
+
+const CARD_SESSION_TTL = 24 * 60 * 60 * 1000; // 24 小时
+const CLEANUP_INTERVAL = 30 * 60 * 1000; // 30 分钟
+
+const cardSessionMap = new Map<string, CardSessionInfo>();
+
+/**
+ * 注册 cardInstanceId → session 映射
+ */
+export function registerCardSession(cardInstanceId: string, info: CardSessionInfo): void {
+  cardSessionMap.set(cardInstanceId, info);
+}
+
+/**
+ * 查找 cardInstanceId 对应的 session 信息
+ */
+export function lookupCardSession(cardInstanceId: string): CardSessionInfo | null {
+  return cardSessionMap.get(cardInstanceId) ?? null;
+}
+
+/**
+ * 清理过期条目（超过 24 小时）
+ */
+export function cleanupExpiredCardSessions(): number {
+  const now = Date.now();
+  let removed = 0;
+  for (const [key, info] of cardSessionMap) {
+    if (now - info.createdAt > CARD_SESSION_TTL) {
+      cardSessionMap.delete(key);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+// 自动清理定时器（unref 防止阻止进程退出）
+const cleanupTimer = setInterval(cleanupExpiredCardSessions, CLEANUP_INTERVAL);
+if (typeof cleanupTimer.unref === "function") {
+  cleanupTimer.unref();
+}
+
+// ============ 反馈写入 ============
+
+/**
+ * 将用户反馈追加到 session JSONL 文件
+ *
+ * 流程：
+ * 1. 通过 outTrackId 查找注册表，获取 sessionKey + agentId
+ * 2. 读取 ~/.openclaw/agents/{agentId}/sessions/sessions.json 获取 sessionFile
+ * 3. 构造 customType: "user-feedback" 条目
+ * 4. appendFileSync 追加到 JSONL 文件
+ *
+ * 此函数永远不会抛出异常（内部 try/catch），调用方无需处理错误。
+ */
+export async function recordFeedbackToSession(params: RecordFeedbackParams): Promise<boolean> {
+  const { outTrackId, like, userId, dislikeReasons, customDislikeReason, logger } = params;
+
+  if (!outTrackId) {
+    logger?.warn?.("[CardFeedback] outTrackId 为空，跳过反馈记录");
+    return false;
+  }
+
+  try {
+    // 1. 查找注册表
+    const info = lookupCardSession(outTrackId);
+    if (!info) {
+      logger?.warn?.(`[CardFeedback] 未找到 outTrackId=${outTrackId} 的 session 映射（可能已重启或过期），跳过`);
+      return false;
+    }
+
+    // 2. 读取 sessions.json 获取 sessionFile 路径
+    const sessionsJsonPath = join(homedir(), ".openclaw", "agents", info.agentId, "sessions", "sessions.json");
+    try {
+      await access(sessionsJsonPath);
+    } catch {
+      logger?.warn?.(`[CardFeedback] sessions.json 不存在: ${sessionsJsonPath}`);
+      return false;
+    }
+
+    let sessionsStore: Record<string, any>;
+    try {
+      sessionsStore = JSON.parse(await readFile(sessionsJsonPath, "utf-8"));
+    } catch (parseErr: any) {
+      logger?.error?.(`[CardFeedback] sessions.json 解析失败: ${parseErr.message}`);
+      return false;
+    }
+
+    const sessionEntry = sessionsStore[info.sessionKey];
+    if (!sessionEntry) {
+      logger?.warn?.(`[CardFeedback] sessionKey=${info.sessionKey} 在 sessions.json 中不存在`);
+      return false;
+    }
+
+    const sessionFile = sessionEntry.sessionFile as string | undefined;
+    if (!sessionFile) {
+      logger?.warn?.(`[CardFeedback] session 文件路径为空`);
+      return false;
+    }
+    try {
+      await access(sessionFile);
+    } catch {
+      logger?.warn?.(`[CardFeedback] session 文件不存在: ${sessionFile}`);
+      return false;
+    }
+
+    // 3. 构造反馈 JSONL 条目
+    const feedbackData: Record<string, unknown> = {
+      like,
+      userId,
+      cardInstanceId: outTrackId,
+      source: "dingtalk-card",
+    };
+    if (like === -1) {
+      if (dislikeReasons && dislikeReasons.length > 0) {
+        feedbackData.dislikeReasons = dislikeReasons;
+      }
+      if (customDislikeReason) {
+        feedbackData.customDislikeReason = customDislikeReason;
+      }
+    }
+
+    const entry = {
+      type: "custom",
+      customType: "user-feedback",
+      data: feedbackData,
+      id: randomBytes(4).toString("hex"),
+      parentId: null,
+      timestamp: new Date().toISOString(),
+    };
+
+    // 4. 追加到 session 文件
+    // 注意：反馈写入通常发生在会话活跃期结束后（用户先看到回复再点赞/踩），
+    // 此时 OpenClaw 通常不再写入该 session 文件，并发冲突概率极低。
+    const jsonLine = "\n" + JSON.stringify(entry);
+    await appendFile(sessionFile, jsonLine, "utf-8");
+
+    logger?.info?.(`[CardFeedback] 反馈已记录到 session: like=${like}, userId=${userId}, outTrackId=${outTrackId}, file=${sessionFile}`);
+    return true;
+  } catch (err: any) {
+    logger?.error?.(`[CardFeedback] 记录反馈异常: ${err.message}`);
+    return false;
+  }
+}
+
+// 导出常量供测试使用
+export { CARD_SESSION_TTL, CLEANUP_INTERVAL };
+// 导出 Map 引用供测试清理
+export function _getRegistryForTesting(): Map<string, CardSessionInfo> {
+  return cardSessionMap;
+}

--- a/src/services/card-session-registry.ts
+++ b/src/services/card-session-registry.ts
@@ -1,0 +1,306 @@
+/**
+ * Card-to-Session 映射注册表
+ *
+ * 维护 cardInstanceId (outTrackId) → session 信息的内存映射，
+ * 使卡片回调（点赞/点踩）能够定位到对应的 session JSONL 文件并追加反馈条目。
+ */
+
+import { readFile, appendFile, access, writeFile, mkdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+// ============ 类型定义 ============
+
+export interface CardSessionInfo {
+  sessionKey: string;
+  agentId: string;
+  createdAt: number;
+}
+
+export interface RecordFeedbackParams {
+  outTrackId: string;
+  like: 1 | -1;
+  userId: string;
+  dislikeReasons?: string[];
+  customDislikeReason?: string;
+  logger?: { info?: (...args: any[]) => void; warn?: (...args: any[]) => void; error?: (...args: any[]) => void };
+}
+
+// ============ 内存注册表 ============
+
+const CARD_SESSION_TTL = 24 * 60 * 60 * 1000; // 24 小时
+const CLEANUP_INTERVAL = 30 * 60 * 1000; // 30 分钟
+
+const cardSessionMap = new Map<string, CardSessionInfo>();
+
+/**
+ * 持久化文件路径：${tmpdir}/dingtalk-connector/card-session-map.json
+ *
+ * 设计说明：
+ * - 放在系统临时目录而非 ~/.openclaw，是因为这只是"重启后老卡片反馈兜底"用的缓存，
+ *   不属于 OpenClaw 的核心状态；系统对 /tmp 的定期清理也能兜底过期条目。
+ * - 使用 lazy 函数而非 module-level 常量，避免在测试中通过 vi.mock("node:os") 替换
+ *   homedir/tmpdir 时被模块加载期的求值踩到 hoisting 时序问题。
+ */
+function getPersistFile(): string {
+  return join(tmpdir(), "dingtalk-connector", "card-session-map.json");
+}
+
+/** 是否已从文件加载过历史映射 */
+let persistLoaded = false;
+
+/**
+ * 从文件加载历史映射（进程启动时调用一次）
+ */
+async function loadFromDisk(): Promise<void> {
+  if (persistLoaded) return;
+  persistLoaded = true;
+  const persistFile = getPersistFile();
+  try {
+    await access(persistFile);
+    const raw = await readFile(persistFile, "utf-8");
+    const entries: Record<string, CardSessionInfo> = JSON.parse(raw);
+    const now = Date.now();
+    let loaded = 0;
+    for (const [key, info] of Object.entries(entries)) {
+      if (now - info.createdAt <= CARD_SESSION_TTL) {
+        cardSessionMap.set(key, info);
+        loaded++;
+      }
+    }
+    if (loaded > 0) {
+      console.warn(`[CardSession] 从磁盘加载 ${loaded} 条卡片映射（进程重启恢复）`);
+    }
+  } catch {
+    // 文件不存在或解析失败，忽略
+  }
+}
+
+/**
+ * 将当前映射写入磁盘
+ */
+async function saveToDisk(): Promise<void> {
+  const persistFile = getPersistFile();
+  try {
+    const obj: Record<string, CardSessionInfo> = {};
+    for (const [key, info] of cardSessionMap) {
+      obj[key] = info;
+    }
+    await mkdir(dirname(persistFile), { recursive: true });
+    await writeFile(persistFile, JSON.stringify(obj), "utf-8");
+  } catch (err: any) {
+    console.warn(`[CardSession] 持久化写入失败: ${err.message}`);
+  }
+}
+
+/**
+ * 注册 cardInstanceId → session 映射
+ */
+export function registerCardSession(cardInstanceId: string, info: CardSessionInfo): void {
+  cardSessionMap.set(cardInstanceId, info);
+  console.warn(`[CardSession] 注册映射: outTrackId=${cardInstanceId}, sessionKey=${info.sessionKey}, agentId=${info.agentId}`);
+  // 异步持久化，不阻塞主流程
+  saveToDisk().catch(() => {});
+}
+
+/**
+ * 查找 cardInstanceId 对应的 session 信息
+ */
+export async function lookupCardSession(cardInstanceId: string): Promise<CardSessionInfo | null> {
+  // 首次查找时从磁盘加载历史映射
+  await loadFromDisk();
+  const result = cardSessionMap.get(cardInstanceId) ?? null;
+  if (!result) {
+    console.warn(`[CardSession] 查找失败: outTrackId=${cardInstanceId}，当前注册表大小=${cardSessionMap.size}`);
+  }
+  return result;
+}
+
+/**
+ * 清理过期条目（超过 24 小时）
+ */
+export function cleanupExpiredCardSessions(): number {
+  const now = Date.now();
+  let removed = 0;
+  for (const [key, info] of cardSessionMap) {
+    if (now - info.createdAt > CARD_SESSION_TTL) {
+      cardSessionMap.delete(key);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+// 自动清理定时器（unref 防止阻止进程退出）
+const cleanupTimer = setInterval(cleanupExpiredCardSessions, CLEANUP_INTERVAL);
+if (typeof cleanupTimer.unref === "function") {
+  cleanupTimer.unref();
+}
+
+// ============ 反馈写入 ============
+
+/**
+ * 将用户反馈追加到 session JSONL 文件
+ *
+ * 流程：
+ * 1. 通过 outTrackId 查找注册表，获取 sessionKey + agentId
+ * 2. 读取 ~/.openclaw/agents/{agentId}/sessions/sessions.json 获取 sessionFile
+ * 3. 构造 customType: "user-feedback" 条目
+ * 4. appendFileSync 追加到 JSONL 文件
+ *
+ * 此函数永远不会抛出异常（内部 try/catch），调用方无需处理错误。
+ */
+export async function recordFeedbackToSession(params: RecordFeedbackParams): Promise<boolean> {
+  const { outTrackId, like, userId, dislikeReasons, customDislikeReason, logger } = params;
+
+  if (!outTrackId) {
+    logger?.warn?.("[CardFeedback] outTrackId 为空，跳过反馈记录");
+    return false;
+  }
+
+  try {
+    // 1. 查找注册表
+    const info = await lookupCardSession(outTrackId);
+    if (!info) {
+      const keysSample = [...cardSessionMap.keys()].slice(0, 5).map(k => k.slice(0, 20) + '...').join(', ');
+      logger?.warn?.(`[CardFeedback] 未找到 outTrackId=${outTrackId} 的 session 映射（可能已重启或过期）。注册表 size=${cardSessionMap.size}, keys样本=[${keysSample}]`);
+      return false;
+    }
+
+    // 2. 读取 sessions.json 获取 sessionFile 路径
+    const sessionsJsonPath = join(homedir(), ".openclaw", "agents", info.agentId, "sessions", "sessions.json");
+    try {
+      await access(sessionsJsonPath);
+    } catch {
+      logger?.warn?.(`[CardFeedback] sessions.json 不存在: ${sessionsJsonPath}`);
+      return false;
+    }
+
+    let sessionsStore: Record<string, any>;
+    try {
+      sessionsStore = JSON.parse(await readFile(sessionsJsonPath, "utf-8"));
+    } catch (parseErr: any) {
+      logger?.error?.(`[CardFeedback] sessions.json 解析失败: ${parseErr.message}`);
+      return false;
+    }
+
+    const sessionEntry = sessionsStore[info.sessionKey];
+    if (!sessionEntry) {
+      logger?.warn?.(`[CardFeedback] sessionKey=${info.sessionKey} 在 sessions.json 中不存在`);
+      return false;
+    }
+
+    const sessionFile = sessionEntry.sessionFile as string | undefined;
+    if (!sessionFile) {
+      logger?.warn?.(`[CardFeedback] session 文件路径为空`);
+      return false;
+    }
+    try {
+      await access(sessionFile);
+    } catch {
+      logger?.warn?.(`[CardFeedback] session 文件不存在: ${sessionFile}`);
+      return false;
+    }
+
+    // 3. 构造反馈 JSONL 条目
+    const feedbackData: Record<string, unknown> = {
+      like,
+      userId,
+      cardInstanceId: outTrackId,
+      source: "dingtalk-card",
+    };
+    if (like === -1) {
+      if (dislikeReasons && dislikeReasons.length > 0) {
+        feedbackData.dislikeReasons = dislikeReasons;
+      }
+      if (customDislikeReason) {
+        feedbackData.customDislikeReason = customDislikeReason;
+      }
+    }
+
+    const entry = {
+      type: "custom",
+      customType: "user-feedback",
+      data: feedbackData,
+      id: randomBytes(4).toString("hex"),
+      parentId: null,
+      timestamp: new Date().toISOString(),
+    };
+
+    // 4. 追加到 session 文件
+    // 注意：反馈写入通常发生在会话活跃期结束后（用户先看到回复再点赞/踩），
+    // 此时 OpenClaw 通常不再写入该 session 文件，并发冲突概率极低。
+    const jsonLine = "\n" + JSON.stringify(entry);
+    await appendFile(sessionFile, jsonLine, "utf-8");
+
+    logger?.info?.(`[CardFeedback] 反馈已记录到 session: like=${like}, userId=${userId}, outTrackId=${outTrackId}, file=${sessionFile}`);
+    return true;
+  } catch (err: any) {
+    logger?.error?.(`[CardFeedback] 记录反馈异常: ${err.message}`);
+    return false;
+  }
+}
+
+// ============ 辅助查询 ============
+
+/**
+ * 根据发送目标（userId/conversationId）查找最近注册过的 sessionKey
+ * 用于 outbound.sendText 路径：该路径无法获得 sessionKey，但可通过
+ * 已注册条目的 sessionKey 中的 target 模式匹配来推断。
+ *
+ * 匹配规则：
+ * - 单聊: sessionKey 以 `:${peerId}` 结尾
+ * - 群聊: sessionKey 中包含 `:${peerId}:`（群聊会话隔离时 peerId 可能在中段）
+ */
+export async function guessSessionKeyByTarget(target: string): Promise<{ sessionKey: string; agentId: string } | null> {
+  // 确保内存映射已从磁盘加载（进程重启后首次调用）
+  await loadFromDisk();
+
+  // 从 target 字符串提取 peerId（去掉 user:/group: 前缀）
+  const peerId = target.replace(/^(user|group):/, '');
+
+  // 两阶段匹配：优先使用 endsWith 严格匹配，无结果时退化到 includes
+  const candidates: { sessionKey: string; agentId: string; createdAt: number }[] = [];
+  const looseCandidates: { sessionKey: string; agentId: string; createdAt: number }[] = [];
+
+  for (const [, info] of cardSessionMap) {
+    // sessionKey 格式: agent:{agentId}:{channel}:{peerKind}:{peerId}
+    // 群聊会话隔离时: agent:{agentId}:{channel}:group:{conversationId}:{senderId}
+    if (info.sessionKey.endsWith(`:${peerId}`)) {
+      candidates.push({ sessionKey: info.sessionKey, agentId: info.agentId, createdAt: info.createdAt });
+    } else if (info.sessionKey.includes(`:${peerId}:`)) {
+      looseCandidates.push({ sessionKey: info.sessionKey, agentId: info.agentId, createdAt: info.createdAt });
+    }
+  }
+
+  // 选择候选集：优先严格匹配
+  const pool = candidates.length > 0 ? candidates : looseCandidates;
+
+  // 安全检查：候选集中若存在多个不同 sessionKey，放弃推断（避免跨用户串话）
+  const uniqueSessionKeys = new Set(pool.map(c => c.sessionKey));
+  if (uniqueSessionKeys.size > 1) {
+    console.warn(`[CardSession] guessSessionKeyByTarget: target=${target} 存在 ${uniqueSessionKeys.size} 个候选 sessionKey，放弃推断（避免跨用户串话）。candidates=${[...uniqueSessionKeys].map(k => k.slice(0, 40) + '...').join(', ')}`);
+    return null;
+  }
+
+  // 从唯一候选中选最新的
+  let bestMatch: { sessionKey: string; agentId: string; createdAt: number } | null = null;
+  for (const c of pool) {
+    if (!bestMatch || c.createdAt > bestMatch.createdAt) {
+      bestMatch = c;
+    }
+  }
+
+  if (bestMatch) {
+    console.warn(`[CardSession] guessSessionKeyByTarget: target=${target} → sessionKey=${bestMatch.sessionKey} (candidates=${pool.length}, registry=${cardSessionMap.size})`);
+  }
+  return bestMatch ? { sessionKey: bestMatch.sessionKey, agentId: bestMatch.agentId } : null;
+}
+
+// 导出常量供测试使用
+export { CARD_SESSION_TTL, CLEANUP_INTERVAL };
+// 导出 Map 引用供测试清理
+export function _getRegistryForTesting(): Map<string, CardSessionInfo> {
+  return cardSessionMap;
+}

--- a/src/services/messaging.ts
+++ b/src/services/messaging.ts
@@ -1066,6 +1066,7 @@ async function sendProactiveInternal(
     try {
       const card = await createAICardForTarget(config, target, externalLog);
       if (card) {
+        console.warn(`[DingTalk][sendProactiveInternal] AI Card 已创建: cardInstanceId=${card.cardInstanceId}, target=${JSON.stringify(target)}`);
         await finishAICard(card, content, config, externalLog);
         return {
           ok: true,

--- a/src/services/messaging/card.ts
+++ b/src/services/messaging/card.ts
@@ -9,7 +9,10 @@ import { dingtalkHttp } from "../../utils/http-client.ts";
 
 // ============ 常量 ============
 
-const AI_CARD_TEMPLATE_ID = "02fcf2f4-5e02-4a85-b672-46d1f715543e.schema";
+const DEFAULT_AI_CARD_TEMPLATE_ID = "02fcf2f4-5e02-4a85-b672-46d1f715543e.schema";
+
+/** 默认的卡片内容字段名（官方 AI Card 模板使用 msgContent） */
+const DEFAULT_CARD_TEMPLATE_KEY = "msgContent";
 
 /**
  * 钉钉卡片 API 的最大 QPS（官方限制约 40 次/秒）。
@@ -259,8 +262,10 @@ export async function createAICardForTarget(
     );
 
     // 1. 创建卡片实例
+    const cardTemplateId = config.cardTemplateId || DEFAULT_AI_CARD_TEMPLATE_ID;
+
     const createBody = {
-      cardTemplateId: AI_CARD_TEMPLATE_ID,
+      cardTemplateId,
       outTrackId: cardInstanceId,
       cardData: {
           cardParamMap: {
@@ -352,6 +357,10 @@ export async function streamAICard(
     log?.warn?.(`[DingTalk][AICard] streamAICard 收到 null card，跳过更新`);
     return;
   }
+
+  // 从 config 中读取自定义内容字段名（自定义模板的 Markdown 变量名），默认 "msgContent"
+  const contentKey = config?.cardTemplateKey || DEFAULT_CARD_TEMPLATE_KEY;
+
   // 确保 token 有效
   if (config) {
     await ensureValidToken(card, config);
@@ -368,10 +377,9 @@ export async function streamAICard(
       cardData: {
         cardParamMap: {
           flowStatus: AICardStatus.INPUTING,
-          msgContent: content,
-          staticMsgContent: "",
+          [contentKey]: content,
           sys_full_json_obj: JSON.stringify({
-            order: ["msgContent"],
+            order: [contentKey],
           }),
           config: JSON.stringify({ autoLayout: true }),
         },
@@ -421,7 +429,7 @@ export async function streamAICard(
   const body = {
     outTrackId: card.cardInstanceId,
     guid: `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-    key: "msgContent",
+    key: contentKey,
     content: fixedContent,
     isFull: true,
     isFinalize: finished,
@@ -494,6 +502,10 @@ export async function finishAICard(
   if (config) {
     await ensureValidToken(card, config);
   }
+
+  // 从 config 中读取自定义内容字段名，默认 "msgContent"
+  const contentKey = config?.cardTemplateKey || DEFAULT_CARD_TEMPLATE_KEY;
+
   const fixedContent = ensureTableBlankLines(content);
   log?.info?.(
     `[DingTalk][AICard] 开始 finish，最终内容长度=${fixedContent.length}`,
@@ -506,10 +518,9 @@ export async function finishAICard(
     cardData: {
       cardParamMap: {
         flowStatus: AICardStatus.FINISHED,
-        msgContent: fixedContent,
-        staticMsgContent: "",
+        [contentKey]: fixedContent,
         sys_full_json_obj: JSON.stringify({
-          order: ["msgContent"],
+          order: [contentKey],
         }),
         config: JSON.stringify({ autoLayout: true }),
       },

--- a/src/services/messaging/card.ts
+++ b/src/services/messaging/card.ts
@@ -9,7 +9,10 @@ import { dingtalkHttp } from "../../utils/http-client.ts";
 
 // ============ 常量 ============
 
-const AI_CARD_TEMPLATE_ID = "02fcf2f4-5e02-4a85-b672-46d1f715543e.schema";
+const DEFAULT_AI_CARD_TEMPLATE_ID = "02fcf2f4-5e02-4a85-b672-46d1f715543e.schema";
+
+/** 默认的卡片内容字段名（官方 AI Card 模板使用 msgContent） */
+const DEFAULT_CARD_TEMPLATE_KEY = "msgContent";
 
 /**
  * 钉钉卡片 API 的最大 QPS（官方限制约 40 次/秒）。
@@ -369,8 +372,10 @@ export async function createAICardForTarget(
     );
 
     // 1. 创建卡片实例
+    const cardTemplateId = config.cardTemplateId || DEFAULT_AI_CARD_TEMPLATE_ID;
+
     const createBody = {
-      cardTemplateId: AI_CARD_TEMPLATE_ID,
+      cardTemplateId,
       outTrackId: cardInstanceId,
       cardData: {
           cardParamMap: {
@@ -462,6 +467,10 @@ export async function streamAICard(
     log?.warn?.(`[DingTalk][AICard] streamAICard 收到 null card，跳过更新`);
     return;
   }
+
+  // 从 config 中读取自定义内容字段名（自定义模板的 Markdown 变量名），默认 "msgContent"
+  const contentKey = config?.cardTemplateKey || DEFAULT_CARD_TEMPLATE_KEY;
+
   // 确保 token 有效
   if (config) {
     await ensureValidToken(card, config);
@@ -473,18 +482,22 @@ export async function streamAICard(
       log?.debug?.(`[DingTalk][AICard] INPUTING 等待限流令牌 ${inputingWaitMs}ms`);
     }
 
+    const inputingCardParamMap: Record<string, any> = {
+          flowStatus: AICardStatus.INPUTING,
+          [contentKey]: normalizeForCard(content),
+          sys_full_json_obj: JSON.stringify({
+            order: [contentKey],
+          }),
+          config: JSON.stringify({ autoLayout: true }),
+    };
+    // 默认模板需要写入 staticMsgContent，自定义模板不写（避免污染用户自定义字段）
+    if (contentKey === DEFAULT_CARD_TEMPLATE_KEY) {
+      inputingCardParamMap.staticMsgContent = "";
+    }
     const statusBody = {
       outTrackId: card.cardInstanceId,
       cardData: {
-        cardParamMap: {
-          flowStatus: AICardStatus.INPUTING,
-          msgContent: normalizeForCard(content),
-          staticMsgContent: "",
-          sys_full_json_obj: JSON.stringify({
-            order: ["msgContent"],
-          }),
-          config: JSON.stringify({ autoLayout: true }),
-        },
+        cardParamMap: inputingCardParamMap,
       },
     };
     const putInputing = () =>
@@ -533,7 +546,7 @@ export async function streamAICard(
   const body = {
     outTrackId: card.cardInstanceId,
     guid: `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-    key: "msgContent",
+    key: contentKey,
     content: streamContent,
     isFull: true,
     isFinalize: finished,
@@ -606,6 +619,10 @@ export async function finishAICard(
   if (config) {
     await ensureValidToken(card, config);
   }
+
+  // 从 config 中读取自定义内容字段名，默认 "msgContent"
+  const contentKey = config?.cardTemplateKey || DEFAULT_CARD_TEMPLATE_KEY;
+
   const fixedContent = normalizeForCard(content);
   log?.info?.(
     `[DingTalk][AICard] 开始 finish，最终内容长度=${fixedContent.length}`,
@@ -613,18 +630,22 @@ export async function finishAICard(
 
   await streamAICard(card, fixedContent, true, config, log);
 
+  const finishedCardParamMap: Record<string, any> = {
+        flowStatus: AICardStatus.FINISHED,
+        [contentKey]: fixedContent,
+        sys_full_json_obj: JSON.stringify({
+          order: [contentKey],
+        }),
+        config: JSON.stringify({ autoLayout: true }),
+  };
+  // 默认模板需要写入 staticMsgContent，自定义模板不写（避免污染用户自定义字段）
+  if (contentKey === DEFAULT_CARD_TEMPLATE_KEY) {
+    finishedCardParamMap.staticMsgContent = "";
+  }
   const body = {
     outTrackId: card.cardInstanceId,
     cardData: {
-      cardParamMap: {
-        flowStatus: AICardStatus.FINISHED,
-        msgContent: fixedContent,
-        staticMsgContent: "",
-        sys_full_json_obj: JSON.stringify({
-          order: ["msgContent"],
-        }),
-        config: JSON.stringify({ autoLayout: true }),
-      },
+      cardParamMap: finishedCardParamMap,
     },
     cardUpdateOptions: { updateCardDataByKey: true },
   };

--- a/tests/card-feedback/card-callback.test.ts
+++ b/tests/card-feedback/card-callback.test.ts
@@ -1,0 +1,305 @@
+/**
+ * TOPIC_CARD 回调处理器单元测试
+ *
+ * 通过模拟 DingTalk Stream client 和 connection.ts 中 TOPIC_CARD 回调逻辑，
+ * 验证 actionId 解析、自定义 actionId 生效、点踩原因提取等核心路径。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ============ 模拟 TOPIC_CARD 回调处理逻辑（从 connection.ts 提取核心逻辑） ============
+
+interface CardCallbackConfig {
+  cardLikeActionId?: string;
+  cardDislikeActionId?: string;
+  cardFeedbackStatusKey?: string;
+}
+
+/**
+ * 模拟 TOPIC_CARD 回调处理器的核心逻辑，
+ * 与 connection.ts 中的实现保持一致。
+ */
+function processCardCallback(
+  rawData: string,
+  config: CardCallbackConfig = {},
+): {
+  response: Record<string, any>;
+  parseFailed: boolean;
+  actionType: "like" | "dislike" | "unknown" | "parse_error";
+  dislikeReasons?: string[];
+  customDislikeReason?: string;
+} {
+  // 1. 解析回调数据
+  let callbackData: any = {};
+  try {
+    callbackData = JSON.parse(rawData);
+  } catch {
+    return {
+      response: { success: false },
+      parseFailed: true,
+      actionType: "parse_error",
+    };
+  }
+
+  // 2. 二次解析 content
+  let parsedContent: any = {};
+  try {
+    const rawContent = callbackData?.content;
+    parsedContent =
+      typeof rawContent === "string"
+        ? JSON.parse(rawContent)
+        : (rawContent ?? {});
+  } catch {
+    parsedContent = {};
+  }
+
+  const actionIds: string[] = Array.isArray(
+    parsedContent?.cardPrivateData?.actionIds,
+  )
+    ? parsedContent.cardPrivateData.actionIds
+    : [];
+  const params = parsedContent?.cardPrivateData?.params ?? {};
+
+  // 3. 从配置读取
+  const likeActionId = config.cardLikeActionId || "ai_res_like";
+  const dislikeActionId = config.cardDislikeActionId || "ai_res_dislike";
+  const likeVar = config.cardFeedbackStatusKey || "like";
+
+  // 4. 构造响应
+  const response: Record<string, any> = {
+    cardUpdateOptions: {
+      updateCardDataByKey: true,
+      updatePrivateDataByKey: true,
+    },
+    cardData: { cardParamMap: {} },
+    userPrivateData: { cardParamMap: {} },
+  };
+
+  let actionType: "like" | "dislike" | "unknown" = "unknown";
+  let dislikeReasons: string[] | undefined;
+  let customDislikeReason: string | undefined;
+
+  if (actionIds.includes(likeActionId)) {
+    response.cardData.cardParamMap[likeVar] = 1;
+    actionType = "like";
+  } else if (actionIds.includes(dislikeActionId)) {
+    response.cardData.cardParamMap[likeVar] = -1;
+    response.cardData.cardParamMap.submitted = "true";
+    actionType = "dislike";
+    dislikeReasons = Array.isArray(params.dislike_reason)
+      ? params.dislike_reason
+      : [];
+    customDislikeReason = params.custom_dislike_reason ?? undefined;
+  }
+
+  return { response, parseFailed: false, actionType, dislikeReasons, customDislikeReason };
+}
+
+// ============ 测试用例 ============
+
+describe("TOPIC_CARD callback handler", () => {
+  // ----- actionId 解析 -----
+
+  describe("actionId 解析", () => {
+    it("默认 actionId 点赞: ai_res_like", () => {
+      const data = JSON.stringify({
+        outTrackId: "card_001",
+        userId: "user1",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["ai_res_like"],
+            params: {},
+          },
+        }),
+      });
+
+      const result = processCardCallback(data);
+      expect(result.actionType).toBe("like");
+      expect(result.response.cardData.cardParamMap.like).toBe(1);
+    });
+
+    it("默认 actionId 点踩: ai_res_dislike", () => {
+      const data = JSON.stringify({
+        outTrackId: "card_002",
+        userId: "user2",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["ai_res_dislike"],
+            params: {
+              dislike_reason: ["回答不准确", "内容过长"],
+              custom_dislike_reason: "缺少代码示例",
+            },
+          },
+        }),
+      });
+
+      const result = processCardCallback(data);
+      expect(result.actionType).toBe("dislike");
+      expect(result.response.cardData.cardParamMap.like).toBe(-1);
+      expect(result.response.cardData.cardParamMap.submitted).toBe("true");
+      expect(result.dislikeReasons).toEqual(["回答不准确", "内容过长"]);
+      expect(result.customDislikeReason).toBe("缺少代码示例");
+    });
+
+    it("未知 actionId 按默认处理", () => {
+      const data = JSON.stringify({
+        outTrackId: "card_003",
+        userId: "user3",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["some_unknown_action"],
+            params: {},
+          },
+        }),
+      });
+
+      const result = processCardCallback(data);
+      expect(result.actionType).toBe("unknown");
+      expect(result.response.cardData.cardParamMap).toEqual({});
+    });
+
+    it("空 actionIds 数组按默认处理", () => {
+      const data = JSON.stringify({
+        outTrackId: "card_004",
+        userId: "user4",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: [],
+            params: {},
+          },
+        }),
+      });
+
+      const result = processCardCallback(data);
+      expect(result.actionType).toBe("unknown");
+    });
+  });
+
+  // ----- 自定义 actionId 生效 -----
+
+  describe("自定义 actionId 生效", () => {
+    it("自定义 cardLikeActionId 生效", () => {
+      const data = JSON.stringify({
+        outTrackId: "card_custom_1",
+        userId: "user5",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["thumbs_up"],
+            params: {},
+          },
+        }),
+      });
+
+      const result = processCardCallback(data, {
+        cardLikeActionId: "thumbs_up",
+        cardDislikeActionId: "thumbs_down",
+      });
+      expect(result.actionType).toBe("like");
+    });
+
+    it("自定义 cardDislikeActionId 生效", () => {
+      const data = JSON.stringify({
+        outTrackId: "card_custom_2",
+        userId: "user6",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["thumbs_down"],
+            params: {},
+          },
+        }),
+      });
+
+      const result = processCardCallback(data, {
+        cardLikeActionId: "thumbs_up",
+        cardDislikeActionId: "thumbs_down",
+      });
+      expect(result.actionType).toBe("dislike");
+    });
+
+    it("自定义 cardFeedbackStatusKey 生效", () => {
+      const data = JSON.stringify({
+        outTrackId: "card_custom_3",
+        userId: "user7",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["ai_res_like"],
+            params: {},
+          },
+        }),
+      });
+
+      const result = processCardCallback(data, {
+        cardFeedbackStatusKey: "feedbackStatus",
+      });
+      expect(result.actionType).toBe("like");
+      expect(result.response.cardData.cardParamMap.feedbackStatus).toBe(1);
+      // 确保旧的 "like" key 不存在
+      expect(result.response.cardData.cardParamMap.like).toBeUndefined();
+    });
+  });
+
+  // ----- 点踩原因 -----
+
+  describe("点踩原因解析", () => {
+    it("点踩包含多个原因", () => {
+      const data = JSON.stringify({
+        outTrackId: "card_reason_1",
+        userId: "user8",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["ai_res_dislike"],
+            params: {
+              dislike_reason: ["太长了", "不相关", "有错误"],
+            },
+          },
+        }),
+      });
+
+      const result = processCardCallback(data);
+      expect(result.dislikeReasons).toEqual(["太长了", "不相关", "有错误"]);
+      expect(result.customDislikeReason).toBeUndefined();
+    });
+
+    it("点踩只有自定义原因", () => {
+      const data = JSON.stringify({
+        outTrackId: "card_reason_2",
+        userId: "user9",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["ai_res_dislike"],
+            params: {
+              custom_dislike_reason: "回答完全错误",
+            },
+          },
+        }),
+      });
+
+      const result = processCardCallback(data);
+      expect(result.dislikeReasons).toEqual([]);
+      expect(result.customDislikeReason).toBe("回答完全错误");
+    });
+  });
+
+  // ----- 解析失败 -----
+
+  describe("解析失败处理", () => {
+    it("非 JSON 数据返回 { success: false }", () => {
+      const result = processCardCallback("not-json-data");
+      expect(result.parseFailed).toBe(true);
+      expect(result.actionType).toBe("parse_error");
+      expect(result.response).toEqual({ success: false });
+    });
+
+    it("content 字段非 JSON 不影响处理", () => {
+      const data = JSON.stringify({
+        outTrackId: "card_parse_1",
+        userId: "user10",
+        content: "invalid-json-content",
+      });
+
+      const result = processCardCallback(data);
+      // content 解析失败降级为空对象，actionIds 为空
+      expect(result.parseFailed).toBe(false);
+      expect(result.actionType).toBe("unknown");
+    });
+  });
+});

--- a/tests/card-feedback/card-contentkey.test.ts
+++ b/tests/card-feedback/card-contentkey.test.ts
@@ -1,0 +1,146 @@
+/**
+ * card.ts 自定义 contentKey 替换路径单元测试
+ *
+ * 验证 streamAICard / finishAICard 在默认模板和自定义模板下：
+ * - 正确使用 contentKey
+ * - 默认模板写入 staticMsgContent: ""
+ * - 自定义模板不写入 staticMsgContent
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock dingtalkHttp 以拦截 API 调用
+const mockPut = vi.fn();
+const mockPost = vi.fn();
+vi.mock("../../src/utils/http-client", () => ({
+  dingtalkHttp: {
+    put: (...args: any[]) => mockPut(...args),
+    post: (...args: any[]) => mockPost(...args),
+  },
+}));
+
+vi.mock("../../src/utils/token", () => ({
+  DINGTALK_API: "https://api.dingtalk.com",
+  getAccessToken: vi.fn().mockResolvedValue("mock-token"),
+}));
+
+import { streamAICard, finishAICard, type AICardInstance } from "../../src/services/messaging/card";
+import type { DingtalkConfig } from "../../src/types/index";
+
+describe("card.ts contentKey 路径", () => {
+  let mockCard: AICardInstance;
+  const mockLog = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+
+  beforeEach(() => {
+    mockCard = {
+      cardInstanceId: "card_test_001",
+      accessToken: "mock-token",
+      tokenExpireTime: Date.now() + 3600000,
+      inputingStarted: false,
+    };
+    mockPut.mockReset();
+    mockPut.mockResolvedValue({ status: 200 });
+    mockPost.mockReset();
+    mockPost.mockResolvedValue({ status: 200, data: {} });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ===== streamAICard =====
+
+  describe("streamAICard - 默认模板", () => {
+    it("使用默认 contentKey='msgContent' 且包含 staticMsgContent", async () => {
+      const config = { clientId: "test" } as DingtalkConfig;
+
+      await streamAICard(mockCard, "Hello world", false, config, mockLog);
+
+      // 第一次调用是 INPUTING 状态切换 (PUT /card/instances)
+      const inputingCall = mockPut.mock.calls[0];
+      const inputingBody = inputingCall[1];
+
+      expect(inputingBody.cardData.cardParamMap.msgContent).toBeDefined();
+      expect(inputingBody.cardData.cardParamMap.staticMsgContent).toBe("");
+      // sys_full_json_obj 中的 order 应包含 msgContent
+      const sysJson = JSON.parse(inputingBody.cardData.cardParamMap.sys_full_json_obj);
+      expect(sysJson.order).toContain("msgContent");
+    });
+  });
+
+  describe("streamAICard - 自定义模板", () => {
+    it("使用自定义 contentKey 且不包含 staticMsgContent", async () => {
+      const config = {
+        clientId: "test",
+        cardTemplateKey: "customContent",
+      } as unknown as DingtalkConfig;
+
+      await streamAICard(mockCard, "Hello custom", false, config, mockLog);
+
+      // INPUTING 状态切换
+      const inputingCall = mockPut.mock.calls[0];
+      const inputingBody = inputingCall[1];
+
+      // 应使用自定义 key
+      expect(inputingBody.cardData.cardParamMap.customContent).toBeDefined();
+      // 不应包含 msgContent
+      expect(inputingBody.cardData.cardParamMap.msgContent).toBeUndefined();
+      // 不应包含 staticMsgContent（避免污染自定义字段）
+      expect(inputingBody.cardData.cardParamMap.staticMsgContent).toBeUndefined();
+      // sys_full_json_obj 中的 order 应包含自定义 key
+      const sysJson = JSON.parse(inputingBody.cardData.cardParamMap.sys_full_json_obj);
+      expect(sysJson.order).toContain("customContent");
+    });
+  });
+
+  // ===== finishAICard =====
+
+  describe("finishAICard - 默认模板", () => {
+    it("FINISHED 状态包含 staticMsgContent: ''", async () => {
+      const config = { clientId: "test" } as DingtalkConfig;
+      // 需要先让 inputingStarted = true 以跳过 INPUTING
+      mockCard.inputingStarted = true;
+
+      await finishAICard(mockCard, "Final content", config, mockLog);
+
+      // finishAICard 内部先调 streamAICard (isFinalize=true) 再调 PUT /card/instances (FINISHED)
+      // 找到 FINISHED 的调用（cardData 包含 flowStatus=3）
+      const finishedCall = mockPut.mock.calls.find((call: any) => {
+        const body = call[1];
+        return body.cardData?.cardParamMap?.flowStatus === "3";
+      });
+
+      expect(finishedCall).toBeDefined();
+      const finishedBody = finishedCall![1];
+      expect(finishedBody.cardData.cardParamMap.msgContent).toBeDefined();
+      expect(finishedBody.cardData.cardParamMap.staticMsgContent).toBe("");
+    });
+  });
+
+  describe("finishAICard - 自定义模板", () => {
+    it("FINISHED 状态不包含 staticMsgContent", async () => {
+      const config = {
+        clientId: "test",
+        cardTemplateKey: "myContent",
+      } as unknown as DingtalkConfig;
+      mockCard.inputingStarted = true;
+
+      await finishAICard(mockCard, "Final custom content", config, mockLog);
+
+      const finishedCall = mockPut.mock.calls.find((call: any) => {
+        const body = call[1];
+        return body.cardData?.cardParamMap?.flowStatus === "3";
+      });
+
+      expect(finishedCall).toBeDefined();
+      const finishedBody = finishedCall![1];
+      expect(finishedBody.cardData.cardParamMap.myContent).toBeDefined();
+      expect(finishedBody.cardData.cardParamMap.msgContent).toBeUndefined();
+      expect(finishedBody.cardData.cardParamMap.staticMsgContent).toBeUndefined();
+    });
+  });
+});

--- a/tests/card-feedback/card-feedback.test.ts
+++ b/tests/card-feedback/card-feedback.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// mock node:os 的 homedir，后续通过 _fakeHome 动态修改返回值
+let _fakeHome = "/tmp";
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: () => _fakeHome,
+  };
+});
+
+import {
+  registerCardSession,
+  lookupCardSession,
+  cleanupExpiredCardSessions,
+  recordFeedbackToSession,
+  _getRegistryForTesting,
+  CARD_SESSION_TTL,
+} from "../../src/services/card-session-registry";
+
+describe("card-session-registry", () => {
+  beforeEach(() => {
+    _getRegistryForTesting().clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ===== registerCardSession / lookupCardSession =====
+
+  describe("registerCardSession / lookupCardSession", () => {
+    it("注册后能查到映射", () => {
+      registerCardSession("card-001", {
+        sessionKey: "agent:admin:dingtalk-connector:direct:100",
+        agentId: "admin",
+        createdAt: Date.now(),
+      });
+
+      const info = lookupCardSession("card-001");
+      expect(info).not.toBeNull();
+      expect(info!.sessionKey).toBe("agent:admin:dingtalk-connector:direct:100");
+      expect(info!.agentId).toBe("admin");
+    });
+
+    it("未注册的 cardInstanceId 返回 null", () => {
+      expect(lookupCardSession("nonexistent")).toBeNull();
+    });
+
+    it("同一 cardInstanceId 注册多次覆盖旧值", () => {
+      registerCardSession("card-001", {
+        sessionKey: "key-old",
+        agentId: "admin",
+        createdAt: Date.now(),
+      });
+      registerCardSession("card-001", {
+        sessionKey: "key-new",
+        agentId: "admin",
+        createdAt: Date.now(),
+      });
+      expect(lookupCardSession("card-001")!.sessionKey).toBe("key-new");
+    });
+  });
+
+  // ===== cleanupExpiredCardSessions =====
+
+  describe("cleanupExpiredCardSessions", () => {
+    it("清理过期的条目，保留未过期的", () => {
+      const now = Date.now();
+      registerCardSession("expired-1", {
+        sessionKey: "key-1",
+        agentId: "admin",
+        createdAt: now - CARD_SESSION_TTL - 1000,
+      });
+      registerCardSession("fresh-1", {
+        sessionKey: "key-2",
+        agentId: "admin",
+        createdAt: now,
+      });
+
+      const removed = cleanupExpiredCardSessions();
+      expect(removed).toBe(1);
+      expect(lookupCardSession("expired-1")).toBeNull();
+      expect(lookupCardSession("fresh-1")).not.toBeNull();
+    });
+
+    it("全部未过期时返回 0", () => {
+      registerCardSession("card-a", {
+        sessionKey: "key-a",
+        agentId: "admin",
+        createdAt: Date.now(),
+      });
+      expect(cleanupExpiredCardSessions()).toBe(0);
+    });
+  });
+
+  // ===== recordFeedbackToSession =====
+
+  describe("recordFeedbackToSession", () => {
+    let tmpDir: string;
+    const agentId = "test-agent";
+    const sessionKey = "agent:test-agent:dingtalk:direct:999";
+    const sessionId = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb";
+
+    beforeEach(() => {
+      // 创建临时目录模拟 ~/.openclaw/agents/{agentId}/sessions/
+      tmpDir = fs.mkdtempSync(path.join("/tmp", "card-feedback-test-"));
+      const sessionsDir = path.join(tmpDir, ".openclaw", "agents", agentId, "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+
+      // 创建 session 文件
+      const sessionFile = path.join(sessionsDir, `${sessionId}.jsonl`);
+      fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", id: "s1" }));
+
+      // 创建 sessions.json
+      const sessionsJson: Record<string, any> = {};
+      sessionsJson[sessionKey] = { sessionId, sessionFile };
+      fs.writeFileSync(
+        path.join(sessionsDir, "sessions.json"),
+        JSON.stringify(sessionsJson)
+      );
+
+      // 设置 fakeHome 使 homedir() 返回 tmpDir
+      _fakeHome = tmpDir;
+
+      // 注册卡片映射
+      registerCardSession("card-feedback-test", {
+        sessionKey,
+        agentId,
+        createdAt: Date.now(),
+      });
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("点赞反馈成功写入 session 文件", async () => {
+      const result = await recordFeedbackToSession({
+        outTrackId: "card-feedback-test",
+        like: 1,
+        userId: "user-001",
+      });
+      expect(result).toBe(true);
+
+      // 读取文件验证
+      const sessionFile = path.join(
+        tmpDir, ".openclaw", "agents", agentId, "sessions", `${sessionId}.jsonl`
+      );
+      const lines = fs.readFileSync(sessionFile, "utf-8").split("\n").filter(Boolean);
+      expect(lines.length).toBe(2); // 原始 session 行 + 反馈行
+
+      const feedbackEntry = JSON.parse(lines[1]);
+      expect(feedbackEntry.type).toBe("custom");
+      expect(feedbackEntry.customType).toBe("user-feedback");
+      expect(feedbackEntry.data.like).toBe(1);
+      expect(feedbackEntry.data.userId).toBe("user-001");
+      expect(feedbackEntry.data.source).toBe("dingtalk-card");
+      expect(feedbackEntry.id).toBeTruthy();
+      expect(feedbackEntry.timestamp).toBeTruthy();
+    });
+
+    it("点踩反馈包含原因信息", async () => {
+      const result = await recordFeedbackToSession({
+        outTrackId: "card-feedback-test",
+        like: -1,
+        userId: "user-002",
+        dislikeReasons: ["回答不准确", "太啰嗦"],
+        customDislikeReason: "没有给出具体代码",
+      });
+      expect(result).toBe(true);
+
+      const sessionFile = path.join(
+        tmpDir, ".openclaw", "agents", agentId, "sessions", `${sessionId}.jsonl`
+      );
+      const lines = fs.readFileSync(sessionFile, "utf-8").split("\n").filter(Boolean);
+      const feedbackEntry = JSON.parse(lines[1]);
+
+      expect(feedbackEntry.data.like).toBe(-1);
+      expect(feedbackEntry.data.dislikeReasons).toEqual(["回答不准确", "太啰嗦"]);
+      expect(feedbackEntry.data.customDislikeReason).toBe("没有给出具体代码");
+    });
+
+    it("点赞反馈不包含 dislikeReasons 字段", async () => {
+      await recordFeedbackToSession({
+        outTrackId: "card-feedback-test",
+        like: 1,
+        userId: "user-003",
+      });
+
+      const sessionFile = path.join(
+        tmpDir, ".openclaw", "agents", agentId, "sessions", `${sessionId}.jsonl`
+      );
+      const lines = fs.readFileSync(sessionFile, "utf-8").split("\n").filter(Boolean);
+      const feedbackEntry = JSON.parse(lines[1]);
+
+      expect(feedbackEntry.data.dislikeReasons).toBeUndefined();
+      expect(feedbackEntry.data.customDislikeReason).toBeUndefined();
+    });
+
+    it("outTrackId 为空时返回 false", async () => {
+      const result = await recordFeedbackToSession({
+        outTrackId: "",
+        like: 1,
+        userId: "user-001",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("找不到卡片映射时返回 false", async () => {
+      const result = await recordFeedbackToSession({
+        outTrackId: "unknown-card",
+        like: 1,
+        userId: "user-001",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("sessions.json 不存在时返回 false", async () => {
+      // 注册一个指向不存在 agentId 目录的卡片
+      registerCardSession("card-no-agent", {
+        sessionKey: "agent:ghost:dingtalk:direct:1",
+        agentId: "ghost",
+        createdAt: Date.now(),
+      });
+
+      const result = await recordFeedbackToSession({
+        outTrackId: "card-no-agent",
+        like: 1,
+        userId: "user-001",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("sessionKey 在 sessions.json 中不存在时返回 false", async () => {
+      registerCardSession("card-wrong-key", {
+        sessionKey: "agent:test-agent:dingtalk:direct:nonexistent",
+        agentId,
+        createdAt: Date.now(),
+      });
+
+      const result = await recordFeedbackToSession({
+        outTrackId: "card-wrong-key",
+        like: -1,
+        userId: "user-001",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("sessionFile 路径在 sessions.json 中存在但实际文件已删除时返回 false", async () => {
+      // 删除 session 文件模拟文件被清理的场景
+      const sessionFile = path.join(
+        tmpDir, ".openclaw", "agents", agentId, "sessions", `${sessionId}.jsonl`
+      );
+      fs.unlinkSync(sessionFile);
+
+      const result = await recordFeedbackToSession({
+        outTrackId: "card-feedback-test",
+        like: 1,
+        userId: "user-001",
+      });
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/tests/card-feedback/card-feedback.test.ts
+++ b/tests/card-feedback/card-feedback.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// mock node:os 的 homedir，后续通过 _fakeHome 动态修改返回值
+let _fakeHome = "/tmp";
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: () => _fakeHome,
+  };
+});
+
+import {
+  registerCardSession,
+  lookupCardSession,
+  cleanupExpiredCardSessions,
+  recordFeedbackToSession,
+  _getRegistryForTesting,
+  CARD_SESSION_TTL,
+} from "../../src/services/card-session-registry";
+
+describe("card-session-registry", () => {
+  beforeEach(() => {
+    _getRegistryForTesting().clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ===== registerCardSession / lookupCardSession =====
+
+  describe("registerCardSession / lookupCardSession", () => {
+    it("注册后能查到映射", async () => {
+      registerCardSession("card-001", {
+        sessionKey: "agent:admin:dingtalk-connector:direct:100",
+        agentId: "admin",
+        createdAt: Date.now(),
+      });
+
+      const info = await lookupCardSession("card-001");
+      expect(info).not.toBeNull();
+      expect(info!.sessionKey).toBe("agent:admin:dingtalk-connector:direct:100");
+      expect(info!.agentId).toBe("admin");
+    });
+
+    it("未注册的 cardInstanceId 返回 null", async () => {
+      expect(await lookupCardSession("nonexistent")).toBeNull();
+    });
+
+    it("同一 cardInstanceId 注册多次覆盖旧值", async () => {
+      registerCardSession("card-001", {
+        sessionKey: "key-old",
+        agentId: "admin",
+        createdAt: Date.now(),
+      });
+      registerCardSession("card-001", {
+        sessionKey: "key-new",
+        agentId: "admin",
+        createdAt: Date.now(),
+      });
+      expect((await lookupCardSession("card-001"))!.sessionKey).toBe("key-new");
+    });
+  });
+
+  // ===== cleanupExpiredCardSessions =====
+
+  describe("cleanupExpiredCardSessions", () => {
+    it("清理过期的条目，保留未过期的", async () => {
+      const now = Date.now();
+      registerCardSession("expired-1", {
+        sessionKey: "key-1",
+        agentId: "admin",
+        createdAt: now - CARD_SESSION_TTL - 1000,
+      });
+      registerCardSession("fresh-1", {
+        sessionKey: "key-2",
+        agentId: "admin",
+        createdAt: now,
+      });
+
+      const removed = cleanupExpiredCardSessions();
+      expect(removed).toBe(1);
+      expect(await lookupCardSession("expired-1")).toBeNull();
+      expect(await lookupCardSession("fresh-1")).not.toBeNull();
+    });
+
+    it("全部未过期时返回 0", () => {
+      registerCardSession("card-a", {
+        sessionKey: "key-a",
+        agentId: "admin",
+        createdAt: Date.now(),
+      });
+      expect(cleanupExpiredCardSessions()).toBe(0);
+    });
+  });
+
+  // ===== recordFeedbackToSession =====
+
+  describe("recordFeedbackToSession", () => {
+    let tmpDir: string;
+    const agentId = "test-agent";
+    const sessionKey = "agent:test-agent:dingtalk:direct:999";
+    const sessionId = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb";
+
+    beforeEach(() => {
+      // 创建临时目录模拟 ~/.openclaw/agents/{agentId}/sessions/
+      tmpDir = fs.mkdtempSync(path.join("/tmp", "card-feedback-test-"));
+      const sessionsDir = path.join(tmpDir, ".openclaw", "agents", agentId, "sessions");
+      fs.mkdirSync(sessionsDir, { recursive: true });
+
+      // 创建 session 文件
+      const sessionFile = path.join(sessionsDir, `${sessionId}.jsonl`);
+      fs.writeFileSync(sessionFile, JSON.stringify({ type: "session", id: "s1" }));
+
+      // 创建 sessions.json
+      const sessionsJson: Record<string, any> = {};
+      sessionsJson[sessionKey] = { sessionId, sessionFile };
+      fs.writeFileSync(
+        path.join(sessionsDir, "sessions.json"),
+        JSON.stringify(sessionsJson)
+      );
+
+      // 设置 fakeHome 使 homedir() 返回 tmpDir
+      _fakeHome = tmpDir;
+
+      // 注册卡片映射
+      registerCardSession("card-feedback-test", {
+        sessionKey,
+        agentId,
+        createdAt: Date.now(),
+      });
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("点赞反馈成功写入 session 文件", async () => {
+      const result = await recordFeedbackToSession({
+        outTrackId: "card-feedback-test",
+        like: 1,
+        userId: "user-001",
+      });
+      expect(result).toBe(true);
+
+      // 读取文件验证
+      const sessionFile = path.join(
+        tmpDir, ".openclaw", "agents", agentId, "sessions", `${sessionId}.jsonl`
+      );
+      const lines = fs.readFileSync(sessionFile, "utf-8").split("\n").filter(Boolean);
+      expect(lines.length).toBe(2); // 原始 session 行 + 反馈行
+
+      const feedbackEntry = JSON.parse(lines[1]);
+      expect(feedbackEntry.type).toBe("custom");
+      expect(feedbackEntry.customType).toBe("user-feedback");
+      expect(feedbackEntry.data.like).toBe(1);
+      expect(feedbackEntry.data.userId).toBe("user-001");
+      expect(feedbackEntry.data.source).toBe("dingtalk-card");
+      expect(feedbackEntry.id).toBeTruthy();
+      expect(feedbackEntry.timestamp).toBeTruthy();
+    });
+
+    it("点踩反馈包含原因信息", async () => {
+      const result = await recordFeedbackToSession({
+        outTrackId: "card-feedback-test",
+        like: -1,
+        userId: "user-002",
+        dislikeReasons: ["回答不准确", "太啰嗦"],
+        customDislikeReason: "没有给出具体代码",
+      });
+      expect(result).toBe(true);
+
+      const sessionFile = path.join(
+        tmpDir, ".openclaw", "agents", agentId, "sessions", `${sessionId}.jsonl`
+      );
+      const lines = fs.readFileSync(sessionFile, "utf-8").split("\n").filter(Boolean);
+      const feedbackEntry = JSON.parse(lines[1]);
+
+      expect(feedbackEntry.data.like).toBe(-1);
+      expect(feedbackEntry.data.dislikeReasons).toEqual(["回答不准确", "太啰嗦"]);
+      expect(feedbackEntry.data.customDislikeReason).toBe("没有给出具体代码");
+    });
+
+    it("点赞反馈不包含 dislikeReasons 字段", async () => {
+      await recordFeedbackToSession({
+        outTrackId: "card-feedback-test",
+        like: 1,
+        userId: "user-003",
+      });
+
+      const sessionFile = path.join(
+        tmpDir, ".openclaw", "agents", agentId, "sessions", `${sessionId}.jsonl`
+      );
+      const lines = fs.readFileSync(sessionFile, "utf-8").split("\n").filter(Boolean);
+      const feedbackEntry = JSON.parse(lines[1]);
+
+      expect(feedbackEntry.data.dislikeReasons).toBeUndefined();
+      expect(feedbackEntry.data.customDislikeReason).toBeUndefined();
+    });
+
+    it("outTrackId 为空时返回 false", async () => {
+      const result = await recordFeedbackToSession({
+        outTrackId: "",
+        like: 1,
+        userId: "user-001",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("找不到卡片映射时返回 false", async () => {
+      const result = await recordFeedbackToSession({
+        outTrackId: "unknown-card",
+        like: 1,
+        userId: "user-001",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("sessions.json 不存在时返回 false", async () => {
+      // 注册一个指向不存在 agentId 目录的卡片
+      registerCardSession("card-no-agent", {
+        sessionKey: "agent:ghost:dingtalk:direct:1",
+        agentId: "ghost",
+        createdAt: Date.now(),
+      });
+
+      const result = await recordFeedbackToSession({
+        outTrackId: "card-no-agent",
+        like: 1,
+        userId: "user-001",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("sessionKey 在 sessions.json 中不存在时返回 false", async () => {
+      registerCardSession("card-wrong-key", {
+        sessionKey: "agent:test-agent:dingtalk:direct:nonexistent",
+        agentId,
+        createdAt: Date.now(),
+      });
+
+      const result = await recordFeedbackToSession({
+        outTrackId: "card-wrong-key",
+        like: -1,
+        userId: "user-001",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("sessionFile 路径在 sessions.json 中存在但实际文件已删除时返回 false", async () => {
+      // 删除 session 文件模拟文件被清理的场景
+      const sessionFile = path.join(
+        tmpDir, ".openclaw", "agents", agentId, "sessions", `${sessionId}.jsonl`
+      );
+      fs.unlinkSync(sessionFile);
+
+      const result = await recordFeedbackToSession({
+        outTrackId: "card-feedback-test",
+        like: 1,
+        userId: "user-001",
+      });
+      expect(result).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- 支持自定义钉钉 AI 卡片模板，通过配置项指定 `cardTemplateId`、`cardTemplateKey` 替换内置模板，使不同业务场景可以使用各自的卡片样式
- 新增 TOPIC_CARD Stream 回调处理器，接收用户点赞/点踩操作并更新卡片状态
- 卡片回调的 actionId 和变量名支持自定义配置（`cardLikeActionId`、`cardDislikeActionId`、`cardLikeVar`），适配不同卡片模板的按钮定义
- 用户反馈（点赞/点踩）自动记录到 OpenClaw session JSONL 文件，供会话统计插件消费
- 单聊和群聊场景均已实测验证通过

解决issue：https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/540
## 变更内容

### 1. 自定义 AI 卡片模板支持（af86a20）

**问题**：之前 AI 卡片模板 ID 硬编码为 `02fcf2f4-5e02-4a85-b672-46d1f715543e.schema`，内容字段名固定为 `msgContent`，无法使用自定义卡片模板。

**方案**：新增 5 个可选配置项（均有默认值，不影响已有配置），将模板 ID、内容字段名、回调按钮 ID 全部参数化。

#### 新增配置项

| 配置项 | 类型 | 默认值 | 说明 |
|--------|------|--------|------|
| `cardTemplateId` | `string` | `02fcf2f4-...schema` | AI 卡片模板 ID |
| `cardTemplateKey` | `string` | `msgContent` | 卡片内容 Markdown 变量名 |
| `cardLikeActionId` | `string` | `ai_res_like` | 点赞按钮的回调 actionId |
| `cardDislikeActionId` | `string` | `ai_res_dislike` | 点踩按钮的回调 actionId |
| `cardLikeVar` | `string` | `like` | 卡片中表示赞踩状态的变量名 |

配置位置：`openclaw.json` 中的 `dingtalk-connector` 插件配置。支持两种配置模式：

**单账号模式**（直接在插件顶层配置）：

```json
{
  "dingtalk-connector": {
    "clientId": "xxx",
    "clientSecret": "xxx",
    "cardTemplateId": "your-custom-template-id.schema",
    "cardTemplateKey": "content",
    "cardLikeActionId": "thumbs_up",
    "cardDislikeActionId": "thumbs_down",
    "cardLikeVar": "feedbackStatus"
  }
}
```

**多账号模式**（在 `accounts[].config` 中配置，可按账号设置不同模板）：

```json
{
  "dingtalk-connector": {
    "accounts": [
      {
        "clientId": "xxx",
        "clientSecret": "xxx",
        "config": {
          "cardTemplateId": "your-custom-template-id.schema",
          "cardTemplateKey": "content"
        }
      }
    ]
  }
}
```

#### 代码变更

- **`src/services/messaging/card.ts`**：将硬编码的 `AI_CARD_TEMPLATE_ID` 改为 `DEFAULT_AI_CARD_TEMPLATE_ID`，`createAICardForTarget`、`streamAICard`、`finishAICard` 均从 config 读取 `cardTemplateId` 和 `cardTemplateKey`
- **`src/config/schema.ts`**：在 `DingtalkSharedConfigShape` 中新增 5 个 optional 字段
- **`openclaw.plugin.json`**：在顶层和 accounts 两处 JSON Schema 中注册新字段
- **`src/core/message-handler.ts`**：移除本文件中重复定义的 `AI_CARD_TEMPLATE_ID` 和 `AICardStatus` 常量（已统一到 `card.ts`）
- **`src/reply-dispatcher.ts`**：移除非 QPS 错误时的立即降级逻辑，改为等待下一次 partial 更新重试

#### TOPIC_CARD 回调处理器

在 `src/core/connection.ts` 中新增 TOPIC_CARD Stream 回调监听器：

- 解析回调数据（支持 content 二次 JSON 解析）
- 从 `cardPrivateData.actionIds` 判断是点赞还是点踩
- 根据配置的 `cardLikeActionId`/`cardDislikeActionId`/`cardLikeVar` 构造响应
- 点踩时解析 `dislike_reason` 和 `custom_dislike_reason` 参数
- 通过 `socketCallBackResponse` 响应回调（finally 块保证无论异常都响应，避免钉钉超时重试）

### 2. 用户反馈记录到 Session（c46fa86）

**问题**：用户的点赞/点踩行为仅在卡片上生效，无法在会话历史中留存，统计插件无法获取用户满意度数据。

**方案**：新增 card-session 内存映射注册表，在卡片创建时注册 `cardInstanceId → sessionKey` 映射，在回调触发时查找映射并将反馈追加到 session JSONL 文件。

#### 数据流

```
卡片创建(reply-dispatcher.ts) → registerCardSession(cardInstanceId, sessionKey)
                                         ↓ (内存 Map)
用户点赞/踩(connection.ts)    → recordFeedbackToSession(outTrackId, like, userId)
                                         ↓
                               查找 sessions.json → 定位 JSONL 文件
                                         ↓
                               appendFile → session JSONL
```

#### JSONL 条目格式

统计插件通过 `type === "custom" && customType === "user-feedback"` 过滤反馈条目。

**点赞：**

```json
{
  "type": "custom",
  "customType": "user-feedback",
  "data": {
    "like": 1,
    "userId": "194584",
    "cardInstanceId": "card_1777440689892_pwm21ymr",
    "source": "dingtalk-card"
  },
  "id": "12bbd507",
  "parentId": null,
  "timestamp": "2026-04-29T05:31:41.309Z"
}
```

**点踩（含原因）：**

```json
{
  "type": "custom",
  "customType": "user-feedback",
  "data": {
    "like": -1,
    "userId": "194584",
    "cardInstanceId": "card_1777440689892_pwm21ymr",
    "source": "dingtalk-card",
    "dislikeReasons": ["回答不准确", "太啰嗦"],
    "customDislikeReason": "没有给出具体代码"
  },
  "id": "c80d4b7c",
  "parentId": null,
  "timestamp": "2026-04-29T05:32:24.593Z"
}
```

> `like` 字段为数字类型：`1` = 点赞，`-1` = 点踩。

#### 重复反馈

用户可以反复点赞或点踩同一张卡片，每次操作追加新条目。**统计时以同一 `(cardInstanceId, userId)` 的最后一条为准**（群聊中多用户可对同一卡片独立反馈）。

#### 核心模块

- **`src/services/card-session-registry.ts`**（新增）：内存注册表（`Map<cardInstanceId, {sessionKey, agentId}>`，24h TTL + 30min 自动清理）+ `recordFeedbackToSession()` 异步写入
- **`src/reply-dispatcher.ts`**：新增 `sessionKey` 参数，在两处卡片创建路径调用 `registerCardSession()`
- **`src/core/message-handler.ts`**：将已有 `sessionKey` 变量传递给 `createDingtalkReplyDispatcher()`
- **`src/core/connection.ts`**：在 TOPIC_CARD 回调中 fire-and-forget 调用 `recordFeedbackToSession()`

## 文件变更

| 文件 | 变更类型 | 说明 |
|------|----------|------|
| `openclaw.plugin.json` | 修改 | 新增 5 个卡片配置项 JSON Schema |
| `src/config/schema.ts` | 修改 | 新增 5 个 optional 配置字段 |
| `src/core/connection.ts` | 修改 | 新增 TOPIC_CARD 回调处理器 + 反馈记录调用 |
| `src/core/message-handler.ts` | 修改 | 移除重复常量 + 传递 sessionKey |
| `src/reply-dispatcher.ts` | 修改 | 支持 sessionKey 参数 + 注册卡片映射 |
| `src/services/messaging/card.ts` | 修改 | 模板 ID 和内容字段名参数化 |
| `src/services/card-session-registry.ts` | **新增** | 卡片-会话映射注册表 + 反馈写入 |
| `tests/card-feedback/card-feedback.test.ts` | **新增** | 13 个单元测试 |
| `USER_FEEDBACK.md` | **新增** | 反馈功能文档（含 PR 描述 + 统计消费指南） |

## 测试

- 单元测试：13 个测试全部通过（`vitest run tests/card-feedback/card-feedback.test.ts`）
  - 注册/查找/覆盖
  - TTL 过期清理
  - 点赞/点踩写入验证
  - 点踩原因字段验证
  - 异常路径（空 outTrackId、未知卡片、sessions.json 不存在、sessionKey 不存在、sessionFile 已删除）
- 集成测试：
  - 单聊（admin agent）：点赞/点踩反馈正确记录到 session JSONL
  - 群聊（main agent）：点赞/点踩反馈正确记录到 session JSONL
- 构建：`npx tsdown` 通过

## 注意事项

- 所有新增配置项均为 optional 且有默认值，**完全向后兼容**，不影响使用内置模板的已有部署
- 内存映射表在进程重启后清空，重启前创建的卡片如收到反馈将无法定位 session（日志输出 warn 提示）
- 反馈写入为 fire-and-forget 异步操作，不阻塞卡片回调响应