### PR TITLE
chore(github): add bilingual issue templates and community routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "📩 钉钉其他业务能力 / Other DingTalk capabilities (please use ticket)"
+    url: https://applink.dingtalk.com/client/aiAgent?assistantId=381bb5860c264d33bc184c51db776fa7&from=development
+    about: 非本 connector 范畴的钉钉产品/开放能力问题请走工单。For DingTalk product/open-platform issues outside this connector, please use the DingTalk ticket center.
+  - name: "🔗 OpenClaw upstream issues"
+    url: https://github.com/openclaw/openclaw/issues
+    about: OpenClaw 本体（网关、模型、多通道等）请到上游仓库。Gateway / models / channels and core OpenClaw behavior — file in the upstream repo.
+  - name: "📌 提 Issue 前必看 / READ FIRST (CN)"
+    url: https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/584
+    about: 置顶说明：反馈分流、版本预期、需要带的信息（中文）。
+  - name: "📌 READ FIRST (EN)"
+    url: https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/585
+    about: Pinned notice — routing, version expectations, what to include (English).

--- a/.github/ISSUE_TEMPLATE/connector-issue-en.md
+++ b/.github/ISSUE_TEMPLATE/connector-issue-en.md
@@ -1,0 +1,45 @@
+---
+name: Connector issue / suggestion (English)
+about: For issues or suggestions about this connector's install, connection, or plugin behavior
+title: "[Connector] "
+---
+
+<!--
+Please skim the pinned notice #585 first: other DingTalk capabilities go to the ticket center; OpenClaw upstream goes to the openclaw repo.
+-->
+
+## Summary
+
+(One sentence describing the symptom or request)
+
+## Versions & environment (required)
+
+| Item | Value |
+|---|---|
+| `@dingtalk-real-ai/dingtalk-connector` version |  |
+| `openclaw` version (`openclaw -v`) |  |
+| OS / deployment | e.g. Windows / macOS / VPS / Docker |
+
+## Upgrade & symptom
+
+1. Did you upgrade connector / openclaw right before the issue appeared? (from → to)
+
+2. Is the symptom **noisy logs only**, or **real functional breakage**?
+
+## Logs & repro steps
+
+1. **Paste logs as text** (redact secrets), not screenshots only:
+
+```text
+
+```
+
+2. Repro steps (the more specific, the better):
+
+## Other notes
+
+(Optional: config highlights, minimal repro, production env, etc.)
+
+---
+
+Background & community guide: pinned [#585](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/585) · 中文: [#584](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/584)

--- a/.github/ISSUE_TEMPLATE/connector-issue-zh.md
+++ b/.github/ISSUE_TEMPLATE/connector-issue-zh.md
@@ -1,0 +1,45 @@
+---
+name: Connector 问题 / 建议（中文）
+about: 与本仓库 connector 接入、连接、插件行为相关的问题或建议
+title: "[Connector] "
+---
+
+<!--
+请先看置顶说明 #584：钉钉其他业务能力请走工单；OpenClaw 本体请到上游仓库。
+-->
+
+## 问题简述
+
+（一句话说明现象或需求）
+
+## 版本与环境（必填）
+
+| 项 | 填写 |
+|---|---|
+| `@dingtalk-real-ai/dingtalk-connector` 版本 |  |
+| `openclaw` 版本（`openclaw -v`） |  |
+| 操作系统 / 部署方式 | 例：Windows / macOS / 云服务器 / Docker |
+
+## 升级与现象
+
+1. 问题出现前是否升级过 connector / openclaw？（从哪版 → 哪版）
+
+2. 现象是 **日志过多**，还是 **功能实际不可用**？
+
+## 日志与复现步骤
+
+1. **运行日志请贴纯文本**（可脱敏），勿仅发截图：
+
+```text
+
+```
+
+2. 复现步骤（越具体越好）：
+
+## 其他说明
+
+（可选：配置要点、最小复现、是否生产环境等）
+
+---
+
+详细背景与社区共建说明见置顶 [#584](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/584) · English: [#585](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/585)

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ AGENTS.md
 .DS_Store
 plans/
 scripts/
+.issue-replies/

--- a/README.en.md
+++ b/README.en.md
@@ -104,11 +104,26 @@ openclaw gateway restart
 
 ---
 
+## Feedback & Community
+
+Before filing an Issue / PR, please skim the pinned notice — clear context helps us debug faster:
+
+- English: [[READ FIRST] #585](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/585)
+- 中文：[【提 Issue 前必看】#584](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/584)
+
+Quick routing:
+
+- **Other DingTalk product / open-platform capabilities** (outside this connector) → [DingTalk developer ticket center](https://applink.dingtalk.com/client/aiAgent?assistantId=381bb5860c264d33bc184c51db776fa7&from=development)
+- **OpenClaw upstream** (gateway, models, channels, etc.) → [openclaw/openclaw Issues](https://github.com/openclaw/openclaw/issues)
+- **This connector** → [GitHub Issues](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues)
+
+---
+
 ## Contributing
 
-Community contributions are welcome! If you find a bug or have feature suggestions, please submit an [Issue](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues) or Pull Request.
+PRs are welcome — small, well-described changes with clear verification land fastest; for larger changes, please open an Issue first. Doc-style reference: [#514](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/514/changes) · code-style reference: [#581](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/581).
 
-For major changes, we recommend discussing with us first via an Issue.
+> **Quarterly thanks**: each quarter, the top 3 PR contributors get a small gift or an invite to a DingTalk on-site visit (details per quarterly announcement). Thanks for co-building the community.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -104,11 +104,26 @@ openclaw gateway restart
 
 ---
 
+## 反馈与社区
+
+提 Issue / PR 前，建议先看一眼置顶说明（信息完整能帮我们更快定位问题）：
+
+- 中文：[【提 Issue 前必看】#584](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/584)
+- English: [[READ FIRST] #585](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/585)
+
+简要分流：
+
+- **钉钉其他业务能力**（非本 connector 范畴）→ [钉钉开发者侧工单入口](https://applink.dingtalk.com/client/aiAgent?assistantId=381bb5860c264d33bc184c51db776fa7&from=development)
+- **OpenClaw 本体**（网关、模型、多通道等）→ [openclaw/openclaw Issues](https://github.com/openclaw/openclaw/issues)
+- **本仓库 connector** → [GitHub Issues](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues)
+
+---
+
 ## 贡献
 
-欢迎社区贡献！如果你发现 Bug 或有功能建议，请提交 [Issue](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues) 或 Pull Request。
+欢迎提交 Pull Request：改动越小、描述与验证步骤越清晰，越容易合入；较大改动建议先开 Issue 同步。文档类参考 [#514](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/514/changes)，代码类参考 [#581](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/581)。
 
-对于较大的改动，建议先通过 Issue 与我们讨论。
+> **季度致谢**：每个季度对 PR 贡献量居前 3 位的伙伴提供小礼品或钉钉参观交流机会（细则以当季公告为准），感谢大家对社区共建的支持。
 
 ---
 


### PR DESCRIPTION
## Summary

让贡献者「走对门」、降低低信号 Issue，并把 README 的反馈段落精简成指路牌。

- **Issue 模板（双语）**：新增 `.github/ISSUE_TEMPLATE/connector-issue-zh.md` 与 `connector-issue-en.md`。模板用紧凑表格收集：connector / openclaw 精确版本、问题出现前的升级路径、现象（日志多 vs 功能不可用）、**纯文本日志**（不是截图）、运行环境（Win / macOS / VPS / Docker 等）。
- **Issue 路由配置**：新增 `.github/ISSUE_TEMPLATE/config.yml`，在 New Issue 页提供四条外链入口：
  - 钉钉其他业务能力 → DingTalk 工单中心
  - OpenClaw 本体 → upstream issues
  - 提 Issue 前必看（中文）→ #584
  - READ FIRST (English) → #585
- **README 精简**：`README.md` / `README.en.md` 把原来的「Contributing」长段替换为简短的「反馈与社区 / Feedback & Community」分流块，直接指向置顶说明与模板入口，不在 README 里重复维护版本预期、节奏、5 条信息清单等（这些在 #584/#585 维护一处即可）。
- **`.gitignore`**：新增 `.issue-replies/`，避免本地起草的 issue 回复草稿误提交。

注意：GitHub Issue 模板只在 **default 分支（main）** 上才会被「New Issue」页读取，因此合入 `main` 后才会在 https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/new/choose 看到效果。

## Verification

- 本地 `git diff origin/main` 确认仅包含 6 个文件改动，无意外混入。
- 模板文件遵循 GitHub Markdown Issue Template 规范（YAML frontmatter `name` / `about` / `title`，无非法字段）。
- `config.yml` 中 `contact_links.name` 用了 emoji + 中英混排，`about` 双语；`blank_issues_enabled: true` 保留空白入口。
- README 链接到 #584 / #585 已与置顶 Issue 内容一致。

## Out of scope

- 不包含任何代码行为变更（不动 `src/`、连接层、消息处理等）。
- 不更改 CI 与构建配置。

Made with Cursor

Made with [Cursor](https://cursor.com)