### PR TITLE
release: v0.8.21-beta.0 (community validation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### 改进 / Improvements
-- 🩹 **群聊空回复兜底文案带修复指引** — 当 OpenClaw `messages.groupChat.visibleReplies` 未设为 `"automatic"` 时，群聊 @ 机器人会因上游 `source-reply-delivery-mode.ts` 走 `message_tool_only` 而拿不到流式 token，最终落到 connector 空回复兜底；以前固定文案「任务执行完成（无文本输出）」无信息量，现群聊场景改为带 `openclaw.json` 配置修复指引的提示，并在 warn 日志中打印完整片段。单聊文案保持不变。
-  **Group-chat empty-reply fallback now ships actionable hint** — When OpenClaw’s `messages.groupChat.visibleReplies` is not `"automatic"`, group `@` mentions hit `message_tool_only` upstream and the connector’s accumulated text stays empty, falling through to a cold fallback. The group-chat fallback message now embeds the exact `openclaw.json` fix snippet, and the warn-level log prints the full hint for operators. DM fallback text unchanged.
-
-### 文档 / Docs
-- 📚 **TROUBLESHOOTING** — 新增「群聊 @ 机器人只返回『任务执行完成（无文本输出）』」条目，给出 `messages.groupChat.visibleReplies = "automatic"` 修复步骤。
-  **TROUBLESHOOTING** — Added "Group `@` only returns 'Task done (no text output)'" entry with the `messages.groupChat.visibleReplies = "automatic"` fix.
-
-## [0.8.21-beta.0] - 2026-05-14
+## [0.8.21-beta.0] - 2026-05-17
 
 ### 修复 / Fixes
-- 🐛 **过滤上游 SDK `console.info` 噪音 (#571 / #536 / #573)** — 上游 `dingtalk-stream@2.1.4` SDK 在 `client.cjs:138 / :185` 每次 `disconnect()` / `connect()` 时直接 `console.info("Disconnecting.")` / `connect success`，绕过 logger，在频繁重连场景下会刷屏。本次在 `src/core/connection.ts` 加 `silenceDingtalkStreamConsoleNoise()`：模块级一次性 patch `console.info`，**只过滤这两条精确字符串**，其他 `console.info` 不受影响。同时在首个账号连上时打印一次连接生命周期说明，解释过滤动机以及"高频重连不正常"的预期。  
-  **Filter upstream SDK `console.info` noise (#571 / #536 / #573)** — Upstream `dingtalk-stream@2.1.4` SDK calls `console.info("Disconnecting.")` / `connect success` directly (`client.cjs:138 / :185`) on every `disconnect()` / `connect()`, bypassing the logger and spamming logs in frequent-reconnect scenarios. This release adds `silenceDingtalkStreamConsoleNoise()` in `src/core/connection.ts`: a module-level one-time `console.info` patch that filters **only these two exact strings**, leaving other `console.info` untouched. It also prints a one-time connection-lifecycle notice on first connect explaining the filter and setting the expectation that high-frequency reconnects are not normal.
+- 🐛 **WebSocket phantom reconnect 根因修复 (#566)** — `setupPongListener` / `setupMessageListener` / `setupCloseListener` 原本在 `client.connect()` 之前调用，此时 `client.socket === undefined`，可选链让三个 listener 静默 no-op，从未真正挂上。pong 没人接 → `lastSocketAvailableTime` 不更新 → 命中 `TIMEOUT_THRESHOLD = 20s` → 约 30 秒一次的幽灵重连。本次把 setup 移到 `client.connect()` 之后（初次连接 + `doReconnect` 两条路径都覆盖），并放在 `await for OPEN` 之前，消除 race window。感谢 @Majorshi 贡献。  
+  **Root-cause fix for WebSocket phantom reconnect (#566)** — `setupPongListener` / `setupMessageListener` / `setupCloseListener` were called before `client.connect()` when `client.socket === undefined`, so optional-chaining silently no-op'd and the three listeners were never attached. With no pong handler, `lastSocketAvailableTime` never refreshed, hit `TIMEOUT_THRESHOLD = 20s`, and triggered a phantom reconnect every ~30s. This release moves the setup calls to right after `client.connect()` (covering both initial connect and `doReconnect`), before the OPEN await, eliminating the race window. Credit: @Majorshi.
+
+- 🐛 **消息处理保活 interval 兜底 bug (#594)** — `markMessageProcessingStart` 启动的兜底定时器原本 30s 间隔，但 `TIMEOUT_THRESHOLD` 早已从 90s 降到 20s，30s 间隔无法在 AI 长任务期间防住超时（约 21s 就可能触发幽灵重连，下次刷新还要等 9 秒）。本次改为 15s 间隔（< TIMEOUT_THRESHOLD），让保活真正生效。  
+  **Fix message-processing keepalive interval (#594)** — The fallback `setInterval` in `markMessageProcessingStart` was 30s, but `TIMEOUT_THRESHOLD` had since dropped from 90s to 20s — the 30s interval couldn't prevent the timeout during long AI tasks (could trigger phantom reconnect around the 21s mark, with the next refresh 9s away). This release changes the interval to 15s (< TIMEOUT_THRESHOLD) so the safety net actually works.
+
+- 🐛 **过滤上游 SDK `console.info` 噪音 (#571 / #536 / #573)** — 上游 `dingtalk-stream@2.1.4` SDK 在 `client.cjs:138 / :185` 每次 `disconnect()` / `connect()` 时直接 `console.info("Disconnecting.")` / `connect success`，绕过 logger，在频繁重连场景下会刷屏。本次在 `src/core/connection.ts` 加 `silenceDingtalkStreamConsoleNoise()`：模块级一次性 patch `console.info`，**只过滤这两条精确字符串**，其他 `console.info` 不受影响。同时在首个账号连上时通过 `printConnectionNoticeOnce()` 打印一次连接生命周期说明，解释过滤动机以及"高频重连不正常"的预期。  
+  **Filter upstream SDK `console.info` noise (#571 / #536 / #573)** — Upstream `dingtalk-stream@2.1.4` SDK calls `console.info("Disconnecting.")` / `connect success` directly (`client.cjs:138 / :185`) on every `disconnect()` / `connect()`, bypassing the logger and spamming logs in frequent-reconnect scenarios. This release adds `silenceDingtalkStreamConsoleNoise()` in `src/core/connection.ts`: a module-level one-time `console.info` patch that filters **only these two exact strings**, leaving other `console.info` untouched. It also prints a one-time connection-lifecycle notice via `printConnectionNoticeOnce()` on first connect explaining the filter and setting the expectation that high-frequency reconnects are not normal.
+
+### 改进 / Improvements
+- 🩹 **群聊空回复兜底文案带修复指引 (#589)** — 当 OpenClaw `messages.groupChat.visibleReplies` 未设为 `"automatic"` 时，群聊 @ 机器人会因上游 `source-reply-delivery-mode.ts` 走 `message_tool_only` 而拿不到流式 token，最终落到 connector 空回复兜底；以前固定文案「任务执行完成（无文本输出）」无信息量，现群聊场景改为带 `openclaw.json` 配置修复指引的提示，并在 warn 日志中打印完整片段；同时在 `onIdle` / `onError` 时若本轮无任何用户可见输出，主动 nudge 一条配置指引，覆盖上游根本不调 `deliver()` 的盲区。单聊文案保持不变。  
+  **Group-chat empty-reply fallback now ships actionable hint (#589)** — When OpenClaw’s `messages.groupChat.visibleReplies` is not `"automatic"`, group `@` mentions hit `message_tool_only` upstream and the connector’s accumulated text stays empty, falling through to a cold fallback. The group-chat fallback message now embeds the exact `openclaw.json` fix snippet, and the warn-level log prints the full hint for operators. A new idle nudge in `onIdle` / `onError` proactively sends the same hint when no user-visible output happens this turn — covering the case where upstream never calls `deliver()` at all. DM fallback text unchanged.
+
+### 文档 / Docs
+- 📚 **TROUBLESHOOTING (#589)** — 新增「群聊 @ 机器人只返回『任务执行完成（无文本输出）』」条目，给出 `messages.groupChat.visibleReplies = "automatic"` 修复步骤。  
+  **TROUBLESHOOTING (#589)** — Added "Group `@` only returns 'Task done (no text output)'" entry with the `messages.groupChat.visibleReplies = "automatic"` fix.
+
+- 📚 **`silenceDingtalkStreamConsoleNoise` 文案与函数命名收紧 (#592)** — `printLoadBalanceNoticeOnce` → `printConnectionNoticeOnce`，banner 文案改为「SDK noise 已过滤 + 真实重连 connector 自动处理 + 高频重连不正常」的预期；相关注释同步收紧，去掉对重连频率的强归因。  
+  **Tighten copy & rename for `silenceDingtalkStreamConsoleNoise` (#592)** — Renamed `printLoadBalanceNoticeOnce` to `printConnectionNoticeOnce`; banner copy now reads "SDK noise filtered + real reconnects handled by connector + high-frequency reconnects are not expected"; related comments tightened.
+
+- 📚 **清理 stale `90 秒` 文档残留 (#594)** — 文件头 docstring 与消息处理保活注释里的 `90 秒超时` → `20 秒超时`，与实际 `TIMEOUT_THRESHOLD` 保持一致。  
+  **Clean up stale `90s` doc references (#594)** — File-header docstring and message-processing keepalive comments updated from `90s timeout` to `20s timeout`, matching the actual `TIMEOUT_THRESHOLD`.
 
 ### 说明 / Notes
-- 不改动 `startKeepAlive` / `setupPongListener` / `lastSocketAvailableTime` 写入时机，不影响 #437 的心跳超时检测修复。  
+- 不改动 `startKeepAlive` / `setupPongListener` / `lastSocketAvailableTime` 写入时机的语义，不影响 #437 的心跳超时检测修复。  
   No changes to `startKeepAlive` / `setupPongListener` / `lastSocketAvailableTime` write semantics — does not affect the #437 heartbeat-timeout fix.
 
 ## [0.8.20] - 2026-04-28

--- a/docs/RELEASE_NOTES_V0.8.21-beta.0.md
+++ b/docs/RELEASE_NOTES_V0.8.21-beta.0.md
@@ -1,12 +1,49 @@
 # Release Notes - v0.8.21-beta.0
 
+> **社区验证版本** — 计划经过 ~3 天社区验证后晋升为正式版 `v0.8.21`。  
+> **Community validation release** — planned to promote to GA `v0.8.21` after ~3 days of community validation.
+
 ## 🎉 本次重点 / Highlights
 
-过滤上游 `dingtalk-stream@2.1.4` SDK 直接走 `console.info` 输出的 `Disconnecting.` / `connect success` 噪音日志（#571 / #536 / #573），并在启动时打印一次连接生命周期说明。
+本版本聚焦 WebSocket 连接稳定性 + 群聊体验：
 
-Filter the noisy `Disconnecting.` / `connect success` lines emitted via `console.info` by upstream `dingtalk-stream@2.1.4` SDK (#571 / #536 / #573), and print a one-time connection-lifecycle notice at startup.
+1. 修掉本仓 listener 注册时机错乱导致的 ~30s 一次幽灵重连（社区贡献 #566）
+2. 修掉消息处理保活 interval 与 `TIMEOUT_THRESHOLD` 不匹配的兜底失效（#594）
+3. 过滤上游 `dingtalk-stream@2.1.4` SDK 直接走 `console.info` 的噪音（#571 / #536 / #573）
+4. 群聊 @ 机器人空回复时，把无信息的「任务执行完成」改为带 `openclaw.json` 修复指引的可操作文案（#589）
+
+This release focuses on WebSocket stability + group-chat UX:
+
+1. Fix root cause of ~30s phantom reconnect cycle caused by listener-registration timing (community contribution, #566)
+2. Fix message-processing keepalive interval mismatch with `TIMEOUT_THRESHOLD` (#594)
+3. Filter noisy `console.info` calls from upstream `dingtalk-stream@2.1.4` (#571 / #536 / #573)
+4. Group `@` mention's empty-reply fallback now embeds an actionable `openclaw.json` fix hint (#589)
 
 ## 🐛 修复 / Fixes
+
+### WebSocket phantom reconnect 根因修复 (#566)
+
+**现象**：约每 30 秒一次的 WebSocket 重连，`Disconnecting.` / `connect success` 成对出现，看起来像连接频繁掉线。
+
+**根因**：`setupPongListener` / `setupMessageListener` / `setupCloseListener` 在 `client.connect()` 之前被调用，此时 `client.socket === undefined`，函数体里 `client.socket?.on(...)` 的可选链让调用静默成 no-op——三个 listener 实际从未挂上。
+
+- pong listener 缺失 → `lastSocketAvailableTime` 不刷新 → 命中 `TIMEOUT_THRESHOLD = 20s` → `doReconnect()` 触发
+- message listener 缺失 → 服务端真实下发的 disconnect topic 也无法响应
+- close listener 缺失 → socket close 不能立即触发重连
+
+**修复**：
+
+- 删除模块初始化时的 no-op setup 调用
+- 初次 `client.connect()` 成功后立即注册三个 listener
+- `doReconnect()` 里把 setup 挪到 `client.connect()` 之后、`await for OPEN` 之前——避免 keepAlive 期间 ping 的 pong 回来时 listener 还没挂被丢的 race window
+
+**致谢**：感谢 [@Majorshi](https://github.com/Majorshi) 提交 [PR #566](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/566)，并感谢 [@lizhiyao](https://github.com/lizhiyao) / [@edokeh](https://github.com/edokeh) / [@jeikl](https://github.com/jeikl) 提前验证修复有效。
+
+### 消息处理保活 interval 兜底 bug (#594)
+
+**根因**：`markMessageProcessingStart` 启动的兜底定时器原本 30s 间隔，但 `TIMEOUT_THRESHOLD` 已在 `d90916b` 中从 90s 降到 20s——30s 间隔无法在 AI 长任务期间防住超时（AI 任务跑到约 21s 就可能触发 keepAlive 幽灵重连，下次刷新还要等 9 秒）。
+
+**修复**：interval 调整为 15s（< `TIMEOUT_THRESHOLD = 20s`），让保活真正生效。同时清理文件头 docstring 与相关注释里的 stale `90 秒超时` 文案。
 
 ### 上游 SDK `console.info` 噪音过滤 (#571 / #536 / #573)
 
@@ -30,20 +67,77 @@ Disconnecting.
 - 在首个账号连上时通过 `printConnectionNoticeOnce()` 打印一次连接生命周期说明，解释过滤动机以及「高频重连不正常」的预期，多 bot 启动时不重复
 - `setupMessageListener` 收到 `disconnect` topic 时加一行 `logger.debug`，便于排查时查看完整生命周期
 
+## 🩹 改进 / Improvements
+
+### 群聊空回复兜底文案带修复指引 (#589)
+
+**现象**：群聊 @ 机器人时只看到「✅ 任务执行完成（无文本输出）」，没有任何模型回复内容。
+
+**根因**：当 OpenClaw `messages.groupChat.visibleReplies` 未设为 `"automatic"` 时，上游 `source-reply-delivery-mode.ts` 对群聊默认走 `message_tool_only`：
+- 不调 `onPartialReply` → connector `accumulatedText` 始终为空
+- 大多数情况下也不调 `deliver(final)` → 三处空 final 兜底全部打到原文案
+
+用户看到的只是一句无信息的「任务执行完成」，完全没线索去查 `openclaw.json`。
+
+**修复**：
+- 新增 `src/utils/empty-reply.ts` 集中兜底文案
+- `reply-dispatcher.ts` 的 `closeStreaming` / `deliver` 空 final 分支：群聊改用带 `openclaw.json` 修复指引的可操作文案
+- 新增 `maybeSendGroupVisibleRepliesIdleNudge`：在 `onIdle` / `onError` 时若本轮无任何用户可见输出（覆盖上游 `message_tool_only` 根本不调 `deliver()` 的盲区），主动 nudge 一条配置指引
+- `core/message-handler.ts` 异步模式同点位分流
+- warn 日志同步打印完整 `openclaw.json` 修复片段，便于运维直接复制
+- **单聊文案保持不变**（`✅ 任务执行完成（无文本输出）`）：单聊空 final 通常是模型本身输出空，不需要指引噪音
+
+### 新群聊兜底文案
+
+```
+ℹ️ 暂未收到模型回复内容。
+若群聊频繁出现该提示，请联系机器人管理员检查 OpenClaw 配置：
+`messages.groupChat.visibleReplies` 需设为 `"automatic"`
+（详见 README / TROUBLESHOOTING.md）。
+```
+
+### 用户/运维侧修复
+
+`~/.openclaw/openclaw.json` 加上：
+
+```json
+{
+  "messages": {
+    "groupChat": { "visibleReplies": "automatic" }
+  }
+}
+```
+
+然后 `openclaw gateway restart`。
+
+> 跟进调研：插件侧直接覆盖 `sourceReplyDeliveryMode: "automatic"` 让用户不需要改 `openclaw.json` 的方案在 [Issue #591](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/591) 跟踪。
+
+## 📚 文档 / Docs
+
+- **TROUBLESHOOTING.md**：新增「群聊 @ 机器人只返回『任务执行完成（无文本输出）』」条目，给出修复步骤
+- `silenceDingtalkStreamConsoleNoise` 周边的注释 / 函数命名 / banner 文案统一收紧（#592）
+- 清理 `src/core/connection.ts` 中的 stale `90 秒超时` 文档残留（#594）
+
 ## 🔒 兼容性 / Compatibility
 
-- **不改动** `startKeepAlive` / `setupPongListener` / `lastSocketAvailableTime` 写入时机
-- **不影响** #437 的心跳超时检测修复（dead connection 仍在 20~30s 内被检测并自动重连）
-- 配置 schema 无变化
-- API 无变化
+- **API 无变化**、配置 schema 无变化、导出符号无变化
+- 不影响 #437 的心跳超时检测修复语义
+- 单聊行为完全不变（兜底文案、流式行为都保持原样）
+- 已配置 `messages.groupChat.visibleReplies = "automatic"` 的群聊行为完全不变
 
-## ⏭ 下一步 / Next steps (under evaluation)
+## 🧪 验证 / Verification
 
-- 多 bot 重连错峰（jitter），降低同 gateway 内集中重连压力
-- 重连窗口内消息缓存与重投递评估
-- 与钉钉 Stream 服务端对齐单实例驻留时间策略
+- 单测：`tests/empty-reply.unit.test.ts` 7/7 + `tests/reply-dispatcher` 7/7 通过
+- 多位社区用户已对 #566 修复 +1 验证有效（@lizhiyao / @edokeh / @jeikl）
+- 本机回归（macOS / OpenClaw 2026.5.7）：
+  - 群聊 @ + `messages: {}` → 看到新的可操作指引
+  - 群聊 @ + `visibleReplies = "automatic"` → 恢复正常流式
+  - 单聊空 final → 文案不变
 
-进展持续在 #506 同步。
+## ⏭ 下一步 / Next steps
+
+- 社区验证 ~3 天稳定后晋升 GA `v0.8.21`
+- [Issue #591](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/591)：插件侧 `sourceReplyDeliveryMode` 调研——下个迭代评估
 
 ## 📥 安装升级 / Installation & Upgrade
 
@@ -51,13 +145,19 @@ Disconnecting.
 npx openclaw@latest add @dingtalk-real-ai/dingtalk-connector@0.8.21-beta.0
 ```
 
+或：
+
+```bash
+npm install @dingtalk-real-ai/dingtalk-connector@beta
+```
+
 ## 🔗 相关链接 / Related Links
 
 - [完整变更日志](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/CHANGELOG.md)
-- 关联 issues: #571 / #536 / #573 / #545
+- 关联 PRs / issues：#566 / #589 / #592 / #594 / #571 / #536 / #573 / #545
 
 ---
 
-**发布日期 / Release Date**：2026-05-14  
+**发布日期 / Release Date**：2026-05-17  
 **版本号 / Version**：v0.8.21-beta.0  
 **兼容性 / Compatibility**：OpenClaw Gateway 2026.4.9+


### PR DESCRIPTION
## Summary

发布 `v0.8.21-beta.0` 给社区验证。版本号在 #583 合入时已经预占，但之后 main 上又积累了 4 个 PR，本次把这 4 个 PR 的内容统一并入 release notes，目标是社区验证 ~3 天稳定后晋升 GA `v0.8.21`。

## 本次 beta 包含的所有改动

| PR | 类型 | 主题 |
|---|---|---|
| #566 | 🐛 Fix | WebSocket phantom reconnect 根因修复（listener 注册时机错乱）@Majorshi 贡献 |
| #594 | 🐛 Fix | 消息处理保活 interval 兜底 bug（30s → 15s，匹配 TIMEOUT_THRESHOLD = 20s）+ stale 注释清理 |
| #583 | 🐛 Fix | 上游 SDK `console.info` 噪音过滤（#571 / #536 / #573） |
| #589 | 🩹 Improvement | 群聊空回复 actionable hint + onIdle / onError 主动 nudge |
| #592 | 📚 Docs | `silenceDingtalkStreamConsoleNoise` 文案与函数命名收紧 |

## 不在本次范围

- 版本号**不**做 bump（仍 `0.8.21-beta.0`，npm 上尚未发布过该版本）
- 不改任何源码或 dist——本 PR 纯文档整理
- [Issue #591](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/591)「插件侧 `sourceReplyDeliveryMode` 调研」推迟到下个迭代

## 发布产物

- `dingtalk-real-ai-dingtalk-connector-0.8.21-beta.0.tgz`
  - sha256: `b93fb4ecaef49c6bf3dcc0a77f01e3f7efa3f5d34995f9c585cf439ae992af31`
  - size: 397 KB
  - npm shasum: `fb87248b9cb72c0fa3a080482a57ebd9fdb4d78a`
  - npm integrity: `sha512-K+66Cop17uhi3...Mv/L9EBevo8OA==`

## 验证 / Verification

- [x] `npm run build` 通过（tsdown）
- [x] `npm pack` 通过（153 files / 405 kB total）
- [x] 单测：`tests/empty-reply.unit.test.ts` 7/7 + `tests/reply-dispatcher` 7/7
- [x] 多位社区用户已对 #566 修复 +1（@lizhiyao / @edokeh / @jeikl）
- [x] 本机回归（macOS / OpenClaw 2026.5.7）：群聊空 messages / 配置 automatic / 单聊空 final 三个场景全通过

## 发布步骤 / Release steps

合入本 PR 后：

```bash
git checkout main && git pull
npm run build
npm pack
npm publish dingtalk-real-ai-dingtalk-connector-0.8.21-beta.0.tgz --tag beta
```

社区验证 ~3 天后晋升 GA：

```bash
# 在新 PR 中把版本 bump 到 0.8.21 并打 tag v0.8.21
# npm publish 时使用 --tag latest
```

Made with [Cursor](https://cursor.com)