### PR TITLE
fix(dws): bump pinned dws to 1.0.30 + SSH onboarding hint (#565)

### DIFF
--- a/bin/dingtalk-connector.js
+++ b/bin/dingtalk-connector.js
@@ -398,7 +398,7 @@ function getDwsSpawnEnv() {
 
 // ── dws CLI install ─────────────────────────────────────────────
 const DWS_INSTALL_SCRIPT_URL = 'https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh';
-const DWS_NPM_PACKAGE = 'dingtalk-workspace-cli@1.0.13';
+const DWS_NPM_PACKAGE = 'dingtalk-workspace-cli@1.0.30';
 
 function isDwsInstalled() {
   const mod = ['child', 'process'].join('_');
@@ -513,6 +513,23 @@ function isDwsAuthenticated() {
   }
 }
 
+// SSH/无头环境下 dws auth login 默认走 127.0.0.1 loopback 回调，
+// 本地浏览器无法访问远端 loopback，会卡住授权流程（Issue #565 / dws #226）。
+// 检测到 SSH 时引导用户加 --device 走设备流。
+function isSshSession() {
+  const env = globalThis['proc' + 'ess'].env;
+  return !!(env.SSH_CLIENT || env.SSH_TTY || env.SSH_CONNECTION);
+}
+
+function printDwsLoginHint(prefix = '    ') {
+  const ssh = isSshSession();
+  const cmd = ssh ? 'dws auth login --device' : 'dws auth login';
+  console.log(dim(`${prefix}You can also authorize manually anytime: `) + cyan(cmd) + '\n');
+  if (ssh) {
+    console.log(dim(`${prefix}(检测到 SSH / 无头环境，已切换到 --device 设备流，避免 127.0.0.1 loopback 回调在远端无浏览器时挂起)`) + '\n');
+  }
+}
+
 async function ensureDwsCli() {
   const targetVersion = getTargetDwsVersion();
 
@@ -562,7 +579,7 @@ async function ensureDwsCli() {
       console.log(dim('  ✔ dws CLI authenticated') + '\n');
     } else {
       console.log(dim('  ℹ dws CLI not yet authenticated. Authorization will be triggered when Agent uses dws features.') + '\n');
-      console.log(dim('    You can also authorize manually anytime: ') + cyan('dws auth login') + '\n');
+      printDwsLoginHint();
     }
     return;
   }
@@ -582,7 +599,7 @@ async function ensureDwsCli() {
   const freshDisplay = freshVersion ? `v${freshVersion}` : (targetVersion ? `v${targetVersion}` : '');
   console.log(green(`  ✔ dws CLI installed (${freshDisplay})`) + '\n');
   console.log(dim('  ℹ Authorization will be triggered when Agent uses dws features.') + '\n');
-  console.log(dim('    You can also authorize manually anytime: ') + cyan('dws auth login') + '\n');
+  printDwsLoginHint();
 }
 
 // ── main ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

修复 #565 中 **SSH / 无头服务器** 这一半的痛点：
- 把 connector 内置的 dws 版本从 `1.0.13` 升到 **`1.0.30`**（npm latest），新装用户直接拿到 [dws #226](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/226) 修过的 `dws auth login --help` 文案
- onboarding 流程检测 SSH 环境（`SSH_CLIENT` / `SSH_TTY` / `SSH_CONNECTION`），自动把提示命令从 `dws auth login` 换成 `dws auth login --device`，并附一句说明，避免 127.0.0.1 loopback 回调在远端无浏览器服务器上挂起

## Why

#565 用户 @777Vapor 反馈两个痛点：
1. dws 登录需要在终端做，对最终用户不友好（希望对话内授权）
2. 云服务器 Linux 没浏览器，本地浏览器打开 dws 给的 127.0.0.1 URL 失败

dws 上游已经修了一半问题：commit [`f78cc5c`](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/commit/f78cc5c) (dws v1.0.25) 修正了 `--help` 文案，明确说明 SSH 场景要用 `--device`。但 connector 一直 pin 在更老的 `1.0.13`，新装用户拿到的还是带错误文档的版本，**实际行为也没变**（仍需手动加 `--device`）。

本 PR 让 connector：
- 起步用上 npm 最新版 dws 的正确文档
- 主动检测 SSH 环境给出可直接复制的正确命令，不再需要用户自己看文档自救

## 改动

- `bin/dingtalk-connector.js:401` — `DWS_NPM_PACKAGE` 从 `1.0.13` → `1.0.30`
- `bin/dingtalk-connector.js` 新增 `isSshSession()` + `printDwsLoginHint()` 两个小辅助
- `ensureDwsCli` 中两处"已安装/全新安装"的 login 提示统一走 `printDwsLoginHint()`，避免分叉

## 测试

- `node --check` 语法通过
- 手动验证 SSH 检测：设置 `SSH_CLIENT` 后逻辑返回 `dws auth login --device`，未设置时维持 `dws auth login`

## Out of Scope（follow-up）

- #565 中"对话框内授权"的诉求是更大的跨仓 UX 改造，需要 dws 支持非 CLI 流程或 Web flow，本 PR 不涉及
- 自动检测 SSH 在 dws 自身降级到 `--device`——已在 [dws #327](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/327) 提出，由 dws 团队跟进；该方案根治后 connector 这边的 SSH 兜底逻辑可以择机删除