### PR TITLE
release: v0.8.22-beta.0 (community validation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.22-beta.0] - 2026-05-21
+
+> **社区验证版本** — 计划 2-3 天观察期后晋升为 `v0.8.22`。详见 [Release Notes](docs/RELEASE_NOTES_V0.8.22-beta.0.md)。
+> Community validation release — planned to promote to `v0.8.22` after a 2-3 day observation window.
+
+### 改进 / Improvements
+
+- ✨ **单聊空回复 UX 文案优化 (#599 / #601)** — 把 `✅ 任务执行完成（无文本输出）` 改为口语化的 `好的 👌 有其他问题随时找我`，避免被用户误判为报错。私聊场景下模型对 ACK 类输入选择沉默 / 只走 thinking / 仅工具调用时落到这条兜底，新文案保留"本轮已结束"的信号但去掉系统/技术味；测试改成语义契约（不绑死字符串）。群聊兜底文案与日志 hint 不变。
+  **Soften direct-chat empty-reply fallback (#599 / #601)** — Replace `✅ 任务执行完成（无文本输出）` with the conversational `好的 👌 有其他问题随时找我`. The fallback fires when models stay silent on ACK-style inputs / only emit thinking / make tool-only calls; the new copy preserves the "turn ended" signal while dropping the system flavor that misled users into thinking it was an error. Tests refactored to semantic contracts.
+
+- ✨ **dws onboarding SSH 兼容 + 版本升级 (#565 / #598)** — `DWS_NPM_PACKAGE` 从 `1.0.13` 升到 npm 最新 `1.0.30`，新装用户拿到 dws #226 修过的 `--help` 文案。onboarding 检测 SSH / 无头环境（`SSH_CLIENT` / `SSH_TTY` / `SSH_CONNECTION`）后，自动把建议命令换成 `dws auth login --device`，避免 127.0.0.1 loopback 在无浏览器服务器上挂死。跨仓根治追踪在 [dws #327](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/327)。
+  **dws onboarding SSH compatibility + version bump (#565 / #598)** — Bump `DWS_NPM_PACKAGE` from `1.0.13` to npm latest `1.0.30` so new installs get the dws #226 docs fix. Onboarding now detects SSH / headless env (`SSH_CLIENT` / `SSH_TTY` / `SSH_CONNECTION`) and auto-suggests `dws auth login --device` to avoid 127.0.0.1 loopback hangs on browserless servers. Cross-repo root fix tracked at [dws #327](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/327).
+
 ## [0.8.21] - 2026-05-19
 
 晋升自 `0.8.21-beta.0` 的 GA 版本，与 beta.0 内容完全一致，经过社区验证后正式发布。  

--- a/docs/RELEASE_NOTES_V0.8.22-beta.0.md
+++ b/docs/RELEASE_NOTES_V0.8.22-beta.0.md
@@ -1,0 +1,107 @@
+# Release Notes - v0.8.22-beta.0
+
+> **社区验证版本** — 计划经过 ~2-3 天社区验证后晋升为正式版 `v0.8.22`。
+> **Community validation release** — planned to promote to GA `v0.8.22` after ~2-3 days of community validation.
+
+## 🎉 本次重点 / Highlights
+
+本版本聚焦 UX 文案与 dws onboarding 体验：
+
+1. 把单聊空回复兜底文案 `✅ 任务执行完成（无文本输出）` 换成口语化确认语 `好的 👌 有其他问题随时找我`，避免被用户误判为报错（#599）
+2. dws CLI 内置版本从 `1.0.13` 升到 npm 最新 `1.0.30`，新装用户拿到正确的 `dws auth login --help` 文案
+3. onboarding 检测 SSH / 无头环境（`SSH_CLIENT` / `SSH_TTY` / `SSH_CONNECTION`），自动建议 `dws auth login --device`，避免 127.0.0.1 loopback 在远端无浏览器服务器上挂起（#565）
+
+This release focuses on UX copy + dws onboarding experience:
+
+1. Replace direct-chat empty-reply fallback `✅ 任务执行完成（无文本输出）` with conversational confirmation `好的 👌 有其他问题随时找我`, so users no longer mistake it for an error (#599)
+2. Bump pinned dws CLI from `1.0.13` to npm latest `1.0.30`; new installs get the corrected `dws auth login --help` copy
+3. Detect SSH / headless env in onboarding and auto-suggest `dws auth login --device`, avoiding 127.0.0.1 loopback hangs on remote headless servers (#565)
+
+## ✨ 改进 / Improvements
+
+### 单聊空回复 UX 文案优化 (#599 / #601)
+
+**现象**：用户对一段说明回「知道了」后，机器人显示 `✅ 任务执行完成（无文本输出）`，被误判为报错。
+
+**根因**：私聊场景下模型可能因 ACK 类输入选择沉默（只走 thinking / tool_call、或纯输出空文本）。connector 的空回复兜底文案系统/技术味偏重，让用户以为是异常。
+
+**改动**：
+
+- `src/utils/empty-reply.ts:23` — `DIRECT_FALLBACK_TEXT` 改为 `好的 👌 有其他问题随时找我`，保留"本轮已结束"信号但去掉技术味
+- 测试改成语义契约（不绑死字符串）：不出现报错感字样 / 以「好」开头 / 包含追问引导 / 与群聊文案不同
+- 群聊兜底文案与日志 hint 维持不变（仍是面向运维的可操作指引）
+
+**Phenomenon**: After replying "知道了" (got it) to a bot's explanation, users saw `✅ 任务执行完成（无文本输出）` and mistook it for an error.
+
+**Root cause**: In direct chat, models may choose to stay silent on ACK-style input (only thinking / tool_call, or empty text output). The connector's fallback copy was too system-y, leading users to misjudge it as a fault.
+
+**Changes**:
+
+- `src/utils/empty-reply.ts:23` — `DIRECT_FALLBACK_TEXT` becomes `好的 👌 有其他问题随时找我`, keeping the "turn ended" signal while dropping the system flavor
+- Tests refactored to semantic contracts (no hardcoded strings): no error-flavored words / starts with 「好」 / contains a follow-up invitation / differs from group fallback
+- Group-chat fallback copy and log hint unchanged (still actionable ops guidance)
+
+### dws onboarding SSH 兼容 + 版本升级 (#565 / #598)
+
+**现象**：SSH / 无头服务器上首次 `dws auth login` 卡死——dws CLI 默认走 127.0.0.1 loopback 回调，本地浏览器无法访问远端 loopback。
+
+**根因**：connector pin 的 dws 是 `1.0.13`，此版本 `--help` 文案描述与实际行为相反，SSH 用户照着 help 跑必然踩坑。
+
+**改动**：
+
+- `bin/dingtalk-connector.js:401` — `DWS_NPM_PACKAGE` 从 `1.0.13` → `1.0.30`（npm latest，含上游 dws #226 文档修复）
+- 新增 `isSshSession()`：检测 `SSH_CLIENT` / `SSH_TTY` / `SSH_CONNECTION` 三个环境变量
+- 新增 `printDwsLoginHint()` 辅助：SSH 命中时把 `dws auth login` 换成 `dws auth login --device`，并附一句说明
+- 把"已安装/全新安装"两条路径的登录提示统一走 `printDwsLoginHint()`，避免分叉
+
+**根治方向（跨仓 follow-up）**：
+
+- [dws #327](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/327) — 建议 dws 自身检测 SSH 环境自动降级到 `--device`，根治后 connector 这边的兜底逻辑可以择机删除
+- 「对话框内授权」是更大的跨仓 UX 改造，需要 dws 支持非 CLI 流程或 Web flow，本版本不涉及
+
+**Phenomenon**: First-time `dws auth login` hangs on SSH / headless servers — the dws CLI defaults to a 127.0.0.1 loopback callback that the local browser can't reach.
+
+**Root cause**: connector pinned dws `1.0.13` whose `--help` text described the opposite of actual behavior; SSH users following the help inevitably hit the trap.
+
+**Changes**:
+
+- `bin/dingtalk-connector.js:401` — `DWS_NPM_PACKAGE` from `1.0.13` → `1.0.30` (npm latest, including upstream dws #226 docs fix)
+- Add `isSshSession()`: detects `SSH_CLIENT` / `SSH_TTY` / `SSH_CONNECTION` env vars
+- Add `printDwsLoginHint()` helper: when SSH is detected, suggest `dws auth login --device` with a brief reason
+- Unify login hint between "already installed" and "fresh install" branches via `printDwsLoginHint()` to avoid drift
+
+**Long-term root fix (cross-repo follow-up)**:
+
+- [dws #327](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/327) — propose dws itself detect SSH and auto-fall back to `--device`. Once that lands, the connector-side workaround can be removed.
+- "In-chat authorization" is a larger cross-repo UX overhaul (needs dws to support non-CLI / Web flow); not in scope for this release.
+
+## 🧪 验证 / Validation
+
+- `tests/empty-reply.unit.test.ts` — 9/9 单测通过（语义契约风格）
+- `node --check bin/dingtalk-connector.js` — 语法通过
+- 手动验证：设置 `SSH_CLIENT` 环境变量后，onboarding 提示自动切到 `dws auth login --device`
+
+## 📦 升级方式 / How to upgrade
+
+```bash
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.22-beta.0
+openclaw gateway restart
+```
+
+或者：
+
+```bash
+npm install -g @dingtalk-real-ai/dingtalk-connector@0.8.22-beta.0
+```
+
+## ⏭️ 后续节奏 / Next steps
+
+- **2026-05-22 ~ 2026-05-24**：社区使用反馈窗口，2-3 天观察期
+- **～2026-05-24 之后**：若无回归，晋升为正式版 `v0.8.22`
+- 升级遇到问题请提交到 [Issues](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues)，按置顶 [#584](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/584) / [#585](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/585) 的模板补全反馈信息
+
+## 🔗 关联 / References
+
+- Issue [#599](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/599) → PR [#601](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/601)
+- Issue [#565](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/565) → PR [#598](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/598)
+- 跨仓 follow-up: [dws #327](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/327)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.8.21",
+  "version": "0.8.22-beta.0",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "author": "DingTalk Real Team",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.8.21",
+  "version": "0.8.22-beta.0",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

社区验证版本 v0.8.22-beta.0，计划 **2-3 天观察期**后晋升为 `v0.8.22` GA。

本次合两条改动：

| Issue | PR | 概要 |
|---|---|---|
| [#599](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/599) | [#601](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/601) | 单聊空回复 UX 文案优化：`✅ 任务执行完成（无文本输出）` → `好的 👌 有其他问题随时找我`，避免被用户误判为报错 |
| [#565](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/565) | [#598](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/598) | dws CLI 内置版本 `1.0.13` → `1.0.30`，onboarding 自动检测 SSH / 无头环境，建议 `dws auth login --device`，避免 127.0.0.1 loopback 挂死 |

## 改动

- `package.json` / `openclaw.plugin.json` — 版本号 `0.8.21` → `0.8.22-beta.0`
- `CHANGELOG.md` — 新增 0.8.22-beta.0 段落
- `docs/RELEASE_NOTES_V0.8.22-beta.0.md` — 完整双语 release notes

代码改动均已通过 #601 / #598 单独合入 main，本 PR 只负责版本号 + changelog。

## 节奏

- **2026-05-21**：beta 发布
- **2026-05-22 ~ 2026-05-24**：社区使用反馈窗口
- **～2026-05-24 之后**：若无回归，promote 为正式版 `v0.8.22`

## 升级方式

```bash
openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.22-beta.0
openclaw gateway restart
```