### PR TITLE
feat: expose DingTalk AI Card create/update gateway methods

### DIFF
--- a/entry-bundled.ts
+++ b/entry-bundled.ts
@@ -26,6 +26,9 @@ export default defineBundledChannelEntry({
   },
   async registerFull(api) {
     const { registerGatewayMethods } = await import("./src/gateway-methods.ts");
+    const { installDingtalkCardBridge, registerDingtalkCardGatewayMethods } = await import("./src/services/card-bridge.ts");
     registerGatewayMethods(api);
+    installDingtalkCardBridge(api);
+    registerDingtalkCardGatewayMethods(api);
   },
 });

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { dingtalkPlugin, initDingtalkPluginConfigSchema } from "./src/channel.ts";
 import { setDingtalkRuntime } from "./src/runtime.ts";
 import { registerGatewayMethods } from "./src/gateway-methods.ts";
+import { installDingtalkCardBridge, registerDingtalkCardGatewayMethods } from "./src/services/card-bridge.ts";
 
 export { dingtalkPlugin, initDingtalkPluginConfigSchema } from "./src/channel.ts";
 export { setDingtalkRuntime } from "./src/runtime.ts";
@@ -74,4 +75,6 @@ export default function register(api: OpenClawPluginApi) {
   initDingtalkPluginConfigSchema();
   api.registerChannel({ plugin: dingtalkPlugin });
   registerGatewayMethods(api);
+  installDingtalkCardBridge(api);
+  registerDingtalkCardGatewayMethods(api);
 }

