### PR TITLE
feat: 兼容钉钉 AI Card 消息换行渲染

### DIFF
--- a/src/services/messaging/card.ts
+++ b/src/services/messaging/card.ts
@@ -168,10 +168,17 @@ export type AICardTarget =
 // ============ Markdown 格式修正 ============
 
 /**
+ * 统一换行符为 \n，避免 CRLF 干扰 Markdown 解析
+ */
+function normalizeLineEndings(text: string): string {
+  return text.replace(/\r\n?/g, "\n");
+}
+
+/**
  * 确保 Markdown 表格前有空行，否则钉钉无法正确渲染表格
  */
 function ensureTableBlankLines(text: string): string {
-  const lines = text.split("\n");
+  const lines = normalizeLineEndings(text).split("\n");
   const result: string[] = [];
 
   const tableDividerRegex = /^\s*\|?\s*:?-+:?\s*(\|?\s*:?-+:?\s*)+\|?\s*$/;
@@ -204,10 +211,105 @@ function ensureTableBlankLines(text: string): string {
 
 /**
  * 将单个 \n 转换为 <br>，保留 \n\n 段落分隔。
- * 钉钉 AI Card 渲染引擎不将单 \n 视为换行，需要显式使用 <br>。
+ *
+ * 钉钉 AI Card 渲染器的换行约定：
+ * - 普通文本：用 `<br>` 做换行，`\n` 不创建视觉换行
+ * - 代码块（```）：用 `\n` 做换行，`<br>` 会原样显示为文本
+ * - 列表（- / 1.）、表格（|）、标题（#）：用 `\n` 做语法行分隔
+ * - 引用块（>）：用 `<br>` + lazy continuation，续行不需要 `>`
+ * - 段落间距：`\n\n`
+ *
+ * 本函数按上述约定转换：
+ * - 代码块内：完全保留原始 `\n`
+ * - 连续引用行：合并为一行，`<br>` 连接，去掉续行 `>` 前缀
+ * - 其余：Markdown 块语法行前保留 `\n`，单 `\n` → `<br>`
  */
-function fixNewlines(text: string): string {
-  return text.replace(/(?<!\n)\n(?!\n)/g, '<br>');
+export function fixNewlines(text: string): string {
+  const normalized = normalizeLineEndings(text);
+  const markdownBlockStartPattern =
+    /^(\s{0,3}(?:[-*+]|\d+[.)])[ ])|(\s{0,3}\|)|(\s{0,3}#{1,6}\s)|(\s{0,3}(?:[-*_])\s*(?:[-*_])\s*(?:[-*_]))/;
+  const fencePattern = /^\s{0,3}```/;
+  const quotePattern = /^\s{0,3}>\s?/;
+
+  // 1. 合并连续引用行：仅在代码块外生效；去掉续行的 > 前缀，用 <br> 连接
+  const mergedLines: string[] = [];
+  let pendingQuoteLines: string[] = [];
+  let inCodeBlock = false;
+  const flushPendingQuoteLines = () => {
+    if (pendingQuoteLines.length > 0) {
+      mergedLines.push(pendingQuoteLines.join("<br>"));
+      pendingQuoteLines = [];
+    }
+  };
+
+  for (const line of normalized.split("\n")) {
+    const isFence = fencePattern.test(line);
+
+    if (inCodeBlock) {
+      flushPendingQuoteLines();
+      mergedLines.push(line);
+      if (isFence) {
+        inCodeBlock = false;
+      }
+      continue;
+    }
+
+    if (isFence) {
+      flushPendingQuoteLines();
+      mergedLines.push(line);
+      inCodeBlock = true;
+      continue;
+    }
+
+    if (quotePattern.test(line)) {
+      if (pendingQuoteLines.length === 0) {
+        pendingQuoteLines.push(line);
+      } else {
+        pendingQuoteLines.push(line.replace(quotePattern, ""));
+      }
+    } else {
+      flushPendingQuoteLines();
+      mergedLines.push(line);
+    }
+  }
+  flushPendingQuoteLines();
+
+  // 2. 逐行处理：代码块保留 \n，Markdown 块语法行前保留 \n，其余转 <br>
+  const lines = mergedLines;
+  inCodeBlock = false;
+  const parts: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const currentLine = lines[i];
+    const nextInCodeBlock = fencePattern.test(currentLine)
+      ? !inCodeBlock
+      : inCodeBlock;
+
+    if (i < lines.length - 1) {
+      const nextLine = lines[i + 1];
+      const keepNewline =
+        nextInCodeBlock ||
+        currentLine === "" ||
+        nextLine === "" ||
+        fencePattern.test(nextLine) ||
+        markdownBlockStartPattern.test(nextLine);
+      parts.push(currentLine + (keepNewline ? "\n" : "<br>"));
+    } else {
+      parts.push(currentLine);
+    }
+
+    inCodeBlock = nextInCodeBlock;
+  }
+
+  return parts.join("");
+}
+
+/**
+ * 标准化 AI Card 消息内容：先修复表格空行，再处理换行符。
+ * 用于 streamAICard 和 finishAICard 的所有路径，确保行为一致。
+ */
+export function normalizeForCard(content: string): string {
+  return fixNewlines(ensureTableBlankLines(content));
 }
 
 // ============ AI Card 相关 ============
@@ -376,7 +478,7 @@ export async function streamAICard(
       cardData: {
         cardParamMap: {
           flowStatus: AICardStatus.INPUTING,
-          msgContent: fixNewlines(content),
+          msgContent: normalizeForCard(content),
           staticMsgContent: "",
           sys_full_json_obj: JSON.stringify({
             order: ["msgContent"],
@@ -425,12 +527,14 @@ export async function streamAICard(
     card.inputingStarted = true;
   }
 
-  const fixedContent = fixNewlines(ensureTableBlankLines(content));
+  const fixedContent = normalizeForCard(content);
+  // 未结束的帧去掉末尾 \n，避免先渲染为 <br> 再被下一帧修正的闪烁
+  const streamContent = finished ? fixedContent : fixedContent.replace(/\n+$/, '');
   const body = {
     outTrackId: card.cardInstanceId,
     guid: `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
     key: "msgContent",
-    content: fixedContent,
+    content: streamContent,
     isFull: true,
     isFinalize: finished,
     isError: false,
@@ -502,7 +606,7 @@ export async function finishAICard(
   if (config) {
     await ensureValidToken(card, config);
   }
-  const fixedContent = fixNewlines(ensureTableBlankLines(content));
+  const fixedContent = normalizeForCard(content);
   log?.info?.(
     `[DingTalk][AICard] 开始 finish，最终内容长度=${fixedContent.length}`,
   );

--- a/src/services/messaging/card.ts
+++ b/src/services/messaging/card.ts
@@ -202,6 +202,14 @@ function ensureTableBlankLines(text: string): string {
   return result.join("\n");
 }
 
+/**
+ * 将单个 \n 转换为 <br>，保留 \n\n 段落分隔。
+ * 钉钉 AI Card 渲染引擎不将单 \n 视为换行，需要显式使用 <br>。
+ */
+function fixNewlines(text: string): string {
+  return text.replace(/(?<!\n)\n(?!\n)/g, '<br>');
+}
+
 // ============ AI Card 相关 ============
 
 /**
@@ -368,7 +376,7 @@ export async function streamAICard(
       cardData: {
         cardParamMap: {
           flowStatus: AICardStatus.INPUTING,
-          msgContent: content,
+          msgContent: fixNewlines(content),
           staticMsgContent: "",
           sys_full_json_obj: JSON.stringify({
             order: ["msgContent"],
@@ -417,7 +425,7 @@ export async function streamAICard(
     card.inputingStarted = true;
   }
 
-  const fixedContent = ensureTableBlankLines(content);
+  const fixedContent = fixNewlines(ensureTableBlankLines(content));
   const body = {
     outTrackId: card.cardInstanceId,
     guid: `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
@@ -494,7 +502,7 @@ export async function finishAICard(
   if (config) {
     await ensureValidToken(card, config);
   }
-  const fixedContent = ensureTableBlankLines(content);
+  const fixedContent = fixNewlines(ensureTableBlankLines(content));
   log?.info?.(
     `[DingTalk][AICard] 开始 finish，最终内容长度=${fixedContent.length}`,
   );

--- a/tests/ai-card/ai-card.test.ts
+++ b/tests/ai-card/ai-card.test.ts
@@ -315,6 +315,98 @@ describe('AI Card helpers', () => {
     }, 10_000);
   });
 
+  describe('fixNewlines', () => {
+    it('should convert single \\n to <br>', async () => {
+      const { __testables } = await import('../test');
+      const { fixNewlines } = __testables as any;
+      expect(fixNewlines('第一行\n第二行')).toBe('第一行<br>第二行');
+    });
+
+    it('should preserve \\n\\n paragraph breaks', async () => {
+      const { __testables } = await import('../test');
+      const { fixNewlines } = __testables as any;
+      expect(fixNewlines('第一段\n\n第二段')).toBe('第一段\n\n第二段');
+    });
+
+    it('should preserve \\n inside fenced code blocks', async () => {
+      const { __testables } = await import('../test');
+      const { fixNewlines } = __testables as any;
+      const input = '```python\ndef hello():\n    print("hi")\n```';
+      expect(fixNewlines(input)).toBe(input);
+    });
+
+    it('should not merge quote-like lines inside fenced code blocks', async () => {
+      const { __testables } = await import('../test');
+      const { fixNewlines } = __testables as any;
+      const input = '```\n> line1\n> line2\n```';
+      expect(fixNewlines(input)).toBe(input);
+    });
+
+    it('should preserve \\n before list items', async () => {
+      const { __testables } = await import('../test');
+      const { fixNewlines } = __testables as any;
+      expect(fixNewlines('- a\n- b')).toBe('- a\n- b');
+      expect(fixNewlines('1. a\n2. b')).toBe('1. a\n2. b');
+    });
+
+    it('should preserve \\n before table rows', async () => {
+      const { __testables } = await import('../test');
+      const { fixNewlines } = __testables as any;
+      expect(fixNewlines('| a |\n| b |')).toBe('| a |\n| b |');
+    });
+
+    it('should merge consecutive quote lines with <br>', async () => {
+      const { __testables } = await import('../test');
+      const { fixNewlines } = __testables as any;
+      expect(fixNewlines('> line1\n> line2')).toBe('> line1<br>line2');
+    });
+
+    it('should handle code block mixed with plain text', async () => {
+      const { __testables } = await import('../test');
+      const { fixNewlines } = __testables as any;
+      const input = '前文\n\n```\ncode\n```\n\n后文';
+      expect(fixNewlines(input)).toBe('前文\n\n```\ncode\n```\n\n后文');
+    });
+
+    it('should handle empty string', async () => {
+      const { __testables } = await import('../test');
+      const { fixNewlines } = __testables as any;
+      expect(fixNewlines('')).toBe('');
+    });
+
+    it('should normalize CRLF line endings', async () => {
+      const { __testables } = await import('../test');
+      const { fixNewlines } = __testables as any;
+      expect(fixNewlines('第一行\r\n第二行')).toBe('第一行<br>第二行');
+    });
+  });
+
+  describe('normalizeForCard', () => {
+    it('should apply both ensureTableBlankLines and fixNewlines', async () => {
+      const { __testables } = await import('../test');
+      const { normalizeForCard } = __testables as any;
+      // Plain text: single \n → <br>
+      expect(normalizeForCard('a\nb')).toBe('a<br>b');
+    });
+
+    it('should handle table content', async () => {
+      const { __testables } = await import('../test');
+      const { normalizeForCard } = __testables as any;
+      const input = 'text\n| a |\n| --- |\n| b |';
+      const result = normalizeForCard(input);
+      // Table rows should have \n preserved
+      expect(result).toContain('| a |');
+      expect(result).toContain('| b |');
+    });
+
+    it('should normalize CRLF before applying table rules', async () => {
+      const { __testables } = await import('../test');
+      const { normalizeForCard } = __testables as any;
+      const input = 'text\r\n| a |\r\n| --- |\r\n| b |';
+      expect(normalizeForCard(input)).toBe('text\n\n| a |\n| --- |\n| b |');
+    });
+  });
+
   describe('isQpsLimitError', () => {
     it('should identify 403 QpsLimit errors', async () => {
       const { __testables } = await import('../test');

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -52,6 +52,8 @@ import {
   streamAICard,
   finishAICard,
   isQpsLimitError,
+  fixNewlines,
+  normalizeForCard,
 } from "../src/services/messaging/card.ts";
 
 // Lazy import to avoid "env + network" pattern detection by security scanners.
@@ -343,6 +345,8 @@ export const __testables = {
   streamAICard,
   finishAICard,
   isQpsLimitError,
+  fixNewlines,
+  normalizeForCard,
   sendAICardToUser,
   sendAICardToGroup,
 


### PR DESCRIPTION
## 摘要

- 为钉钉 AI Card 增加 Markdown-aware 的换行兼容处理，而不是全局替换所有单个 `\n`
- 保留代码块、Markdown 表格、列表、标题、分割线和段落分隔所需的原始 `\n`
- 将连续引用行转换为钉钉 AI Card 可正确渲染的 `<br>` + lazy continuation 格式
- 统一 INPUTING、streaming 和 finish 三条路径的内容归一化逻辑
- 补充普通文本、段落、代码块、表格、列表、引用、CRLF 和混合内容的回归测试

## 背景

钉钉 AI Card 的内容渲染行为和 webhook markdown 不完全一致：普通文本中的单个 `\n` 不会产生可见换行，需要使用 `<br>` 才能得到正常的单行换行效果。

之前的实现直接全局替换单个 `\n`，可以解决普通文本换行问题，但会破坏 Markdown 语法。例如代码块、表格、列表和引用块都依赖特定的换行语义，不能简单统一替换。

## 实现

- 新增 `normalizeForCard()` 作为 AI Card 内容归一化的统一入口
- 在 Markdown 处理前统一归一化 CRLF 换行
- 代码块内部完全保留原始 `\n`
- Markdown 块语法行前保留 `\n`，避免破坏表格、列表、标题和分割线
- 普通文本中的单行换行转换为 `<br>`
- 连续引用行用 `<br>` 合并，并去掉续行重复的 `>` 前缀，以匹配钉钉 AI Card 的引用渲染行为
- 未完成的 streaming 帧去掉末尾换行，避免流式过程中出现短暂 `<br>` 闪烁

Fixes #580

## 验证

```bash
npm exec vitest -- run tests/ai-card/ai-card.test.ts
```

结果：36 个测试全部通过。
