### PR TITLE
fix(connection): silence upstream dingtalk-stream 30s rebalance log noise (#571, #536, #573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.21-beta.0] - 2026-05-14
+
+### 修复 / Fixes
+- 🐛 **抑制上游 SDK 30s 负载均衡日志刷屏 (#571 / #536 / #573)** — 钉钉 Stream 服务端会周期性下发 `disconnect` topic（约 30s/次）做负载均衡，上游 `dingtalk-stream@2.1.4` SDK 在 `client.cjs:138 / :185` 直接 `console.info("Disconnecting.")` / `connect success`，导致单 bot 也会刷屏，看起来像故障。本次在 `src/core/connection.ts` 加 `silenceDingtalkStreamConsoleNoise()`：模块级一次性 patch `console.info`，**只过滤这两条精确字符串**，其他 `console.info` 不受影响。同时在首个账号连上时打印一次「30s 周期断连属正常机制」提示，消除误导。  
+  **Silence upstream SDK 30s rebalance log noise (#571 / #536 / #573)** — DingTalk Stream server periodically pushes `disconnect` topic (~30s) for load balancing; upstream `dingtalk-stream@2.1.4` SDK directly calls `console.info("Disconnecting.")` / `connect success` (`client.cjs:138 / :185`), spamming logs and looking like a failure even on a single bot. This release adds `silenceDingtalkStreamConsoleNoise()` in `src/core/connection.ts`: a module-level one-time patch that filters **only these two exact strings**, leaving other `console.info` untouched. Also prints a one-time "periodic rebalance is normal" notice on first connect to avoid user confusion.
+
+### 说明 / Notes
+- 不改动 `startKeepAlive` / `setupPongListener` / `lastSocketAvailableTime` 写入时机，不影响 #437 的心跳超时检测修复。  
+  No changes to `startKeepAlive` / `setupPongListener` / `lastSocketAvailableTime` write semantics — does not affect the #437 heartbeat-timeout fix.
+
 ## [0.8.20] - 2026-04-28
 
 ### 修复 / Fixes

--- a/docs/RELEASE_NOTES_V0.8.21-beta.0.md
+++ b/docs/RELEASE_NOTES_V0.8.21-beta.0.md
@@ -1,0 +1,63 @@
+# Release Notes - v0.8.21-beta.0
+
+## 🎉 本次重点 / Highlights
+
+抑制上游 `dingtalk-stream@2.1.4` SDK 在 30 秒负载均衡断连周期里的日志刷屏问题（#571 / #536 / #573），并在启动时给出一次性协议机制说明，消除"看起来在故障"的误导。
+
+Silence the log-spamming behavior of upstream `dingtalk-stream@2.1.4` SDK during the 30s load-balance reconnect cycle (#571 / #536 / #573), and print a one-time protocol-mechanism notice at startup to remove the "looks-like-failure" misperception.
+
+## 🐛 修复 / Fixes
+
+### 上游 SDK 30s 负载均衡日志刷屏 (#571 / #536 / #573)
+
+**现象**：日志反复出现
+```
+[2026-05-09T07:04:42.420Z] connect success
+Disconnecting.
+[2026-05-09T07:05:12.483Z] connect success
+Disconnecting.
+...
+```
+每约 30 秒一次，看起来像连接频繁掉线。
+
+**根因**：
+1. 钉钉 Stream 服务端会周期性下发 `disconnect` topic（约 30s/次）做负载均衡，客户端必须立即断开重连 —— 这是钉钉协议设计
+2. 上游 `dingtalk-stream@2.1.4` SDK 在 `client.cjs:138 / :185` 直接 `console.info("Disconnecting.")` / `[time] connect success`，绕过 logger，单 bot 也会刷屏
+3. 我们的 connector 早就在 `src/core/connection.ts:setupMessageListener` / `setupCloseListener` 中正确处理了重连，消息收发实际无感
+
+**修复**：
+- 在 `src/core/connection.ts` 新增 `silenceDingtalkStreamConsoleNoise()`：模块级一次性 patch `console.info`，**只过滤 `Disconnecting.` 和 `[time] connect success` 两条精确字符串**，其他 `console.info` 不受影响
+- 在首个账号连上时通过 `printLoadBalanceNoticeOnce()` 打印一次「30s 周期断连属正常机制」说明，多 bot 启动时不会重复
+- `setupMessageListener` 收到 `disconnect` topic 时加一行 `logger.debug`，便于排查时查看完整生命周期
+
+## 🔒 兼容性 / Compatibility
+
+- **不改动** `startKeepAlive` / `setupPongListener` / `lastSocketAvailableTime` 写入时机
+- **不影响** #437 的心跳超时检测修复（dead connection 仍在 20~30s 内被检测并自动重连）
+- 配置 schema 无变化
+- API 无变化
+
+## ⏭ 下一步 / Next steps (under evaluation)
+
+- 多 bot 重连错峰（jitter），降低同 gateway 内集中重连压力
+- 重连窗口内消息缓存与重投递评估
+- 与钉钉 Stream 服务端对齐单实例驻留时间策略
+
+进展持续在 #506 同步。
+
+## 📥 安装升级 / Installation & Upgrade
+
+```bash
+npx openclaw@latest add @dingtalk-real-ai/dingtalk-connector@0.8.21-beta.0
+```
+
+## 🔗 相关链接 / Related Links
+
+- [完整变更日志](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/CHANGELOG.md)
+- 关联 issues: #571 / #536 / #573 / #545
+
+---
+
+**发布日期 / Release Date**：2026-05-14  
+**版本号 / Version**：v0.8.21-beta.0  
+**兼容性 / Compatibility**：OpenClaw Gateway 2026.4.9+

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.8.20",
+  "version": "0.8.21-beta.0",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "author": "DingTalk Real Team",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.8.20",
+  "version": "0.8.21-beta.0",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "type": "module",
   "exports": {

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -64,6 +64,47 @@ const BASE_BACKOFF_DELAY = 1000; // 1 秒
 /** 最大退避时间（毫秒） */
 const MAX_BACKOFF_DELAY = 30 * 1000; // 30 秒
 
+// ============ 上游 SDK 噪音抑制 ============
+//
+// 背景（#571 / #536 / #573）：
+// 钉钉 Stream 服务端会周期性下发 `disconnect` topic（约 30s 一次）用于负载均衡 /
+// 实例切换；客户端必须立即断开重连，这是钉钉协议设计。但上游 SDK
+// `dingtalk-stream@2.1.4`（client.cjs:138 / :185）在连接建立和断开时直接调用
+// `console.info(...)`，导致单 bot 也会刷出 `Disconnecting.` / `connect success`
+// 循环刷屏的日志，看起来像是故障。
+//
+// 这里在模块加载时一次性 patch `console.info`，**只过滤这两条精确字符串**，
+// 其他 console.info 不受影响。connector 自己在 `doReconnect` 流程中通过
+// `logger.info` 输出更友好的连接生命周期日志（受 debug 配置控制）。
+//
+// 注意：此函数不动 keepAlive 心跳逻辑、不动 lastSocketAvailableTime
+// 写入时机、不动 setupPongListener —— 不影响 #437 的心跳超时修复。
+let _streamNoiseSilenced = false;
+function silenceDingtalkStreamConsoleNoise(): void {
+  if (_streamNoiseSilenced) return;
+  _streamNoiseSilenced = true;
+  const origConsoleInfo = console.info.bind(console);
+  console.info = (...args: any[]) => {
+    const first = args[0];
+    if (typeof first === "string") {
+      if (first === "Disconnecting.") return;
+      if (/^\[[^\]]+\] connect success$/.test(first)) return;
+    }
+    return origConsoleInfo(...args);
+  };
+}
+
+// 一次性提示：避免多 bot 启动时每个账号都打一遍同样的协议说明
+let _lbProtocolNoticePrinted = false;
+function printLoadBalanceNoticeOnce(): void {
+  if (_lbProtocolNoticePrinted) return;
+  _lbProtocolNoticePrinted = true;
+  console.log(
+    "[dingtalk-connector] ℹ️  钉钉 Stream 服务端会周期性下发负载均衡断开（约 30s/次），" +
+      "connector 已自动重连，属正常机制，非故障。详见 #571 / #536 / #573。",
+  );
+}
+
 // ============ 监控账号 ============
 
 export async function monitorSingleAccount(
@@ -71,6 +112,10 @@ export async function monitorSingleAccount(
 ): Promise<void> {
   const { cfg, account, runtime, abortSignal, messageHandler, onStatusChange } = opts;
   const { accountId } = account;
+
+  // 在 dingtalk-stream SDK 被动态 import 之前抑制其 console.info 噪音
+  // （#571 / #536 / #573：30s 负载均衡断连导致 SDK 自带日志刷屏）
+  silenceDingtalkStreamConsoleNoise();
 
   // 保存 cfg 以便传递给 messageHandler
   const clawdbotConfig = cfg;
@@ -313,6 +358,8 @@ export async function monitorSingleAccount(
       try {
         const msg = JSON.parse(data);
         if (msg.type === "SYSTEM" && msg.headers?.topic === "disconnect") {
+          // 钉钉服务端周期性下发的负载均衡断开，属协议机制，非故障
+          logger.debug(`收到服务端 disconnect topic（负载均衡），即将重连`);
           if (!isStopped && !isReconnecting) {
             // 立即重连，不退避
             doReconnect(true).catch((err) => {
@@ -643,6 +690,10 @@ export async function monitorSingleAccount(
       logger.info(
         `✅ 自定义 keepAlive: true (10 秒心跳，90 秒超时), 指数退避重连`,
       );
+
+      // 首个账号连上时，打印一次"30s 周期断连属正常"的协议说明，避免用户误以为故障
+      // （#571 / #536 / #573）
+      printLoadBalanceNoticeOnce();
 
       // 初次连接成功，向框架报告 connected: true
       onStatusChange?.({ connected: true, lastConnectedAt: Date.now() });


### PR DESCRIPTION
## Summary

修复 [#571](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/571) / [#536](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/536) / [#573](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/573) / #545：上游 `dingtalk-stream@2.1.4` SDK 在钉钉 Stream 服务端 30s 负载均衡断连周期里直接 `console.info("Disconnecting.")` / `connect success` 刷屏，看起来像故障。本仓 connector 早已通过 `doReconnect(true)` 正确处理重连，消息收发不受影响 —— 这是体验侧 bug。

## Changes

- `src/core/connection.ts`
  - 新增 `silenceDingtalkStreamConsoleNoise()`：模块级一次性 patch `console.info`，**只过滤 `Disconnecting.` 和 `[time] connect success` 两条精确字符串**，其他 `console.info` 完全不受影响
  - 新增 `printLoadBalanceNoticeOnce()`：首个账号连上时打印一次「30s 周期断连属正常」协议说明，多 bot 启动不重复
  - `setupMessageListener` 收到服务端 `disconnect` topic 时新增 `logger.debug` 一行，便于排查
- `package.json` / `openclaw.plugin.json`：版本 `0.8.20` → `0.8.21-beta.0`
- `CHANGELOG.md` / `docs/RELEASE_NOTES_V0.8.21-beta.0.md`：变更说明

## 与 #437 修复的兼容性

完全不重叠：

| 区域 | #437 修复 | 本 PR |
|------|----------|-------|
| `startKeepAlive` 函数体内 ping 后逻辑 | ✅ 删除 `lastSocketAvailableTime = Date.now()` | ❌ 不动 |
| `setupPongListener` 中 `lastSocketAvailableTime` 写入 | ✅ 唯一更新点 | ❌ 不动 |
| 心跳超时检测 20s 阈值语义 | ✅ 修复 | ❌ 不动 |
| `dingtalk-stream` SDK `console.info` 噪音 | 未涉及 | ✅ 本 PR 修复 |

**Dead connection 仍在 20-30s 内被检测并自动重连。**

## Verification

- `npm run type-check`：error 数 `35 → 35`（全部 pre-existing，无新增）
- `npm test`：`17 / 17` passed
- `npm run build`：成功，dist 产物正常

## What this PR does NOT promise

按 #571 / #536 / #573 评论中已对齐的 P1/P2 计划：
- **P1（评估中）**：多 bot 重连错峰（jitter）、重连窗口消息缓存与重投递 —— 不在本 PR 范围
- **P2（长期方向）**：与钉钉 Stream 服务端对齐单实例驻留时间策略 —— 跨团队

本 PR 只覆盖 P0：让用户停止误以为是故障。

## Test plan

- [x] CI 通过（type-check / test / build）
- [x] 本地用 0.8.21-beta.0 起一个 bot，观察 30s 周期不再有 `Disconnecting.` / `connect success` 刷屏，首次连上时看到 LB 协议说明
- [x] debug 模式下 `logger.debug` 能看到服务端 disconnect topic 的完整生命周期
- [ ] 多 bot 启动时，LB 说明仅打印一次

Refs: #571 #536 #573 #545 / 不影响 #437

Made with [Cursor](https://cursor.com)