--- a/src/services/card-bridge.ts
+++ b/src/services/card-bridge.ts
@@ -1,0 +1,388 @@
+import type { ClawdbotConfig, OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { resolveDingtalkAccount } from "../config/accounts.ts";
+import type { DingtalkConfig } from "../types/index.ts";
+import {
+  createAICardForTarget,
+  finishAICard,
+  streamAICard,
+  type AICardInstance,
+  type AICardTarget,
+} from "./messaging/card.ts";
+
+export const DINGTALK_CARD_BRIDGE_SYMBOL = Symbol.for("@dingtalk-connector/card-bridge");
+
+const CARD_RECORD_TTL_MS = 24 * 60 * 60 * 1000;
+const CARD_RECORD_MAX_SIZE = 10_000;
+const CARD_RECORD_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+const DEFAULT_FAILED_CARD_MARKDOWN = "Task failed";
+const TARGET_ID_MAX_LENGTH = 256;
+const TARGET_ID_PATTERN = /^[A-Za-z0-9_:\-$]+$/;
+const PUBLIC_ERROR_PREFIXES = [
+  "target is required",
+  "cardInstanceId is required",
+  "Unknown cardInstanceId",
+  "DingTalk not configured",
+  "Failed to create DingTalk AI Card",
+];
+
+type LoggerLike = {
+  debug?: (message: string) => void;
+  error?: (message: string) => void;
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+};
+
+type CardRecord = {
+  card: AICardInstance;
+  config: DingtalkConfig;
+  lastUsedAt: number;
+  queue: Promise<unknown>;
+};
+
+export type CardUpdateStatus = "running" | "completed" | "failed";
+
+export type CardCreateParams = {
+  cfg?: ClawdbotConfig;
+  accountId?: string;
+  target: string;
+  markdown?: string;
+  log?: LoggerLike;
+};
+
+export type CardUpdateParams = {
+  cardInstanceId: string;
+  markdown?: string;
+  status?: CardUpdateStatus;
+  log?: LoggerLike;
+};
+
+export type DingtalkCardBridge = {
+  create(params: CardCreateParams): Promise<{
+    cardInstanceId: string;
+    accountId: string;
+    target: string;
+  }>;
+  update(params: CardUpdateParams): Promise<{
+    cardInstanceId: string;
+    status: CardUpdateStatus;
+  }>;
+};
+
+const cards = new Map<string, CardRecord>();
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : {};
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "Unknown error";
+}
+
+function publicErrorMessage(err: unknown, fallback: string): string {
+  const message = errorMessage(err);
+  return PUBLIC_ERROR_PREFIXES.some((prefix) => message.startsWith(prefix))
+    ? message
+    : fallback;
+}
+
+function isValidTargetId(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length <= TARGET_ID_MAX_LENGTH &&
+    TARGET_ID_PATTERN.test(value)
+  );
+}
+
+function parseCardTarget(target: unknown): AICardTarget | null {
+  if (typeof target !== "string") return null;
+  const raw = target.trim();
+  if (!raw) return null;
+  const lowered = raw.toLowerCase();
+  if (lowered.startsWith("user:")) {
+    const userId = raw.slice("user:".length).trim();
+    return isValidTargetId(userId) ? { type: "user", userId } : null;
+  }
+  if (lowered.startsWith("group:")) {
+    const openConversationId = raw.slice("group:".length).trim();
+    return isValidTargetId(openConversationId) ? { type: "group", openConversationId } : null;
+  }
+  if (raw.startsWith("cid") && isValidTargetId(raw)) {
+    return { type: "group", openConversationId: raw };
+  }
+  return null;
+}
+
+function targetToString(target: AICardTarget): string {
+  return target.type === "user" ? `user:${target.userId}` : `group:${target.openConversationId}`;
+}
+
+function normalizeStatus(value: unknown): CardUpdateStatus {
+  if (value === "completed" || value === "failed") return value;
+  return "running";
+}
+
+function cleanupExpiredCards(log?: LoggerLike, timestamp = nowMs()): number {
+  let removed = 0;
+  for (const [cardInstanceId, record] of cards) {
+    if (timestamp - record.lastUsedAt > CARD_RECORD_TTL_MS) {
+      cards.delete(cardInstanceId);
+      removed += 1;
+    }
+  }
+  if (removed > 0) {
+    log?.info?.(`[DingTalk][CardBridge] cleaned expired cards count=${removed}`);
+  }
+  return removed;
+}
+
+function evictOverflowCards(log?: LoggerLike): number {
+  let removed = 0;
+  while (cards.size > CARD_RECORD_MAX_SIZE) {
+    let oldestId: string | undefined;
+    let oldestLastUsedAt = Infinity;
+    for (const [cardInstanceId, record] of cards) {
+      if (record.lastUsedAt < oldestLastUsedAt) {
+        oldestId = cardInstanceId;
+        oldestLastUsedAt = record.lastUsedAt;
+      }
+    }
+    if (!oldestId) break;
+    cards.delete(oldestId);
+    removed += 1;
+  }
+  if (removed > 0) {
+    log?.warn?.(`[DingTalk][CardBridge] evicted old cards count=${removed}`);
+  }
+  return removed;
+}
+
+const cleanupTimer = setInterval(() => {
+  cleanupExpiredCards();
+}, CARD_RECORD_CLEANUP_INTERVAL_MS);
+cleanupTimer.unref?.();
+
+function rememberCard(card: AICardInstance, config: DingtalkConfig, log?: LoggerLike): CardRecord {
+  cleanupExpiredCards(log);
+  const timestamp = nowMs();
+  const record: CardRecord = {
+    card,
+    config,
+    lastUsedAt: timestamp,
+    queue: Promise.resolve(),
+  };
+  cards.set(card.cardInstanceId, record);
+  evictOverflowCards(log);
+  return record;
+}
+
+async function loadRuntimeConfig(
+  api: OpenClawPluginApi,
+  cfg?: ClawdbotConfig,
+): Promise<ClawdbotConfig> {
+  if (cfg) return cfg;
+  const apiConfig = (api as OpenClawPluginApi & { config?: ClawdbotConfig }).config;
+  if (apiConfig) return apiConfig;
+  const { loadConfig } = await import("openclaw/plugin-sdk/config-runtime");
+  return loadConfig() as ClawdbotConfig;
+}
+
+function getCardRecord(cardInstanceId: string): CardRecord {
+  const record = cards.get(cardInstanceId);
+  if (!record) throw new Error(`Unknown cardInstanceId: ${cardInstanceId}`);
+  record.lastUsedAt = nowMs();
+  return record;
+}
+
+function resolveAccountConfig(
+  cfg: ClawdbotConfig,
+  accountId: unknown,
+  log: LoggerLike | undefined,
+  method: string,
+) {
+  const account = resolveDingtalkAccount({
+    cfg,
+    accountId: typeof accountId === "string" ? accountId : undefined,
+  });
+  if (!account.enabled || !account.configured) {
+    throw new Error("DingTalk not configured");
+  }
+  log?.debug?.(`[DingTalk][CardBridge][${method}] using accountId=${account.accountId}`);
+  return account;
+}
+
+async function createCard(params: {
+  cfg: ClawdbotConfig;
+  accountId?: string;
+  target: AICardTarget;
+  markdown?: string;
+  log?: LoggerLike;
+}) {
+  const account = resolveAccountConfig(params.cfg, params.accountId, params.log, "card.create");
+  const card = await createAICardForTarget(account.config, params.target, params.log);
+  if (!card) throw new Error("Failed to create DingTalk AI Card");
+  rememberCard(card, account.config, params.log);
+  try {
+    if (params.markdown) {
+      await streamAICard(card, params.markdown, false, account.config, params.log);
+    }
+  } catch (err) {
+    cards.delete(card.cardInstanceId);
+    throw err;
+  }
+  params.log?.info?.(`[DingTalk][CardBridge][card.create] created cardInstanceId=${card.cardInstanceId}`);
+  return {
+    cardInstanceId: card.cardInstanceId,
+    accountId: account.accountId,
+    target: targetToString(params.target),
+  };
+}
+
+async function updateCard(params: {
+  cardInstanceId: string;
+  markdown: string;
+  status?: CardUpdateStatus;
+  log?: LoggerLike;
+}) {
+  const record = getCardRecord(params.cardInstanceId);
+  const status = normalizeStatus(params.status);
+  const operation = record.queue.then(
+    () => updateCardRecord(record, params.cardInstanceId, params.markdown, status, params.log),
+    () => updateCardRecord(record, params.cardInstanceId, params.markdown, status, params.log),
+  );
+  record.queue = operation.catch(() => undefined);
+  await operation;
+  return {
+    cardInstanceId: params.cardInstanceId,
+    status,
+  };
+}
+
+async function updateCardRecord(
+  record: CardRecord,
+  cardInstanceId: string,
+  markdown: string,
+  status: CardUpdateStatus,
+  log?: LoggerLike,
+) {
+  if (cards.get(cardInstanceId) !== record) {
+    throw new Error(`Unknown cardInstanceId: ${cardInstanceId}`);
+  }
+  record.lastUsedAt = nowMs();
+  log?.info?.(`[DingTalk][CardBridge][card.update] cardInstanceId=${cardInstanceId} status=${status}`);
+  if (status === "completed") {
+    try {
+      await finishAICard(record.card, markdown || " ", record.config, log);
+    } finally {
+      cards.delete(cardInstanceId);
+    }
+  } else if (status === "failed") {
+    const content = markdown.trim() ? markdown : DEFAULT_FAILED_CARD_MARKDOWN;
+    try {
+      await finishAICard(record.card, content, record.config, log);
+    } finally {
+      cards.delete(cardInstanceId);
+    }
+  } else {
+    await streamAICard(record.card, markdown || " ", false, record.config, log);
+  }
+}
+
+/**
+ * Return the in-process DingTalk card bridge installed by this connector.
+ *
+ * Contract:
+ * - Symbol key: `Symbol.for("@dingtalk-connector/card-bridge")`
+ * - `create({ target, accountId?, markdown?, cfg?, log? })`
+ * - `update({ cardInstanceId, markdown?, status?, log? })`
+ *
+ * This bridge is intentionally process-local. Cross-process callers should use
+ * the gateway methods registered below instead.
+ */
+export function getDingtalkCardBridge(): DingtalkCardBridge | undefined {
+  return (globalThis as any)[DINGTALK_CARD_BRIDGE_SYMBOL];
+}
+
+export function installDingtalkCardBridge(api: OpenClawPluginApi): void {
+  const g = globalThis as any;
+  g[DINGTALK_CARD_BRIDGE_SYMBOL] = {
+    async create(params: CardCreateParams) {
+      const cfg = await loadRuntimeConfig(api, params?.cfg);
+      const target = parseCardTarget(params?.target);
+      if (!target) throw new Error("target is required (user:<userId>, group:<openConversationId>, or cid...)");
+      return createCard({
+        cfg,
+        accountId: params?.accountId,
+        target,
+        markdown: optionalString(params?.markdown),
+        log: params?.log ?? api.logger,
+      });
+    },
+    async update(params: CardUpdateParams) {
+      if (!params?.cardInstanceId) throw new Error("cardInstanceId is required");
+      return updateCard({
+        cardInstanceId: String(params.cardInstanceId),
+        markdown: String(params?.markdown ?? ""),
+        status: normalizeStatus(params?.status),
+        log: params?.log ?? api.logger,
+      });
+    },
+  } satisfies DingtalkCardBridge;
+}
+
+export function registerDingtalkCardGatewayMethods(api: OpenClawPluginApi): void {
+  const log = api.logger;
+
+  api.registerGatewayMethod("dingtalk-connector.card.create", async ({ params, respond }) => {
+    try {
+      const { loadConfig } = await import("openclaw/plugin-sdk/config-runtime");
+      const cfg = loadConfig() as ClawdbotConfig;
+      const rawParams = asRecord(params);
+      const target = parseCardTarget(rawParams.target);
+      if (!target) {
+        return respond(false, {
+          error: "target is required (user:<userId>, group:<openConversationId>, or cid...)",
+        });
+      }
+      const result = await createCard({
+        cfg,
+        accountId: optionalString(rawParams.accountId),
+        target,
+        markdown: optionalString(rawParams.markdown),
+        log,
+      });
+      respond(true, result);
+    } catch (err: unknown) {
+      log?.error?.(`[Gateway][card.create] 错误: ${errorMessage(err)}`);
+      respond(false, { error: publicErrorMessage(err, "card.create failed") });
+    }
+  });
+
+  api.registerGatewayMethod("dingtalk-connector.card.update", async ({ params, respond }) => {
+    try {
+      const rawParams = asRecord(params);
+      if (!rawParams.cardInstanceId) {
+        return respond(false, { error: "cardInstanceId is required" });
+      }
+      const result = await updateCard({
+        cardInstanceId: String(rawParams.cardInstanceId),
+        markdown: String(rawParams.markdown ?? ""),
+        status: normalizeStatus(rawParams.status),
+        log,
+      });
+      respond(true, result);
+    } catch (err: unknown) {
+      log?.error?.(`[Gateway][card.update] 错误: ${errorMessage(err)}`);
+      respond(false, { error: publicErrorMessage(err, "card.update failed") });
+    }
+  });
+}

