### PR TITLE
chore(connection): clean up stale 90s timeout references + fix message-processing keepalive interval

### DIFF
--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -3,7 +3,7 @@
  *
  * 职责：
  * - 管理单个钉钉账号的 WebSocket 连接
- * - 实现应用层心跳检测（10 秒间隔，90 秒超时）
+ * - 实现应用层心跳检测（10 秒间隔，20 秒超时）
  * - 处理连接重连逻辑，带指数退避
  * - 消息去重（内置 Map，5 分钟 TTL）
  *
@@ -213,25 +213,26 @@ export async function monitorSingleAccount(
   
   /**
    * 标记消息处理开始，启动定期更新机制
-   * 在消息处理期间，每 30 秒更新一次 lastSocketAvailableTime
+   * 在消息处理期间，定时刷新 lastSocketAvailableTime
    * 防止长时间处理（如复杂的 AI 任务）触发心跳超时
    */
   function markMessageProcessingStart() {
     activeMessageProcessing = true;
     lastSocketAvailableTime = Date.now();
-    
+
     // 清理旧的定时器（如果存在）
     if (messageProcessingKeepAliveTimer) {
       clearInterval(messageProcessingKeepAliveTimer);
     }
-    
-    // 每 30 秒更新一次，确保不会触发 90 秒超时
+
+    // 每 15 秒更新一次（< TIMEOUT_THRESHOLD = 20s），保证 AI 长任务期间不会
+    // 因为 elapsed 超过 20 秒触发 keepAlive 兜底重连
     messageProcessingKeepAliveTimer = setInterval(() => {
       if (activeMessageProcessing) {
         lastSocketAvailableTime = Date.now();
         logger.debug(`📝 消息处理中，更新 socket 可用时间`);
       }
-    }, 30 * 1000); // 30 秒间隔
+    }, 15 * 1000); // 15 秒间隔
     
     logger.debug(`📝 消息处理开始，启动活跃标记定时器`);
   }


### PR DESCRIPTION
## Summary

`TIMEOUT_THRESHOLD` 在历史 refactor (`d90916b`) 中从 90s 调整到 20s 时漏改了两处文档与一个 setInterval 数值。本 PR 跟进清理（沿用 #566 review 里 P3 的建议），同时修掉一个 stale 注释暴露的真 bug。

## Changes

| 位置 | 旧值 | 新值 | 备注 |
|---|---|---|---|
| `src/core/connection.ts:6`（文件头 docstring） | `10 秒间隔，90 秒超时` | `10 秒间隔，20 秒超时` | 纯文档 |
| `src/core/connection.ts:228`（消息处理保活注释） | `每 30 秒更新一次，确保不会触发 90 秒超时` | `每 15 秒更新一次（< TIMEOUT_THRESHOLD = 20s）...` | 同步描述 |
| `src/core/connection.ts:234`（消息处理保活 setInterval） | `30 * 1000` | `15 * 1000` | **修真 bug** — 见下 |

## 为什么 setInterval 也要改

`markMessageProcessingStart` 是给 AI 长任务用的兜底保活，本意是「定期刷新 `lastSocketAvailableTime`，防止 AI 处理太久被 keepAlive 误判为连接死」。

历史上 `TIMEOUT_THRESHOLD = 90s`，所以 30s 间隔的刷新每 90s 内可以刷 3 次，安全。但 `d90916b` 把 `TIMEOUT_THRESHOLD` 降到 20s 后，30s 间隔已经**失效**——AI 任务跑到约 21s 时，距上次刷新（t=0）已经超过 20s，keepAlive 会触发兜底重连，而消息处理保活的下一次刷新还要等 9 秒才到。

把 interval 改成 15s（< 20s）让保活真正生效。

> 注：PR #566 修好后 pong listener 工作正常，正常情况下每 ~10s 就会从 pong 路径刷新 `lastSocketAvailableTime`，所以这条保活已经多半被 pong 路径兜住了。但事件循环被长 AI 任务阻塞时 pong 处理可能延迟，保留这条保活作为额外兜底依然有意义。

## What this does NOT change

- 不改 `TIMEOUT_THRESHOLD` 本身（仍 20s）
- 不改 `HEARTBEAT_INTERVAL`（仍 10s）
- 不改 keepAlive / pong listener / doReconnect 等核心逻辑
- 不改任何函数签名 / 导出符号 / 配置 schema

## Test plan

- [x] `npm run build` 通过
- [x] grep 确认 `src/core/connection.ts` 已无任何 stale `90 秒` / `90s` 引用
- [x] 文档（`docs/RELEASE_NOTES_V0.7.9.md` / `CHANGELOG.md` 历史条目）保留原始 `90s` 表述——那是当时的真实状态，属历史记录，不动

Refs: #566 review's P3 follow-up

Made with [Cursor](https://cursor.com)