### PR TITLE
chore(github): route dws (dingtalk-workspace-cli) issues to upstream repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,9 @@ contact_links:
   - name: "🔗 OpenClaw upstream issues"
     url: https://github.com/openclaw/openclaw/issues
     about: OpenClaw 本体（网关、模型、多通道等）请到上游仓库。Gateway / models / channels and core OpenClaw behavior — file in the upstream repo.
+  - name: "🛠 dingtalk-workspace-cli (dws) issues"
+    url: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues
+    about: dws（钉钉工作空间 CLI）相关问题请到该仓库提交。dws CLI behavior / commands / docs — file in the dingtalk-workspace-cli repo.
   - name: "📌 提 Issue 前必看 / READ FIRST (CN)"
     url: https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/584
     about: 置顶说明：反馈分流、版本预期、需要带的信息（中文）。

--- a/.github/ISSUE_TEMPLATE/connector-issue-en.md
+++ b/.github/ISSUE_TEMPLATE/connector-issue-en.md
@@ -5,7 +5,7 @@ title: "[Connector] "
 ---
 
 <!--
-Please skim the pinned notice #585 first: other DingTalk capabilities go to the ticket center; OpenClaw upstream goes to the openclaw repo.
+Please skim the pinned notice #585 first: other DingTalk capabilities → ticket center; OpenClaw upstream → openclaw repo; dws (DingTalk workspace CLI) → dingtalk-workspace-cli repo.
 -->
 
 ## Summary

--- a/.github/ISSUE_TEMPLATE/connector-issue-zh.md
+++ b/.github/ISSUE_TEMPLATE/connector-issue-zh.md
@@ -5,7 +5,7 @@ title: "[Connector] "
 ---
 
 <!--
-请先看置顶说明 #584：钉钉其他业务能力请走工单；OpenClaw 本体请到上游仓库。
+请先看置顶说明 #584：钉钉其他业务能力请走工单；OpenClaw 本体请到上游仓库；dws（钉钉工作空间 CLI）请到 dingtalk-workspace-cli 仓库。
 -->
 
 ## 问题简述

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ AGENTS.md
 plans/
 scripts/
 .issue-replies/
+*.tgz

--- a/README.en.md
+++ b/README.en.md
@@ -115,6 +115,7 @@ Quick routing:
 
 - **Other DingTalk product / open-platform capabilities** (outside this connector) → [DingTalk developer ticket center](https://applink.dingtalk.com/client/aiAgent?assistantId=381bb5860c264d33bc184c51db776fa7&from=development)
 - **OpenClaw upstream** (gateway, models, channels, etc.) → [openclaw/openclaw Issues](https://github.com/openclaw/openclaw/issues)
+- **`dingtalk-workspace-cli` (dws)** (DingTalk workspace CLI behavior) → [dingtalk-workspace-cli Issues](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues)
 - **This connector** → [GitHub Issues](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues)
 
 ---

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ openclaw gateway restart
 
 - **钉钉其他业务能力**（非本 connector 范畴）→ [钉钉开发者侧工单入口](https://applink.dingtalk.com/client/aiAgent?assistantId=381bb5860c264d33bc184c51db776fa7&from=development)
 - **OpenClaw 本体**（网关、模型、多通道等）→ [openclaw/openclaw Issues](https://github.com/openclaw/openclaw/issues)
+- **dws（钉钉工作空间 CLI）** → [dingtalk-workspace-cli Issues](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues)
 - **本仓库 connector** → [GitHub Issues](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues)
 
 ---


### PR DESCRIPTION
## Summary

为 dws（`dingtalk-workspace-cli`，钉钉工作空间 CLI）补一条独立的反馈入口，避免相关问题误投递到本仓库。

- `README.md` / `README.en.md`：在「简要分流 / Quick routing」里加 dws 一行
- `.github/ISSUE_TEMPLATE/config.yml`：新增 dws contact_link，指向 `DingTalk-Real-AI/dingtalk-workspace-cli/issues`
- `.github/ISSUE_TEMPLATE/connector-issue-{zh,en}.md`：模板顶部注释提醒分流时再多看一眼 dws
- `.gitignore`：忽略本地 `*.tgz` 构建产物（验证打包时会产生）

置顶说明 #584 / #585 已同步在表格里新增对应条目（通过 `gh issue edit` 直接更新 issue body，不在本 PR 范围内）。

## Test plan

- [x] 本地查看 README 渲染（mdcat / 在 GitHub 预览）确认列表对齐
- [x] 打开 https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/new/choose 应看到新增的 dws 入口
- [x] 置顶 issue #584 / #585 路由表已新增 dws 行

Made with [Cursor](https://cursor.com)