--- a/tests/gateway-methods.unit.test.ts
+++ b/tests/gateway-methods.unit.test.ts
@@ -7,6 +7,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { OpenClawPluginApi } from 'openclaw/plugin-sdk';
 import { registerGatewayMethods } from '../src/gateway-methods';
+import {
+  DINGTALK_CARD_BRIDGE_SYMBOL,
+  getDingtalkCardBridge,
+  installDingtalkCardBridge,
+  registerDingtalkCardGatewayMethods,
+} from '../src/services/card-bridge';
+
+const {
+  mockCreateAICardForTarget,
+  mockStreamAICard,
+  mockFinishAICard,
+} = vi.hoisted(() => ({
+  mockCreateAICardForTarget: vi.fn(),
+  mockStreamAICard: vi.fn(),
+  mockFinishAICard: vi.fn(),
+}));
 
 // ============ Mock 数据 ============
 
@@ -23,6 +39,12 @@ const mockConfig = {
 // Mock loadConfig：gateway-methods.ts 通过动态 import 获取配置
 vi.mock('openclaw/plugin-sdk/config-runtime', () => ({
   loadConfig: () => mockConfig,
+}));
+
+vi.mock('../src/services/messaging/card', () => ({
+  createAICardForTarget: mockCreateAICardForTarget,
+  streamAICard: mockStreamAICard,
+  finishAICard: mockFinishAICard,
 }));
 
 const mockLogger = {
@@ -50,7 +72,7 @@ function createMockApi() {
   return {
     api: api as OpenClawPluginApi,
     handlers,
-    callMethod: async (name: string, params: any = {}) => {
+    callMethod: async (name: string, params: unknown = {}) => {
       const handler = handlers.get(name);
       if (!handler) {
         throw new Error(`Method ${name} not registered`);
@@ -83,6 +105,7 @@ describe('Gateway Methods - 注册', () => {
   it('应该注册所有方法', () => {
     const { api, handlers } = createMockApi();
     registerGatewayMethods(api);
+    registerDingtalkCardGatewayMethods(api);
 
     // 验证所有方法都已注册
     expect(handlers.has('dingtalk-connector.sendToUser')).toBe(true);
@@ -98,9 +121,11 @@ describe('Gateway Methods - 注册', () => {
     expect(handlers.has('dingtalk-connector.fixStuckCards')).toBe(true);
     expect(handlers.has('dingtalk-connector.listAccounts')).toBe(true);
     expect(handlers.has('dingtalk-connector.bootstrapBotIdentity')).toBe(true);
+    expect(handlers.has('dingtalk-connector.card.create')).toBe(true);
+    expect(handlers.has('dingtalk-connector.card.update')).toBe(true);
 
-    // 10 原有 + fixStuckCards + listAccounts + bootstrapBotIdentity
-    expect(handlers.size).toBe(13);
+    // 10 原有 + fixStuckCards + listAccounts + bootstrapBotIdentity + card.create/update
+    expect(handlers.size).toBe(15);
   });
 });
 
@@ -276,6 +301,293 @@ describe('Gateway Methods - 配置读取', () => {
     // 验证 respond 被调用且成功（loadConfig 已被 mock 返回 mockConfig）
     expect(respond).toHaveBeenCalled();
     expect(respond.mock.calls[0][0]).toBe(true);
+  });
+});
+
+describe('Card Gateway Methods - 参数验证', () => {
+  let mockApi: ReturnType<typeof createMockApi>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete (globalThis as any)[DINGTALK_CARD_BRIDGE_SYMBOL];
+    mockCreateAICardForTarget.mockResolvedValue({
+      cardInstanceId: 'card_test_1',
+      accessToken: 'token',
+      tokenExpireTime: Date.now() + 60_000,
+      inputingStarted: false,
+    });
+    mockStreamAICard.mockResolvedValue(undefined);
+    mockFinishAICard.mockResolvedValue(undefined);
+    mockApi = createMockApi();
+    registerDingtalkCardGatewayMethods(mockApi.api);
+  });
+
+  it('card.create 缺少 target 应该返回错误', async () => {
+    const { ok, result } = await mockApi.callMethod('dingtalk-connector.card.create', {
+      markdown: '处理中',
+    });
+
+    expect(ok).toBe(false);
+    expect(result?.error).toContain('target');
+  });
+
+  it('card.update 缺少 cardInstanceId 应该返回错误', async () => {
+    const { ok, result } = await mockApi.callMethod('dingtalk-connector.card.update', {
+      markdown: '处理中',
+    });
+
+    expect(ok).toBe(false);
+    expect(result?.error).toContain('cardInstanceId');
+  });
+
+  it('card.update 未知 cardInstanceId 应该返回错误', async () => {
+    const { ok, result } = await mockApi.callMethod('dingtalk-connector.card.update', {
+      cardInstanceId: 'card_missing',
+      markdown: '处理中',
+    });
+
+    expect(ok).toBe(false);
+    expect(result?.error).toContain('Unknown cardInstanceId');
+  });
+
+  it('card.create 应支持 user/group/cid target 格式并拒绝非法格式', async () => {
+    const cases = [
+      ['user:user_123', { type: 'user', userId: 'user_123' }, 'user:user_123'],
+      ['group:cid-group_123', { type: 'group', openConversationId: 'cid-group_123' }, 'group:cid-group_123'],
+      ['cid_direct_123', { type: 'group', openConversationId: 'cid_direct_123' }, 'group:cid_direct_123'],
+    ] as const;
+
+    for (const [target, expectedTarget, expectedReturn] of cases) {
+      mockCreateAICardForTarget.mockResolvedValueOnce({
+        cardInstanceId: `card_${target.replace(/[^a-zA-Z0-9]/g, '_')}`,
+        accessToken: 'token',
+        tokenExpireTime: Date.now() + 60_000,
+        inputingStarted: false,
+      });
+
+      const { ok, result } = await mockApi.callMethod('dingtalk-connector.card.create', {
+        target,
+        markdown: '处理中',
+      });
+
+      expect(ok).toBe(true);
+      expect(result?.target).toBe(expectedReturn);
+      expect(mockCreateAICardForTarget).toHaveBeenLastCalledWith(
+        expect.any(Object),
+        expectedTarget,
+        mockLogger,
+      );
+    }
+
+    for (const target of ['plain_user', 'ding:user:user_123', '<script>alert(1)</script>', `user:${'a'.repeat(257)}`]) {
+      const { ok, result } = await mockApi.callMethod('dingtalk-connector.card.create', {
+        target,
+      });
+
+      expect(ok).toBe(false);
+      expect(result?.error).toContain('target');
+    }
+  });
+
+  it('card.create -> card.update(running) -> card.update(completed) 应完成完整生命周期', async () => {
+    const { ok: createOk, result: createResult } = await mockApi.callMethod('dingtalk-connector.card.create', {
+      target: 'user:user_123',
+      markdown: '启动',
+    });
+
+    expect(createOk).toBe(true);
+    expect(createResult?.cardInstanceId).toBe('card_test_1');
+    expect(mockStreamAICard).toHaveBeenCalledWith(
+      expect.objectContaining({ cardInstanceId: 'card_test_1' }),
+      '启动',
+      false,
+      expect.any(Object),
+      mockLogger,
+    );
+
+    const { ok: runningOk, result: runningResult } = await mockApi.callMethod('dingtalk-connector.card.update', {
+      cardInstanceId: 'card_test_1',
+      markdown: '处理中',
+      status: 'running',
+    });
+
+    expect(runningOk).toBe(true);
+    expect(runningResult?.status).toBe('running');
+    expect(mockStreamAICard).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cardInstanceId: 'card_test_1' }),
+      '处理中',
+      false,
+      expect.any(Object),
+      mockLogger,
+    );
+
+    const { ok: completedOk, result: completedResult } = await mockApi.callMethod('dingtalk-connector.card.update', {
+      cardInstanceId: 'card_test_1',
+      markdown: '完整报告',
+      status: 'completed',
+    });
+
+    expect(completedOk).toBe(true);
+    expect(completedResult?.status).toBe('completed');
+    expect(mockFinishAICard).toHaveBeenCalledWith(
+      expect.objectContaining({ cardInstanceId: 'card_test_1' }),
+      '完整报告',
+      expect.any(Object),
+      mockLogger,
+    );
+
+    const retry = await mockApi.callMethod('dingtalk-connector.card.update', {
+      cardInstanceId: 'card_test_1',
+      markdown: '不应成功',
+    });
+    expect(retry.ok).toBe(false);
+    expect(retry.result?.error).toContain('Unknown cardInstanceId');
+  });
+
+  it('card.update completed 即使 finishAICard 抛错也应回收 card record', async () => {
+    await mockApi.callMethod('dingtalk-connector.card.create', {
+      target: 'user:user_123',
+    });
+    mockFinishAICard.mockRejectedValueOnce(new Error('finish failed'));
+
+    const completed = await mockApi.callMethod('dingtalk-connector.card.update', {
+      cardInstanceId: 'card_test_1',
+      markdown: '完整报告',
+      status: 'completed',
+    });
+
+    expect(completed.ok).toBe(false);
+    expect(completed.result?.error).toBe('card.update failed');
+
+    const retry = await mockApi.callMethod('dingtalk-connector.card.update', {
+      cardInstanceId: 'card_test_1',
+      markdown: '重试',
+    });
+
+    expect(retry.ok).toBe(false);
+    expect(retry.result?.error).toContain('Unknown cardInstanceId');
+  });
+
+  it('card.update completed 应过滤内部 finishAICard 错误消息', async () => {
+    await mockApi.callMethod('dingtalk-connector.card.create', {
+      target: 'user:user_123',
+    });
+    mockFinishAICard.mockRejectedValueOnce(new Error('token=secret internal stack'));
+
+    const completed = await mockApi.callMethod('dingtalk-connector.card.update', {
+      cardInstanceId: 'card_test_1',
+      markdown: '完整报告',
+      status: 'completed',
+    });
+
+    expect(completed.ok).toBe(false);
+    expect(completed.result?.error).toBe('card.update failed');
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('token=secret internal stack'),
+    );
+  });
+
+  it('card.update failed 缺少 markdown 时应使用默认失败文案', async () => {
+    await mockApi.callMethod('dingtalk-connector.card.create', {
+      target: 'user:user_123',
+    });
+
+    const failed = await mockApi.callMethod('dingtalk-connector.card.update', {
+      cardInstanceId: 'card_test_1',
+      status: 'failed',
+    });
+
+    expect(failed.ok).toBe(true);
+    expect(mockFinishAICard).toHaveBeenCalledWith(
+      expect.objectContaining({ cardInstanceId: 'card_test_1' }),
+      'Task failed',
+      expect.any(Object),
+      mockLogger,
+    );
+  });
+
+  it('card.create 时应清理超过 TTL 的旧 card record', async () => {
+    const realDateNow = Date.now;
+    let currentTime = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
+    mockCreateAICardForTarget
+      .mockResolvedValueOnce({
+        cardInstanceId: 'card_expired',
+        accessToken: 'token',
+        tokenExpireTime: currentTime + 60_000,
+        inputingStarted: false,
+      })
+      .mockResolvedValueOnce({
+        cardInstanceId: 'card_current',
+        accessToken: 'token',
+        tokenExpireTime: currentTime + 60_000,
+        inputingStarted: false,
+      });
+
+    try {
+      await mockApi.callMethod('dingtalk-connector.card.create', {
+        target: 'user:user_123',
+      });
+
+      currentTime += 24 * 60 * 60 * 1000 + 1;
+
+      await mockApi.callMethod('dingtalk-connector.card.create', {
+        target: 'user:user_456',
+      });
+
+      const expired = await mockApi.callMethod('dingtalk-connector.card.update', {
+        cardInstanceId: 'card_expired',
+        markdown: '不应成功',
+      });
+      const current = await mockApi.callMethod('dingtalk-connector.card.update', {
+        cardInstanceId: 'card_current',
+        markdown: '仍可更新',
+      });
+
+      expect(expired.ok).toBe(false);
+      expect(expired.result?.error).toContain('Unknown cardInstanceId');
+      expect(current.ok).toBe(true);
+    } finally {
+      Date.now = realDateNow;
+    }
+  });
+
+  it('同一个 card 的 update 应串行执行', async () => {
+    await mockApi.callMethod('dingtalk-connector.card.create', {
+      target: 'user:user_123',
+    });
+
+    const order: string[] = [];
+    mockStreamAICard.mockImplementation(async (_card, markdown) => {
+      order.push(`start:${markdown}`);
+      await new Promise((resolve) => setTimeout(resolve, markdown === 'first' ? 20 : 0));
+      order.push(`end:${markdown}`);
+    });
+
+    await Promise.all([
+      mockApi.callMethod('dingtalk-connector.card.update', {
+        cardInstanceId: 'card_test_1',
+        markdown: 'first',
+        status: 'running',
+      }),
+      mockApi.callMethod('dingtalk-connector.card.update', {
+        cardInstanceId: 'card_test_1',
+        markdown: 'second',
+        status: 'running',
+      }),
+    ]);
+
+    expect(order).toEqual(['start:first', 'end:first', 'start:second', 'end:second']);
+  });
+
+  it('installDingtalkCardBridge 应安装可发现的同进程 bridge', () => {
+    installDingtalkCardBridge(mockApi.api);
+    const bridge = getDingtalkCardBridge();
+
+    expect(bridge).toBeDefined();
+    expect(bridge).toBe((globalThis as any)[DINGTALK_CARD_BRIDGE_SYMBOL]);
+    expect(typeof bridge?.create).toBe('function');
+    expect(typeof bridge?.update).toBe('function');
   });
 });
 


### PR DESCRIPTION
# feat: 暴露钉钉 AI Card 创建与更新能力

## 背景

当前 `dingtalk-connector` 已经具备创建、流式更新和完成 AI Card 的内部能力，但这些能力主要服务于 connector 自身的回复链路，外部 OpenClaw tool 无法稳定复用。

在一些长耗时任务场景中，例如外部 SSE 工具持续接收进度事件，需要由 tool 自己创建一张过程卡片，并在任务执行期间持续更新卡片内容。任务完成后，再将最终报告写入同一张过程卡片。

本 PR 以最小改动方式暴露 AI Card 的创建与更新能力，方便外部 tool/plugin 复用 connector 已有的钉钉 AI Card 能力。

## 改动内容

本 PR 新增两个 gateway method：

- `dingtalk-connector.card.create`
- `dingtalk-connector.card.update`

同时新增一个同进程 card bridge，方便同一 OpenClaw 运行时内的其他 plugin/tool 直接复用这些能力。

### `dingtalk-connector.card.create`

用于创建一张钉钉 AI Card。

支持参数：

- `target`：投放目标
  - `user:<userId>`
  - `group:<openConversationId>`
  - `cid...`
- `accountId`：可选，指定钉钉账号
- `markdown`：可选，初始卡片内容

返回：

- `cardInstanceId`
- `accountId`
- `target`

### `dingtalk-connector.card.update`

用于更新或结束一张已创建的 AI Card。

支持参数：

- `cardInstanceId`：必填
- `markdown`：卡片内容
- `status`：
  - `running`：流式更新卡片
  - `completed`：完成卡片
  - `failed`：失败态结束卡片

完成态复用现有 `finishAICard`，即通过 `/v1.0/card/streaming` 的 `isFinalize=true` 写入最终内容，再设置卡片为 `FINISHED`。

## 设计说明

本 PR 不在 `dingtalk-connector` 中内置 SSE 逻辑。

SSE 的连接、循环读取、事件映射、节流和最终报告组装，仍由外部 tool/plugin 负责。`dingtalk-connector` 只提供最小的 AI Card 生命周期能力：

- 创建卡片
- 更新卡片
- 完成卡片
- 失败态结束卡片

这样可以避免 connector 与具体业务协议耦合，也能让其他长任务工具复用同一套卡片能力。

## 涉及文件

- `src/services/card-bridge.ts`
  - 新增 card bridge 和 card gateway methods
- `index.ts`
  - 注册 card bridge 和 card gateway methods
- `entry-bundled.ts`
  - bundled 入口同步注册
- `tests/gateway-methods.unit.test.ts`
  - 补充注册和参数校验测试

## 环境信息

- OpenClaw: `2026.5.12 (f066dd2)`
- dingtalk-connector: `0.8.22-beta.0`
- Node.js: `v22.22.3`
- npm: `10.9.8`
- DingTalk connector mode: `stream`
- 本地调试 LLM: `bailian/qwen3.6-plus`

## 验证结果

### 自动化测试

已执行：

```bash
npx vitest run tests/ai-card/ai-card.test.ts tests/card-update/card-update.test.ts tests/gateway-methods.unit.test.ts
```

结果：

```text
Test Files  3 passed
Tests       61 passed
```

### 构建验证

已执行：

```bash
npm run build
```

结果：通过。

### 真实钉钉环境验证

已在 OpenClaw debug gateway + 真实钉钉机器人会话中验证：

- 外部 SSE tool 可以通过 card bridge 创建过程卡片
- 过程事件可以持续更新到同一张钉钉 AI Card
- 最终报告可以写入同一张过程卡片
- 钉钉 API 返回成功：
  - create
  - inputing
  - streaming update
  - streaming finalize
  - finished

## 限制说明

- 当前 card 状态保存在进程内存中，进程重启后无法继续更新重启前创建的 card。
- 对于 `STREAM` 类型 AI Card，最终可见内容仍需要通过 `/v1.0/card/streaming` 且 `isFinalize=true` 写入。
- 测试中发现，仅通过 card instance data 更新 `msgContent` 虽然可能返回 200，但不能稳定刷新已进入 streaming 状态卡片的可见内容。
- 本 PR 不新增 `card.delete`，也不引入持久化存储。

## 兼容性

- 不改变现有钉钉消息回复主链路。
- 不改变已有 `sendToUser`、`sendToGroup`、AI Card 回复等接口行为。
- 新增能力为增量 gateway method 和同进程 bridge，默认不会影响现有用户。

## Checklist

- [x] 新增 `card.create`
- [x] 新增 `card.update`
- [x] bundled 入口完成注册
- [x] 默认入口完成注册
- [x] 补充 gateway method 注册测试
- [x] 补充参数校验测试
- [x] 通过相关单测
- [x] 通过 build
- [x] 经过真实钉钉机器人会话验证