### PR TITLE
fix(reply): soften direct-chat empty-reply fallback text (#599)

### DIFF
--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -1579,7 +1579,8 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
 
         // ✅ 异步模式下 final 文本为空时的兜底
         // 群聊场景下，常见根因是 OpenClaw `messages.groupChat.visibleReplies` 未设为 "automatic"
-        // （详见 src/utils/empty-reply.ts），给运维一份可操作的指引而不是无信息量的「任务执行完成」。
+        // （详见 src/utils/empty-reply.ts），给运维一份可操作的指引；
+        // 单聊则用口语化确认语兜底，避免被用户误判为报错。
         let textToSend = finalText.trim();
         if (!textToSend) {
           const isGroup = !isDirect;

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -308,8 +308,9 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       // ✅ 如果累积的文本为空，使用默认提示文案
       // 群聊场景下，常见根因是 OpenClaw `messages.groupChat.visibleReplies` 未设为
       // "automatic"（上游 source-reply-delivery-mode.ts 走 message_tool_only 时
-      // 会跳过 onPartialReply，accumulatedText 始终为空）。给运维一份可操作的指引，
-      // 而不是一句无信息量的「任务执行完成」。详见 src/utils/empty-reply.ts。
+      // 会跳过 onPartialReply，accumulatedText 始终为空）。给运维一份可操作的指引；
+      // 单聊则用口语化确认语兜底，避免「任务执行完成（无文本输出）」让用户误判为报错。
+      // 详见 src/utils/empty-reply.ts。
       if (!finalText.trim()) {
         const isGroup = !isDirect;
         finalText = pickEmptyReplyFallbackText(isGroup);

--- a/src/utils/empty-reply.ts
+++ b/src/utils/empty-reply.ts
@@ -3,7 +3,7 @@
  *
  * 背景
  * ----
- * 群聊场景下用户 @ 机器人后看到「任务执行完成（无文本输出）」，常见根因不是 connector，
+ * 群聊场景下用户 @ 机器人后看到空回复兜底文案，常见根因不是 connector，
  * 而是上游 OpenClaw 的 reply delivery mode（`source-reply-delivery-mode.ts`）：群聊
  * 默认走 `message_tool_only`，会跳过 `onPartialReply` 与 `accumulatedText`，
  * 导致本插件累积的文本始终为空，最后落到 connector 的空回复兜底。
@@ -15,12 +15,14 @@
  *     }
  *   }
  *
- * 本模块的优化目标：让群聊场景看到的兜底文案变成一句可操作的提示，
- * 并在日志里给运维一份完整指引，而不是一句无信息量的「任务执行完成」。
- * 单聊场景的兜底文案保持原样（单聊空 final 通常是模型自身输出空）。
+ * 本模块的优化目标：让兜底文案在两种场景下都自然不"像报错"——
+ *   - 群聊：返回一段可操作的运维指引（指向 `messages.groupChat.visibleReplies`）。
+ *   - 单聊：返回一段口语化的简短确认语（单聊空 final 通常是模型自身没产出文本，
+ *     如纯思考、只走 tool_call、对 ACK 类输入选择沉默等），并隐含邀请用户继续提问，
+ *     避免历史上的「✅ 任务执行完成（无文本输出）」让用户误以为是报错。
  */
 
-const DIRECT_FALLBACK_TEXT = '✅ 任务执行完成（无文本输出）';
+const DIRECT_FALLBACK_TEXT = '好的 👌 有其他问题随时找我';
 
 const GROUP_FALLBACK_TEXT = [
   'ℹ️ 暂未收到模型回复内容。',

--- a/tests/empty-reply.unit.test.ts
+++ b/tests/empty-reply.unit.test.ts
@@ -4,7 +4,8 @@
  * 群聊空 final 常由 OpenClaw `messages.groupChat.visibleReplies` 未设为 "automatic"
  * 触发；本测试锁定兜底文案的分流契约：
  *   - 群聊：必须给出可操作的修复指引，至少包含 visibleReplies / automatic 关键字
- *   - 单聊：保持原文案 "✅ 任务执行完成（无文本输出）"
+ *   - 单聊：用口语化确认语兜底，避免「任务执行完成（无文本输出）」让用户误判为报错；
+ *           不应再出现「任务执行完成」「无文本输出」「无输出」等带技术味的字样
  *   - 日志 hint：要包含 openclaw.json 片段和 messages.groupChat 关键字
  */
 import { describe, it, expect } from 'vitest';
@@ -15,16 +16,30 @@ import {
 } from '../src/utils/empty-reply.ts';
 
 describe('pickEmptyReplyFallbackText', () => {
-  it('单聊保持原"任务执行完成（无文本输出）"文案', () => {
+  it('单聊兜底文案不再出现「任务执行完成」/「无文本输出」等报错感字样', () => {
     const text = pickEmptyReplyFallbackText(false);
-    expect(text).toBe('✅ 任务执行完成（无文本输出）');
+    expect(text).not.toContain('任务执行完成');
+    expect(text).not.toContain('无文本输出');
+    expect(text).not.toContain('无输出');
+  });
+
+  it('单聊兜底文案是口语化确认语并邀请继续提问', () => {
+    const text = pickEmptyReplyFallbackText(false);
+    // 用「好」开头的口语化确认（"好的" / "好嘞" 等），并包含可继续追问的引导
+    expect(text).toMatch(/^好/);
+    expect(text).toMatch(/(找我|问我|继续|有.*问题)/);
   });
 
   it('群聊给出包含 visibleReplies / automatic 的修复指引', () => {
     const text = pickEmptyReplyFallbackText(true);
     expect(text).toContain('visibleReplies');
     expect(text).toContain('automatic');
-    expect(text).not.toBe('✅ 任务执行完成（无文本输出）');
+  });
+
+  it('群聊文案与单聊不同（确保分流生效）', () => {
+    const direct = pickEmptyReplyFallbackText(false);
+    const group = pickEmptyReplyFallbackText(true);
+    expect(group).not.toBe(direct);
   });
 
   it('群聊文案不抛配置细节给终端用户，要建议联系管理员', () => {


### PR DESCRIPTION
## Summary

私聊场景下，模型本轮没有产出文本时（如对「知道了」类 ACK 沉默、纯思考、只走 tool_call），connector 会落到一段兜底文案。原文案 `✅ 任务执行完成（无文本输出）` 系统/技术味偏重，[#599](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/599) 用户截图显示其会被误判为「机器人报错」。

本 PR 把单聊兜底文案换成口语化确认语：

> **好的 👌 有其他问题随时找我**

保留信号（让用户感知本轮结束），但去掉「任务执行完成」「无文本输出」等容易被当作错误的措辞。

群聊兜底文案与日志 hint 维持不变（仍是面向运维的可操作指引，指向 `messages.groupChat.visibleReplies`）。

## Why

#599 用户提供的截图：用户对一段说明回了「知道了」，模型本轮判定无需回复输出空 final，connector 因此落入兜底，用户看到 `✅ 任务执行完成（无文本输出）` 误以为是异常。这种 UX 在私聊里非常常见（小模型 / 短 ACK / 纯思考路径都会触发）。

修复路径在文案侧最低成本：让兜底看起来像一句正常的聊天回复而不是后端日志。

## 改动

- `src/utils/empty-reply.ts:23` — `DIRECT_FALLBACK_TEXT` 替换 + 模块注释更新
- `src/reply-dispatcher.ts` / `src/core/message-handler.ts` — inline 注释同步更新
- `tests/empty-reply.unit.test.ts` — 新增三条断言：
  - 单聊文案不再出现「任务执行完成」/「无文本输出」/「无输出」
  - 单聊文案以「好」开头并包含可继续追问的引导
  - 群聊与单聊文案分流不同
  - 弱化对具体字符串的硬绑定，只锁定语义契约

## 测试

- `npx vitest run tests/empty-reply.unit.test.ts` — 9/9 通过
- 群聊兜底文案 / 日志 hint 行为不变

## 不在范围内

- 私聊触发空回复兜底的根因（模型自身输出空）属于模型 / 提示词侧，不在 connector 修复范围
- 群聊空回复 UX 已在 #589 完成

Refs: #599