### PR TITLE
fix: WebSocket phantom reconnect caused by unregistered pong listener

### DIFF
--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -242,6 +242,12 @@ export async function monitorSingleAccount(
       // 2. 重新建立连接
       await client.connect();
 
+      // 立即注册 socket 事件监听器，避免在等待 OPEN 期间错过 pong/message/close 事件
+      // （keepAlive 期间发的 ping，如果 pong 回来时 listener 还没挂，会被丢，最坏踩到 TIMEOUT_THRESHOLD 边界）
+      setupPongListener();
+      setupMessageListener();
+      setupCloseListener();
+
       // 3. 等待连接真正建立（监听 open 事件，最多等待 10 秒）
       const connectionEstablished = await new Promise<boolean>((resolve) => {
         const timeout = setTimeout(() => {
@@ -286,11 +292,6 @@ export async function monitorSingleAccount(
 
       // 重连成功，向框架报告 connected: true
       onStatusChange?.({ connected: true, lastConnectedAt: Date.now() });
-
-      // 重新注册 socket 事件监听器（新 socket 需要新的 listener）
-      setupPongListener();
-      setupMessageListener();
-      setupCloseListener();
 
       logger.info(`✅ 重连成功 (socket 状态=${client.socket?.readyState})`);
     } catch (err: any) {

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -287,6 +287,11 @@ export async function monitorSingleAccount(
       // 重连成功，向框架报告 connected: true
       onStatusChange?.({ connected: true, lastConnectedAt: Date.now() });
 
+      // 重新注册 socket 事件监听器（新 socket 需要新的 listener）
+      setupPongListener();
+      setupMessageListener();
+      setupCloseListener();
+
       logger.info(`✅ 重连成功 (socket 状态=${client.socket?.readyState})`);
     } catch (err: any) {
       reconnectAttempts++;
@@ -448,11 +453,6 @@ export async function monitorSingleAccount(
 
     logger.debug(`Connection 已停止`);
   }
-
-  // 初始化：设置所有事件监听器
-  setupPongListener();
-  setupMessageListener();
-  setupCloseListener();
 
   return new Promise<void>(async (resolve, reject) => {
     // Handle abort signal
@@ -638,6 +638,12 @@ export async function monitorSingleAccount(
     // Connect to DingTalk Stream
     try {
       await client.connect();
+
+      // 注册 socket 事件监听器（必须在 connect 后，此时 client.socket 已创建）
+      setupPongListener();
+      setupMessageListener();
+      setupCloseListener();
+
       logger.info(`Connected to DingTalk Stream successfully`);
       logger.info(`PID: ${process.pid}`);
       logger.info(


### PR DESCRIPTION
## Summary                                                                                        
  - WebSocket 事件监听器（pong/message/close）在 client.connect() 之前注册，此时 client.socket 为   
  null，导致 listener 从未附加到 socket 上                                                          
  - keepAlive 定时器每 10 秒发送 ping，但 pong listener 未注册 → lastSocketAvailableTime 不更新 → 20
   秒超时 → 触发重连                                                                                
  - doReconnect() 成功后也未重新注册 listener，导致重连后新 socket 同样没有 listener →              
  无限循环，约每 30 秒重连一次                                                        
                                                                                                    
  ## 修复         
  1. 删除 connect() 前的无效 listener 注册                                                          
  2. 在 client.connect() 成功后注册 listener（此时 socket 已创建）
  3. 在 doReconnect() 成功后重新注册 listener（新 socket 需要新的 listener）                        
                                                                                                    
  ## 影响                                                                                           
  - 消除每 30 秒的幽灵重连，减少消息丢失窗口                                                        
  - 减少不必要的 TLS 握手和钉钉 Stream 协议握手开销 