### PR TITLE
[codex] add Hermes DingTalk plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ openclaw gateway restart
 
 ---
 
+## Hermes 版本
+
+`hermes-plugin/` 提供 Hermes Agent 的平台插件入口。Hermes 当前已经内建 DingTalk Stream 通道、扫码注册、媒体接收和 AI Card 支持；这个插件复用 Hermes 的 DingTalk 适配器，并补上本 connector 使用的官方 AI Card 默认模板、主动发用户/群消息、本地图片/文件上传，以及 DingTalk `dws` skill。
+
+```bash
+cp -R hermes-plugin ~/.hermes/plugins/dingtalk-official
+hermes plugins enable dingtalk-official
+```
+
+配置 `DINGTALK_CLIENT_ID` 与 `DINGTALK_CLIENT_SECRET` 后启动 Hermes gateway。若需关闭默认 AI Card 模板，可在 Hermes 配置中显式覆盖 `platforms.dingtalk.extra.card_template_id`。
+
+详细说明见 [Hermes 插件 README](hermes-plugin/README.md)。
+
+---
+
 ## 使用指南
 
 [OpenClaw 钉钉官方插件使用指南](https://alidocs.dingtalk.com/i/nodes/2Amq4vjg89GEno0zfPqoPGqdV3kdP0wQ?utm_scene=team_space)

--- a/hermes-plugin/README.md
+++ b/hermes-plugin/README.md
@@ -1,0 +1,189 @@
+# DingTalk Official for Hermes
+
+This directory is the Hermes Agent plugin form of the DingTalk official
+OpenClaw connector.
+
+Hermes already has the core DingTalk Stream adapter, QR registration flow,
+media intake, and AI Card support. This plugin registers that adapter through
+the Hermes platform-plugin surface and keeps the official connector defaults:
+
+- platform name `dingtalk`, so normal Hermes DingTalk config keeps working
+- official AI Card template enabled unless `card_template_id` is overridden
+- proactive robot sends to `user` and `group` targets through the
+  `dingtalk_official_send` tool
+- local image and file upload for Hermes DingTalk adapter replies when the
+  current inbound DingTalk context identifies the target
+- one plugin skill, `dingtalk-official:dingtalk-dws`, for DingTalk product
+  operations through the `dws` CLI
+
+## Install
+
+Copy this directory into the Hermes user plugin directory, then enable it:
+
+```bash
+cp -R hermes-plugin ~/.hermes/plugins/dingtalk-official
+hermes plugins enable dingtalk-official
+```
+
+Install the DingTalk Hermes dependencies if they are not already present:
+
+```bash
+pip install "hermes-agent[dingtalk]"
+```
+
+## Configure
+
+An env-only setup is enough:
+
+```bash
+export DINGTALK_CLIENT_ID="your-app-key"
+export DINGTALK_CLIENT_SECRET="your-app-secret"
+export DINGTALK_ACCOUNT_ID="main-bot"
+export DINGTALK_ALLOWED_USERS="your-sender-or-staff-id"
+```
+
+`DINGTALK_ALLOW_ALL_USERS=true` opens Hermes gateway authorization for this
+platform and should only be used intentionally. Group behavior can be tuned
+with `DINGTALK_REQUIRE_MENTION`, `DINGTALK_ALLOWED_CHATS`,
+`DINGTALK_FREE_RESPONSE_CHATS`, and `DINGTALK_MENTION_PATTERNS`.
+
+The plugin seeds the official AI Card template automatically. Keep credentials
+in env vars, and override card options in Hermes YAML when another template is
+required:
+
+```yaml
+platforms:
+  dingtalk:
+    enabled: true
+    extra:
+      card_template_id: your-card-template-id
+      robot_code: your-robot-code
+```
+
+The adapter still falls back to DingTalk session-webhook Markdown replies when
+AI Card SDK setup or delivery is unavailable.
+
+## Quiet Chat Mode
+
+DingTalk is usually a real user-facing conversation, so this plugin suppresses
+Hermes intermediate activity by default: tool-progress bubbles, terminal command
+previews, streaming draft chunks, and interim assistant commentary are not sent
+to the chat. Final replies, local images/files, and explicit proactive
+`user:`/`group:` targets still send normally.
+
+Turn activity back on while debugging:
+
+```bash
+export DINGTALK_SHOW_ACTIVITY=true
+```
+
+Or configure it in Hermes YAML:
+
+```yaml
+platforms:
+  dingtalk:
+    enabled: true
+    extra:
+      suppress_intermediate: false
+```
+
+## Official Send Delta
+
+Hermes' built-in DingTalk `send_message` path is a static robot-webhook path.
+This plugin adds the official connector's OpenAPI send path separately:
+
+- use the agent tool `dingtalk_official_send` for proactive user or group
+  sends
+- pass a DingTalk `staff_id` for `target_type=user`; Hermes `sender_id` is
+  not a substitute for the proactive robot API
+- pass a DingTalk group `openConversationId` for `target_type=group`
+- pass `content` for text or Markdown
+- pass `file_path` for a local image or regular file upload
+- set `file_kind` only when auto-detection should be overridden
+- pass `at_accounts`, `at_dingtalk_ids`, `at_user_ids`, or `at_all` when a
+  proactive text/Markdown message should visibly mention another bot or user
+
+The platform adapter also accepts explicit proactive chat IDs when a caller is
+already on the adapter send path:
+
+```text
+user:<dingtalk-user-id>
+group:<open-conversation-id>
+```
+
+For normal replies to an inbound DingTalk message, Hermes still uses its
+session reply and AI Card behavior. If the reply dispatcher emits a local
+image, the plugin uploads it and sends the official connector's
+`![image](mediaId)` Markdown form through the current `sessionWebhook`.
+If it emits a local document, the plugin uploads it and sends a native DingTalk
+file message through the current `sessionWebhook`. Explicit `user:` or `group:`
+targets still use the proactive robot send path.
+
+The proactive send path defaults `robotCode` to the DingTalk client ID, matching
+the official OpenClaw connector. If DingTalk reports that `robotCode` was not
+found, configure `DINGTALK_ROBOT_CODE` or
+`platforms.dingtalk.extra.robot_code` with the robot code for that app and
+verify that the credentials belong to a robot-enabled DingTalk app.
+
+## Multi-Bot Mentions
+
+OpenClaw's full multi-agent mode starts several DingTalk robot accounts and
+routes each account to a different Agent through `accounts` and `bindings`.
+Hermes currently creates one adapter for the `dingtalk` platform, so this
+plugin does not run multiple DingTalk accounts inside one gateway process.
+
+The portable part is bot-to-bot mention resolution. Configure the other bots'
+`chatbotUserId` values and aliases, then Hermes can write `@dev-agent` or pass
+`at_accounts=["dev-bot"]`; the plugin rewrites the message to DingTalk's
+encrypted bot ID and adds `at.atDingtalkIds` on session-webhook replies.
+
+When a bot receives a DingTalk message, the plugin prints its own identity once:
+
+```text
+[DingTalk:main-bot] [BotIdentity] accountId=main-bot chatbotUserId=$:LWCP_v1:$... chatbotCorpId=...
+```
+
+Use that `chatbotUserId` in the other server's mention config. The agent can
+also call `dingtalk_official_mentions` to list configured aliases and missing
+IDs before testing a handoff.
+
+```bash
+export DINGTALK_BOT_MENTIONS='[
+  {
+    "account_id": "dev-bot",
+    "name": "开发助手",
+    "agent_ids": ["dev-agent"],
+    "aliases": ["dev"],
+    "chatbot_user_id": "$:LWCP_v1:$example"
+  }
+]'
+```
+
+The same structure can live in Hermes YAML:
+
+```yaml
+platforms:
+  dingtalk:
+    enabled: true
+    extra:
+      bot_mentions:
+        - account_id: dev-bot
+          name: 开发助手
+          agent_ids: [dev-agent]
+          aliases: [dev]
+          chatbot_user_id: "$:LWCP_v1:$example"
+```
+
+You can also copy an OpenClaw-like `accounts` plus `bindings` shape into
+`platforms.dingtalk.extra`; `accountId`, `name`, bound `agentId`, and `aliases`
+become valid mention names.
+
+## Scope
+
+The Node/OpenClaw channel runtime is not loaded by Hermes. Incoming/outgoing
+chat traffic is handled by Hermes' Python DingTalk adapter. DingTalk business
+operations such as docs, calendar, todo, reports, AI tables, and DING messages
+remain `dws` CLI work and are described by the bundled plugin skill. Native
+OpenClaw-style routing of different DingTalk accounts to different Hermes
+profiles would require Hermes gateway core support for multiple adapters or
+profile routing per platform message.

--- a/hermes-plugin/__init__.py
+++ b/hermes-plugin/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/hermes-plugin/adapter.py
+++ b/hermes-plugin/adapter.py
@@ -1,0 +1,1501 @@
+"""Hermes platform plugin entrypoint for the official DingTalk connector.
+
+Hermes already owns a DingTalk gateway adapter.  The official OpenClaw
+connector and that adapter use the same DingTalk Stream registration flow, so
+this plugin keeps the channel implementation in one place and contributes the
+official defaults that differ from a bare Hermes DingTalk config.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import mimetypes
+import os
+import re
+from pathlib import Path
+from typing import Any, Callable
+from uuid import uuid4
+
+PLATFORM_NAME = "dingtalk"
+OFFICIAL_CARD_TEMPLATE_ID = "02fcf2f4-5e02-4a85-b672-46d1f715543e.schema"
+DINGTALK_API = "https://api.dingtalk.com"
+DINGTALK_OAPI = "https://oapi.dingtalk.com"
+MAX_MEDIA_UPLOAD_BYTES = 20 * 1024 * 1024
+IMAGE_EXTENSIONS = frozenset({".gif", ".jpeg", ".jpg", ".png", ".webp"})
+_OFFICIAL_ADAPTER_CLASS: type | None = None
+CHATBOT_ID_PATTERN = re.compile(r"\$:LWCP_v1:\$[A-Za-z0-9+/=]+")
+logger = logging.getLogger(__name__)
+
+
+DINGTALK_OFFICIAL_SEND_SCHEMA: dict[str, Any] = {
+    "name": "dingtalk_official_send",
+    "description": (
+        "Send a proactive DingTalk robot message through the official robot "
+        "OpenAPI to a DingTalk user or group. Use this for DingTalk delivery "
+        "that is not a reply to the current inbound message, and for local "
+        "image or file attachments."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "target_type": {
+                "type": "string",
+                "enum": ["user", "group"],
+                "description": "Whether target_id is a DingTalk staff_id or group open conversation ID.",
+            },
+            "target_id": {
+                "type": "string",
+                "description": "DingTalk staff_id for user sends or group openConversationId.",
+            },
+            "content": {
+                "type": "string",
+                "description": "Optional text or Markdown content to send before any attachment.",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["auto", "text", "markdown"],
+                "description": "Content message format. Default auto.",
+            },
+            "title": {
+                "type": "string",
+                "description": "Markdown title when format resolves to markdown.",
+            },
+            "file_path": {
+                "type": "string",
+                "description": "Optional local image or file path to upload and send.",
+            },
+            "file_kind": {
+                "type": "string",
+                "enum": ["auto", "image", "file"],
+                "description": "Attachment kind. Default auto by file extension.",
+            },
+            "at_accounts": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional configured DingTalk bot account IDs or aliases "
+                    "to @. Resolved through DINGTALK_BOT_MENTIONS or "
+                    "platforms.dingtalk.extra.bot_mentions."
+                ),
+            },
+            "at_dingtalk_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional encrypted DingTalk chatbotUserId values to @.",
+            },
+            "at_user_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional DingTalk staff/user IDs to visibly @ in text content.",
+            },
+            "at_all": {
+                "type": "boolean",
+                "description": "Append @all to text content when supported by the target conversation.",
+            },
+        },
+        "required": ["target_type", "target_id"],
+        "additionalProperties": False,
+    },
+}
+
+
+DINGTALK_OFFICIAL_MENTIONS_SCHEMA: dict[str, Any] = {
+    "name": "dingtalk_official_mentions",
+    "description": (
+        "List DingTalk bot mention aliases configured for multi-bot handoff "
+        "and report which entries have chatbotUserId values ready."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+}
+
+
+def _load_hermes_dingtalk() -> tuple[type, Callable[[], bool]]:
+    """Load the Hermes adapter lazily so plugin metadata can be inspected alone."""
+    from gateway.platforms.dingtalk import DingTalkAdapter, check_dingtalk_requirements
+
+    return DingTalkAdapter, check_dingtalk_requirements
+
+
+def _extra(config: Any) -> dict[str, Any]:
+    return dict(getattr(config, "extra", {}) or {})
+
+
+def _has_credentials(config: Any) -> bool:
+    extra = _extra(config)
+    return bool(
+        (extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID"))
+        and (extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET"))
+    )
+
+
+def _apply_official_defaults(config: Any) -> Any:
+    """Set official defaults while preserving user-provided Hermes extras."""
+    extra = _extra(config)
+    account_id = os.getenv("DINGTALK_ACCOUNT_ID", "").strip()
+    if account_id:
+        extra.setdefault("account_id", account_id)
+
+    extra.setdefault(
+        "card_template_id",
+        os.getenv("DINGTALK_CARD_TEMPLATE_ID") or OFFICIAL_CARD_TEMPLATE_ID,
+    )
+
+    robot_code = os.getenv("DINGTALK_ROBOT_CODE") or extra.get("client_id")
+    if robot_code:
+        extra.setdefault("robot_code", robot_code)
+
+    if "suppress_intermediate" not in extra:
+        env_value = os.getenv("DINGTALK_SUPPRESS_INTERMEDIATE", "").strip()
+        show_activity = os.getenv("DINGTALK_SHOW_ACTIVITY", "").strip()
+        extra["suppress_intermediate"] = (
+            not _boolish(show_activity, default=False)
+            if show_activity
+            else _boolish(env_value, default=True)
+        )
+
+    config.extra = extra
+    return config
+
+
+def _send_result(*, success: bool, message_id: str | None = None, error: str | None = None, raw_response: Any = None):
+    from gateway.platforms.base import SendResult
+
+    return SendResult(
+        success=success,
+        message_id=message_id,
+        error=error,
+        raw_response=raw_response,
+    )
+
+
+def _parse_proactive_target(chat_id: str | None) -> dict[str, str] | None:
+    """Parse explicit Hermes chat IDs for non-session DingTalk sends."""
+    raw = str(chat_id or "").strip()
+    lowered = raw.lower()
+    for prefix, target_type in (("user:", "user"), ("group:", "group")):
+        if lowered.startswith(prefix):
+            target_id = raw[len(prefix) :].strip()
+            if target_id:
+                return {"type": target_type, "id": target_id}
+    return None
+
+
+def _metadata_target(metadata: dict[str, Any] | None) -> dict[str, str] | None:
+    if not metadata:
+        return None
+    raw = metadata.get("dingtalk_target") or metadata.get("proactive_target")
+    if isinstance(raw, str):
+        return _parse_proactive_target(raw)
+    target_type = str(metadata.get("dingtalk_target_type") or "").strip().lower()
+    target_id = str(metadata.get("dingtalk_target_id") or "").strip()
+    if target_type in {"user", "group"} and target_id:
+        return {"type": target_type, "id": target_id}
+    return None
+
+
+def _metadata_session_webhook(metadata: dict[str, Any] | None) -> str:
+    if not metadata:
+        return ""
+    return str(metadata.get("session_webhook") or "").strip()
+
+
+def _metadata_force_send(metadata: dict[str, Any] | None) -> bool:
+    if not metadata:
+        return False
+    return any(
+        _boolish(metadata.get(key), default=False)
+        for key in (
+            "dingtalk_force_send",
+            "force_send",
+            "deliver_intermediate",
+            "show_activity",
+        )
+    )
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _boolish(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if not text:
+        return default
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _metadata_at_options(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    if not metadata:
+        return {}
+    return {
+        "at_accounts": (
+            metadata.get("dingtalk_at_accounts")
+            or metadata.get("at_accounts")
+            or metadata.get("at_bot_accounts")
+        ),
+        "at_dingtalk_ids": (
+            metadata.get("dingtalk_at_dingtalk_ids")
+            or metadata.get("at_dingtalk_ids")
+        ),
+        "at_user_ids": metadata.get("dingtalk_at_user_ids") or metadata.get("at_user_ids"),
+        "at_all": _truthy(metadata.get("dingtalk_at_all") or metadata.get("at_all")),
+    }
+
+
+def _message_context_target(message: Any, chat_id: str) -> dict[str, str] | None:
+    if message is None:
+        return None
+    if str(getattr(message, "conversation_type", "1")) == "2":
+        conversation_id = str(getattr(message, "conversation_id", "") or chat_id).strip()
+        return {"type": "group", "id": conversation_id} if conversation_id else None
+
+    sender_staff_id = str(getattr(message, "sender_staff_id", "") or "").strip()
+    return {"type": "user", "id": sender_staff_id} if sender_staff_id else None
+
+
+def _looks_like_markdown(content: str) -> bool:
+    return bool(
+        "\n" in content
+        or any(marker in content for marker in ("#", "*", "_", "`", "[", "]", ">"))
+    )
+
+
+def _markdown_title(content: str, title: str | None = None) -> str:
+    if title and title.strip():
+        return title.strip()[:100]
+    first_line = next((line.strip(" #*>-_") for line in content.splitlines() if line.strip()), "")
+    return first_line[:20] or "Hermes"
+
+
+def _build_message_payload(
+    msg_type: str,
+    content: str,
+    *,
+    title: str | None = None,
+    file_name: str | None = None,
+) -> dict[str, str]:
+    """Build DingTalk's normal robot-message template payload."""
+    normalized = msg_type.strip().lower()
+    if normalized == "markdown":
+        msg_key = "sampleMarkdown"
+        msg_param = {"title": _markdown_title(content, title), "text": content}
+    elif normalized == "image":
+        msg_key = "sampleImageMsg"
+        msg_param = {"photoURL": content}
+    elif normalized == "file":
+        resolved_name = file_name or "attachment"
+        msg_key = "sampleFile"
+        msg_param = {
+            "mediaId": content,
+            "fileName": resolved_name,
+            "fileType": Path(resolved_name).suffix.lstrip(".") or "file",
+        }
+    else:
+        msg_key = "sampleText"
+        msg_param = {"content": content}
+    return {"msgKey": msg_key, "msgParam": json.dumps(msg_param, ensure_ascii=False)}
+
+
+def _session_image_markdown(uploaded: dict[str, str], caption: str | None = None) -> str:
+    """Build the session-webhook Markdown image form used by the connector."""
+    image_markdown = f"![image]({uploaded['media_id']})"
+    return f"{caption}\n\n{image_markdown}" if caption else image_markdown
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+        if raw.startswith("["):
+            try:
+                parsed = json.loads(raw)
+            except Exception:
+                parsed = None
+            if isinstance(parsed, list):
+                return _coerce_string_list(parsed)
+        return [part.strip() for part in re.split(r"[\n,]", raw) if part.strip()]
+    text = str(value).strip()
+    return [text] if text else []
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if text and text not in seen:
+            seen.add(text)
+            out.append(text)
+    return out
+
+
+def _load_jsonish(raw: Any) -> Any:
+    if not isinstance(raw, str):
+        return raw
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except Exception:
+        return raw
+
+
+def _bot_entry_from_mapping(account_id: str, data: Any) -> dict[str, Any]:
+    item = data if isinstance(data, dict) else {"chatbotUserId": data}
+    resolved_id = str(
+        item.get("account_id")
+        or item.get("accountId")
+        or item.get("id")
+        or account_id
+        or ""
+    ).strip()
+    name = str(item.get("name") or item.get("label") or "").strip()
+    chatbot_user_id = str(
+        item.get("chatbot_user_id")
+        or item.get("chatbotUserId")
+        or item.get("dingtalk_id")
+        or item.get("dingtalkId")
+        or ""
+    ).strip()
+    agent_ids = _coerce_string_list(item.get("agent_ids") or item.get("agentIds"))
+    aliases = _coerce_string_list(item.get("aliases") or item.get("alias"))
+
+    alias_candidates = [resolved_id, name, *agent_ids, *aliases]
+    return {
+        "account_id": resolved_id,
+        "name": name,
+        "chatbot_user_id": chatbot_user_id,
+        "agent_ids": _dedupe_strings(agent_ids),
+        "aliases": _dedupe_strings(alias_candidates),
+    }
+
+
+def _entries_from_openclaw_shape(raw: dict[str, Any]) -> list[dict[str, Any]]:
+    root = raw.get("channels", {}).get("dingtalk-connector")
+    if not isinstance(root, dict):
+        root = raw
+    accounts = root.get("accounts")
+    if not isinstance(accounts, dict):
+        return []
+
+    entries_by_account = {
+        str(account_id): _bot_entry_from_mapping(str(account_id), account)
+        for account_id, account in accounts.items()
+        if str(account_id).strip()
+    }
+
+    bindings = raw.get("bindings")
+    if not isinstance(bindings, list):
+        bindings = root.get("bindings")
+    if isinstance(bindings, list):
+        for binding in bindings:
+            if not isinstance(binding, dict):
+                continue
+            match = binding.get("match")
+            if not isinstance(match, dict):
+                continue
+            if match.get("channel") and match.get("channel") != "dingtalk-connector":
+                continue
+            account_id = str(match.get("accountId") or match.get("account_id") or "").strip()
+            agent_id = str(binding.get("agentId") or binding.get("agent_id") or "").strip()
+            entry = entries_by_account.get(account_id)
+            if entry and agent_id:
+                entry["agent_ids"] = _dedupe_strings([*entry["agent_ids"], agent_id])
+                entry["aliases"] = _dedupe_strings([*entry["aliases"], agent_id])
+
+    return list(entries_by_account.values())
+
+
+def _normalize_bot_mention_entries(raw: Any) -> list[dict[str, Any]]:
+    data = _load_jsonish(raw)
+    if data is None:
+        return []
+    if isinstance(data, dict) and (
+        "accounts" in data or "channels" in data
+    ):
+        return _entries_from_openclaw_shape(data)
+    if isinstance(data, dict):
+        return [
+            _bot_entry_from_mapping(str(account_id), item)
+            for account_id, item in data.items()
+            if str(account_id).strip()
+        ]
+    if isinstance(data, list):
+        entries = []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            account_id = str(
+                item.get("account_id") or item.get("accountId") or item.get("id") or ""
+            ).strip()
+            if account_id:
+                entries.append(_bot_entry_from_mapping(account_id, item))
+        return entries
+    return []
+
+
+def _configured_bot_mentions(config_or_extra: Any = None) -> list[dict[str, Any]]:
+    extra = config_or_extra if isinstance(config_or_extra, dict) else _extra(config_or_extra)
+    sources: list[Any] = []
+
+    env_mentions = os.getenv("DINGTALK_BOT_MENTIONS", "").strip()
+    if env_mentions:
+        sources.append(env_mentions)
+
+    for key in ("bot_mentions", "botMentions"):
+        if key in extra:
+            sources.append(extra.get(key))
+
+    if "accounts" in extra:
+        sources.append({"accounts": extra.get("accounts"), "bindings": extra.get("bindings")})
+
+    merged: list[dict[str, Any]] = []
+    for source in sources:
+        merged.extend(_normalize_bot_mention_entries(source))
+    return merged
+
+
+def _bot_alias_map(config_or_extra: Any = None) -> dict[str, str]:
+    alias_map: dict[str, str] = {}
+    for entry in _configured_bot_mentions(config_or_extra):
+        chatbot_user_id = str(entry.get("chatbot_user_id") or "").strip()
+        if not chatbot_user_id:
+            continue
+        for alias in _coerce_string_list(entry.get("aliases")):
+            alias_map.setdefault(alias.lower(), chatbot_user_id)
+    return alias_map
+
+
+def _resolve_at_accounts(
+    at_accounts: Any,
+    config_or_extra: Any = None,
+) -> tuple[list[str], list[str]]:
+    if not at_accounts:
+        return [], []
+    alias_map = _bot_alias_map(config_or_extra)
+    resolved: list[str] = []
+    missing: list[str] = []
+    for account in _coerce_string_list(at_accounts):
+        chatbot_user_id = alias_map.get(account.lower())
+        if chatbot_user_id:
+            resolved.append(chatbot_user_id)
+        else:
+            missing.append(account)
+    return _dedupe_strings(resolved), missing
+
+
+def _substitute_bot_mentions(
+    text: str,
+    config_or_extra: Any = None,
+) -> tuple[str, list[str]]:
+    if not text:
+        return text or "", []
+    alias_map = _bot_alias_map(config_or_extra)
+    if not alias_map:
+        return text, _dedupe_strings(CHATBOT_ID_PATTERN.findall(text))
+
+    injected: list[str] = []
+    out = text
+    for alias in sorted(alias_map, key=len, reverse=True):
+        chatbot_user_id = alias_map[alias]
+        pattern = re.compile(
+            rf"@{re.escape(alias)}(?![A-Za-z0-9_\u4e00-\u9fff-])",
+            re.IGNORECASE,
+        )
+
+        def replace(_match: re.Match[str]) -> str:
+            injected.append(chatbot_user_id)
+            return f"@{chatbot_user_id}"
+
+        out = pattern.sub(replace, out)
+
+    injected.extend(CHATBOT_ID_PATTERN.findall(out))
+    return out, _dedupe_strings(injected)
+
+
+def _prepare_multi_bot_mentions(
+    content: str,
+    *,
+    config_or_extra: Any = None,
+    at_accounts: Any = None,
+    at_dingtalk_ids: Any = None,
+) -> dict[str, Any]:
+    resolved_accounts, missing_accounts = _resolve_at_accounts(at_accounts, config_or_extra)
+    substituted, injected_ids = _substitute_bot_mentions(content, config_or_extra)
+    explicit_ids = _coerce_string_list(at_dingtalk_ids)
+    merged_ids = _dedupe_strings([*explicit_ids, *resolved_accounts, *injected_ids])
+
+    final_content = substituted
+    for chatbot_user_id in _dedupe_strings([*explicit_ids, *resolved_accounts]):
+        marker = f"@{chatbot_user_id}"
+        if marker not in final_content:
+            final_content = f"{final_content} {marker}".strip()
+
+    return {
+        "content": final_content,
+        "at_dingtalk_ids": merged_ids,
+        "missing_accounts": missing_accounts,
+    }
+
+
+def _append_visible_mentions(
+    content: str,
+    *,
+    at_dingtalk_ids: Any = None,
+    at_user_ids: Any = None,
+    at_all: bool = False,
+) -> str:
+    final_content = content or ""
+    for mention_id in _dedupe_strings(
+        [*_coerce_string_list(at_dingtalk_ids), *_coerce_string_list(at_user_ids)]
+    ):
+        marker = f"@{mention_id}"
+        if marker not in final_content:
+            final_content = f"{final_content} {marker}".strip()
+    if at_all and "@all" not in final_content:
+        final_content = f"{final_content} @all".strip()
+    return final_content
+
+
+def _display_bot_mention_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    account_id = str(entry.get("account_id") or "").strip()
+    chatbot_user_id = str(entry.get("chatbot_user_id") or "").strip()
+    aliases = _coerce_string_list(entry.get("aliases"))
+    return {
+        "account_id": account_id,
+        "name": str(entry.get("name") or account_id).strip(),
+        "agent_ids": _coerce_string_list(entry.get("agent_ids")),
+        "aliases": aliases,
+        "chatbotUserId": chatbot_user_id or None,
+        "mentionReady": bool(chatbot_user_id),
+    }
+
+
+def _bot_mentions_report(config_or_extra: Any = None) -> dict[str, Any]:
+    entries = [_display_bot_mention_entry(entry) for entry in _configured_bot_mentions(config_or_extra)]
+    ready = [entry for entry in entries if entry["mentionReady"]]
+    missing = [entry["account_id"] for entry in entries if not entry["mentionReady"]]
+
+    report_lines = [
+        f"[BotIdentity] configured={len(entries)} ready={len(ready)} missing={len(missing)}"
+    ]
+    if ready:
+        report_lines.append(
+            "[OK] Ready: "
+            + ", ".join(
+                f"{entry['account_id']}({', '.join(entry['aliases'])})"
+                for entry in ready
+            )
+        )
+    if missing:
+        report_lines.append(
+            "[WARN] Missing chatbotUserId: "
+            + ", ".join(missing)
+            + ". Send a DingTalk message to each bot and copy the [BotIdentity] log value."
+        )
+    if not entries:
+        report_lines.append(
+            "[INFO] No bot mention aliases configured. Set DINGTALK_BOT_MENTIONS "
+            "or platforms.dingtalk.extra.bot_mentions."
+        )
+
+    return {
+        "ready": bool(entries) and not missing,
+        "totalAccounts": len(entries),
+        "readyAccounts": len(ready),
+        "missingChatbotUserId": missing,
+        "accounts": entries,
+        "report": "\n".join(report_lines),
+    }
+
+
+def _response_json(response: Any) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except Exception:
+        payload = {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _response_excerpt(response: Any) -> str:
+    body = str(getattr(response, "text", "") or "").strip()
+    return body[:200] or "empty response"
+
+
+def _proactive_send_error(response: Any) -> str:
+    payload = _response_json(response)
+    code = str(payload.get("code") or "").strip()
+    message = str(payload.get("message") or "").strip()
+    excerpt = _response_excerpt(response)
+
+    if code == "staffId.notExisted":
+        return (
+            "DingTalk proactive user send failed: target_id must be a DingTalk "
+            "staff_id available to this bot and organization; a Hermes sender_id "
+            f"is not interchangeable. DingTalk response: {excerpt}"
+        )
+    if code == "resource.not.found" and ("robot" in message.lower() or "机器人" in message):
+        return (
+            "DingTalk proactive send failed: DingTalk did not find robotCode. "
+            "Check DINGTALK_ROBOT_CODE or platforms.dingtalk.extra.robot_code, "
+            "and verify that these credentials belong to a robot-enabled DingTalk "
+            f"app. DingTalk response: {excerpt}"
+        )
+    return f"DingTalk proactive send failed: {excerpt}"
+
+
+async def _api_access_token(http_client: Any, client_id: str, client_secret: str) -> str:
+    response = await http_client.post(
+        f"{DINGTALK_API}/v1.0/oauth2/accessToken",
+        json={"appKey": client_id, "appSecret": client_secret},
+        timeout=15.0,
+    )
+    payload = _response_json(response)
+    token = str(payload.get("accessToken") or "").strip()
+    if getattr(response, "status_code", 500) >= 300 or not token:
+        raise RuntimeError(f"DingTalk access token request failed: {_response_excerpt(response)}")
+    return token
+
+
+async def _oapi_access_token(http_client: Any, client_id: str, client_secret: str) -> str:
+    response = await http_client.get(
+        f"{DINGTALK_OAPI}/gettoken",
+        params={"appkey": client_id, "appsecret": client_secret},
+        timeout=15.0,
+    )
+    payload = _response_json(response)
+    token = str(payload.get("access_token") or "").strip()
+    if (
+        getattr(response, "status_code", 500) >= 300
+        or payload.get("errcode") not in (0, "0", None)
+        or not token
+    ):
+        raise RuntimeError(f"DingTalk OAPI token request failed: {_response_excerpt(response)}")
+    return token
+
+
+async def _upload_local_media(
+    http_client: Any,
+    client_id: str,
+    client_secret: str,
+    file_path: str,
+    media_type: str,
+) -> dict[str, str]:
+    """Upload a local file through DingTalk OAPI media/upload."""
+    path = Path(file_path).expanduser()
+    if not path.is_file():
+        raise RuntimeError(f"Local file does not exist: {path}")
+    if path.stat().st_size > MAX_MEDIA_UPLOAD_BYTES:
+        raise RuntimeError("DingTalk local media upload is limited to 20 MB in this plugin")
+
+    upload_type = "image" if media_type == "image" else "file"
+    token = await _oapi_access_token(http_client, client_id, client_secret)
+    content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    with path.open("rb") as handle:
+        response = await http_client.post(
+            f"{DINGTALK_OAPI}/media/upload",
+            params={"access_token": token, "type": upload_type},
+            files={"media": (path.name, handle, content_type)},
+            timeout=60.0,
+        )
+    payload = _response_json(response)
+    media_id = str(payload.get("media_id") or "").strip()
+    if getattr(response, "status_code", 500) >= 300 or not media_id:
+        raise RuntimeError(f"DingTalk media upload failed: {_response_excerpt(response)}")
+    clean_media_id = media_id[1:] if media_id.startswith("@") else media_id
+    return {
+        "media_id": media_id,
+        "download_url": f"https://down.dingtalk.com/media/{clean_media_id}",
+        "file_name": path.name,
+    }
+
+
+async def _send_proactive_payload(
+    http_client: Any,
+    *,
+    client_id: str,
+    client_secret: str,
+    robot_code: str,
+    target: dict[str, str],
+    payload: dict[str, str],
+) -> dict[str, Any]:
+    token = await _api_access_token(http_client, client_id, client_secret)
+    target_type = target.get("type")
+    target_id = str(target.get("id") or "").strip()
+    if target_type == "user":
+        endpoint = f"{DINGTALK_API}/v1.0/robot/oToMessages/batchSend"
+        target_body = {"userIds": [target_id]}
+    elif target_type == "group":
+        endpoint = f"{DINGTALK_API}/v1.0/robot/groupMessages/send"
+        target_body = {"openConversationId": target_id}
+    else:
+        raise RuntimeError("DingTalk proactive target must be a user or group")
+    if not target_id:
+        raise RuntimeError("DingTalk proactive target ID is required")
+
+    body = {"robotCode": robot_code or client_id, **target_body, **payload}
+    response = await http_client.post(
+        endpoint,
+        json=body,
+        headers={
+            "x-acs-dingtalk-access-token": token,
+            "Content-Type": "application/json",
+        },
+        timeout=15.0,
+    )
+    data = _response_json(response)
+    if getattr(response, "status_code", 500) >= 300 or data.get("success") is False:
+        raise RuntimeError(_proactive_send_error(response))
+    return data
+
+
+class _OfficialDingTalkMixin:
+    """Official-connector send features layered onto Hermes DingTalk."""
+
+    @property
+    def SUPPORTS_MESSAGE_EDITING(self) -> bool:  # noqa: N802
+        if self._official_suppress_intermediate():
+            return False
+        return bool(getattr(super(), "SUPPORTS_MESSAGE_EDITING", True))
+
+    @property
+    def REQUIRES_EDIT_FINALIZE(self) -> bool:  # noqa: N802
+        if self._official_suppress_intermediate():
+            return False
+        return bool(getattr(super(), "REQUIRES_EDIT_FINALIZE", False))
+
+    def _official_suppress_intermediate(self) -> bool:
+        extra = _extra(getattr(self, "config", None))
+        show_activity = os.getenv("DINGTALK_SHOW_ACTIVITY", "").strip()
+        if show_activity:
+            return not _boolish(show_activity, default=False)
+        env_value = os.getenv("DINGTALK_SUPPRESS_INTERMEDIATE", "").strip()
+        if env_value:
+            return _boolish(env_value, default=True)
+        return _boolish(extra.get("suppress_intermediate"), default=True)
+
+    def _should_suppress_intermediate_send(
+        self,
+        chat_id: str,
+        reply_to: str | None,
+        metadata: dict[str, Any] | None,
+    ) -> bool:
+        if not self._official_suppress_intermediate():
+            return False
+        if reply_to is not None:
+            return False
+        if _metadata_force_send(metadata):
+            return False
+        if _metadata_target(metadata) or _parse_proactive_target(chat_id):
+            return False
+        return True
+
+    def _official_account_id(self) -> str:
+        extra = _extra(getattr(self, "config", None))
+        return (
+            str(extra.get("account_id") or "").strip()
+            or os.getenv("DINGTALK_ACCOUNT_ID", "").strip()
+            or str(getattr(self, "_robot_code", "") or "").strip()
+            or str(getattr(self, "_client_id", "") or "").strip()
+            or "dingtalk"
+        )
+
+    def _record_bot_identity(self, message: Any) -> None:
+        chatbot_user_id = str(
+            getattr(message, "chatbot_user_id", None)
+            or getattr(message, "chatbotUserId", None)
+            or ""
+        ).strip()
+        chatbot_corp_id = str(
+            getattr(message, "chatbot_corp_id", None)
+            or getattr(message, "chatbotCorpId", None)
+            or ""
+        ).strip()
+        if not (chatbot_user_id or chatbot_corp_id):
+            return
+
+        identity = {
+            "accountId": self._official_account_id(),
+            "chatbotUserId": chatbot_user_id or None,
+            "chatbotCorpId": chatbot_corp_id or None,
+        }
+        if getattr(self, "_official_last_bot_identity", None) == identity:
+            return
+        self._official_last_bot_identity = identity
+        line = (
+            f"[DingTalk:{identity['accountId']}] [BotIdentity] "
+            f"accountId={identity['accountId']} "
+            f"chatbotUserId={chatbot_user_id or 'N/A'} "
+            f"chatbotCorpId={chatbot_corp_id or 'N/A'}"
+        )
+        logger.info(line)
+        print(line, flush=True)
+
+    async def _on_message(self, message: Any) -> None:
+        self._record_bot_identity(message)
+        await super()._on_message(message)
+
+    def _official_target(self, chat_id: str, metadata: dict[str, Any] | None = None) -> dict[str, str] | None:
+        explicit = _metadata_target(metadata) or _parse_proactive_target(chat_id)
+        if explicit:
+            return explicit
+        return _message_context_target(self._message_contexts.get(chat_id), chat_id)
+
+    async def _official_send_payload(self, target: dict[str, str], payload: dict[str, str]):
+        if not self._http_client:
+            return _send_result(success=False, error="HTTP client not initialized")
+        try:
+            raw = await _send_proactive_payload(
+                self._http_client,
+                client_id=self._client_id,
+                client_secret=self._client_secret,
+                robot_code=self._robot_code,
+                target=target,
+                payload=payload,
+            )
+        except Exception as exc:
+            return _send_result(success=False, error=str(exc))
+        message_id = str(raw.get("processQueryKey") or raw.get("messageId") or uuid4().hex[:12])
+        return _send_result(success=True, message_id=message_id, raw_response=raw)
+
+    async def _official_upload(self, file_path: str, media_type: str):
+        if not self._http_client:
+            raise RuntimeError("HTTP client not initialized")
+        return await _upload_local_media(
+            self._http_client,
+            self._client_id,
+            self._client_secret,
+            file_path,
+            media_type,
+        )
+
+    def _official_session_webhook(self, chat_id: str, metadata: dict[str, Any] | None = None) -> str:
+        webhook = _metadata_session_webhook(metadata)
+        if webhook:
+            return webhook
+        getter = getattr(self, "_get_valid_webhook", None)
+        if not getter:
+            return ""
+        webhook_info = getter(chat_id)
+        if not webhook_info:
+            return ""
+        return str(webhook_info[0] or "").strip()
+
+    async def _official_session_token(self) -> str:
+        token_getter = getattr(self, "_get_access_token", None)
+        token = ""
+        if token_getter:
+            token = str(await token_getter() or "").strip()
+        if token:
+            return token
+        if not self._http_client:
+            raise RuntimeError("HTTP client not initialized")
+        return await _api_access_token(self._http_client, self._client_id, self._client_secret)
+
+    async def _official_send_session_media(
+        self,
+        chat_id: str,
+        uploaded: dict[str, str],
+        *,
+        media_kind: str,
+        file_name: str,
+        metadata: dict[str, Any] | None = None,
+    ):
+        if not self._http_client:
+            return _send_result(success=False, error="HTTP client not initialized")
+        session_webhook = self._official_session_webhook(chat_id, metadata)
+        if not session_webhook:
+            return _send_result(
+                success=False,
+                error="No valid DingTalk session_webhook available for file reply.",
+            )
+
+        try:
+            token = await self._official_session_token()
+            media_field = "image" if media_kind == "image" else "file"
+            media_payload = {"media_id": uploaded["media_id"]}
+            if media_kind == "file":
+                media_payload.update(
+                    {
+                        "fileName": file_name,
+                        "fileType": Path(file_name).suffix.lstrip(".") or "file",
+                    }
+                )
+            response = await self._http_client.post(
+                session_webhook,
+                json={
+                    "msgtype": media_kind,
+                    media_field: media_payload,
+                },
+                headers={
+                    "x-acs-dingtalk-access-token": token,
+                    "Content-Type": "application/json",
+                },
+                timeout=15.0,
+            )
+            data = _response_json(response)
+            if getattr(response, "status_code", 500) >= 300 or data.get("success") is False:
+                return _send_result(
+                    success=False,
+                    error=f"DingTalk session {media_kind} send failed: {_response_excerpt(response)}",
+                    raw_response=data,
+                )
+        except Exception as exc:
+            return _send_result(success=False, error=str(exc))
+
+        return _send_result(
+            success=True,
+            message_id=str(data.get("processQueryKey") or data.get("messageId") or uuid4().hex[:12]),
+            raw_response=data,
+        )
+
+    async def _official_send_session_text(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        at_dingtalk_ids: list[str] | None = None,
+        at_user_ids: list[str] | None = None,
+        at_all: bool = False,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ):
+        if not self._http_client:
+            return _send_result(success=False, error="HTTP client not initialized")
+        session_webhook = self._official_session_webhook(chat_id, metadata)
+        if not session_webhook:
+            return _send_result(
+                success=False,
+                error="No valid DingTalk session_webhook available for text reply.",
+            )
+
+        close_cards = getattr(self, "_close_streaming_siblings", None)
+        if close_cards:
+            await close_cards(chat_id)
+
+        normalizer = getattr(self, "_normalize_markdown", None)
+        trimmed = content[: self.MAX_MESSAGE_LENGTH]
+        normalized = normalizer(trimmed) if normalizer else trimmed
+        payload: dict[str, Any] = {
+            "msgtype": "markdown",
+            "markdown": {"title": "Hermes", "text": normalized},
+        }
+
+        dingtalk_ids = _dedupe_strings(at_dingtalk_ids or [])
+        user_ids = _dedupe_strings(at_user_ids or [])
+        if dingtalk_ids or user_ids or at_all:
+            payload["at"] = {
+                **({"atUserIds": user_ids} if user_ids else {}),
+                **({"atDingtalkIds": dingtalk_ids} if dingtalk_ids else {}),
+                "isAtAll": bool(at_all),
+            }
+
+        headers = {"Content-Type": "application/json"}
+        try:
+            token = await self._official_session_token()
+            if token:
+                headers["x-acs-dingtalk-access-token"] = token
+        except Exception:
+            pass
+
+        try:
+            response = await self._http_client.post(
+                session_webhook,
+                json=payload,
+                headers=headers,
+                timeout=15.0,
+            )
+            data = _response_json(response)
+            if getattr(response, "status_code", 500) >= 300 or data.get("success") is False:
+                return _send_result(
+                    success=False,
+                    error=f"DingTalk session text send failed: {_response_excerpt(response)}",
+                    raw_response=data,
+                )
+        except Exception as exc:
+            return _send_result(success=False, error=str(exc))
+
+        if reply_to is not None:
+            done = getattr(self, "_fire_done_reaction", None)
+            if done:
+                done(chat_id)
+        return _send_result(
+            success=True,
+            message_id=str(data.get("processQueryKey") or data.get("messageId") or uuid4().hex[:12]),
+            raw_response=data,
+        )
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ):
+        target = _metadata_target(metadata) or _parse_proactive_target(chat_id)
+        if self._should_suppress_intermediate_send(chat_id, reply_to, metadata):
+            logger.debug(
+                "[%s] Suppressed DingTalk intermediate activity message for chat_id=%s",
+                getattr(self, "name", "dingtalk"),
+                chat_id,
+            )
+            return _send_result(
+                success=True,
+                raw_response={"suppressed": True, "reason": "intermediate_activity"},
+            )
+
+        at_options = _metadata_at_options(metadata)
+        prepared = _prepare_multi_bot_mentions(
+            content,
+            config_or_extra=getattr(self, "config", None),
+            at_accounts=at_options.get("at_accounts"),
+            at_dingtalk_ids=at_options.get("at_dingtalk_ids"),
+        )
+        at_user_ids = _coerce_string_list(at_options.get("at_user_ids"))
+        prepared_content = _append_visible_mentions(
+            prepared["content"],
+            at_dingtalk_ids=prepared["at_dingtalk_ids"],
+            at_user_ids=at_user_ids,
+            at_all=bool(at_options.get("at_all")),
+        )
+        if target:
+            msg_type = "markdown" if _looks_like_markdown(content) else "text"
+            return await self._official_send_payload(
+                target,
+                _build_message_payload(
+                    msg_type,
+                    prepared_content[: self.MAX_MESSAGE_LENGTH],
+                    title=(metadata or {}).get("title"),
+                ),
+            )
+        if (
+            prepared["at_dingtalk_ids"]
+            or at_user_ids
+            or at_options.get("at_all")
+        ):
+            return await self._official_send_session_text(
+                chat_id,
+                prepared_content,
+                at_dingtalk_ids=prepared["at_dingtalk_ids"],
+                at_user_ids=at_user_ids,
+                at_all=bool(at_options.get("at_all")),
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        return await super().send(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ):
+        explicit_target = _metadata_target(metadata) or _parse_proactive_target(chat_id)
+        current_message = self._message_contexts.get(chat_id)
+        target = explicit_target or _message_context_target(current_message, chat_id)
+        if not target:
+            return _send_result(
+                success=False,
+                error="Local DingTalk images need an inbound message context or user:/group: target.",
+            )
+        try:
+            uploaded = await self._official_upload(image_path, "image")
+        except Exception as exc:
+            return _send_result(success=False, error=str(exc))
+        if current_message is not None and not explicit_target:
+            # The official connector renders local reply images through the
+            # session Markdown form after OAPI upload. Proactive robot sends
+            # still use sampleImageMsg below.
+            return await self._official_send_session_text(
+                chat_id,
+                _session_image_markdown(uploaded, caption)[: self.MAX_MESSAGE_LENGTH],
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        if caption:
+            caption_mentions = _prepare_multi_bot_mentions(
+                caption,
+                config_or_extra=getattr(self, "config", None),
+            )
+            caption_result = await self._official_send_payload(
+                target,
+                _build_message_payload(
+                    "text",
+                    caption_mentions["content"][: self.MAX_MESSAGE_LENGTH],
+                ),
+            )
+            if not caption_result.success:
+                return caption_result
+        return await self._official_send_payload(
+            target,
+            _build_message_payload("image", uploaded["media_id"]),
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ):
+        explicit_target = _metadata_target(metadata) or _parse_proactive_target(chat_id)
+        current_message = self._message_contexts.get(chat_id)
+        target = explicit_target or _message_context_target(current_message, chat_id)
+        if not target:
+            return _send_result(
+                success=False,
+                error="Local DingTalk files need an inbound message context, session_webhook, or user:/group: target.",
+            )
+        try:
+            uploaded = await self._official_upload(file_path, "file")
+        except Exception as exc:
+            return _send_result(success=False, error=str(exc))
+        resolved_file_name = file_name or uploaded["file_name"]
+        if current_message is not None and not explicit_target:
+            if caption:
+                caption_result = await self.send(
+                    chat_id,
+                    caption[: self.MAX_MESSAGE_LENGTH],
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+                if not caption_result.success:
+                    return caption_result
+            session_result = await self._official_send_session_media(
+                chat_id,
+                uploaded,
+                media_kind="file",
+                file_name=resolved_file_name,
+                metadata=metadata,
+            )
+            if session_result.success or "session_webhook" not in str(session_result.error):
+                return session_result
+        if caption:
+            caption_mentions = _prepare_multi_bot_mentions(
+                caption,
+                config_or_extra=getattr(self, "config", None),
+            )
+            caption_result = await self._official_send_payload(
+                target,
+                _build_message_payload(
+                    "text",
+                    caption_mentions["content"][: self.MAX_MESSAGE_LENGTH],
+                ),
+            )
+            if not caption_result.success:
+                return caption_result
+        return await self._official_send_payload(
+            target,
+            _build_message_payload(
+                "file",
+                uploaded["media_id"],
+                file_name=resolved_file_name,
+            ),
+        )
+
+
+def _official_adapter_class() -> type:
+    global _OFFICIAL_ADAPTER_CLASS
+    if _OFFICIAL_ADAPTER_CLASS is None:
+        DingTalkAdapter, _ = _load_hermes_dingtalk()
+        _OFFICIAL_ADAPTER_CLASS = type(
+            "OfficialDingTalkAdapter",
+            (_OfficialDingTalkMixin, DingTalkAdapter),
+            {},
+        )
+    return _OFFICIAL_ADAPTER_CLASS
+
+
+def _adapter_factory(config: Any) -> Any:
+    return _official_adapter_class()(_apply_official_defaults(config))
+
+
+def check_requirements() -> bool:
+    """Check env credentials and the Hermes DingTalk dependency set."""
+    try:
+        _, check_dingtalk_requirements = _load_hermes_dingtalk()
+        return bool(check_dingtalk_requirements())
+    except Exception:
+        return False
+
+
+def validate_config(config: Any) -> bool:
+    return _has_credentials(config)
+
+
+def is_connected(config: Any) -> bool:
+    return validate_config(config)
+
+
+def _env_enablement() -> dict[str, Any] | None:
+    client_id = os.getenv("DINGTALK_CLIENT_ID", "").strip()
+    client_secret = os.getenv("DINGTALK_CLIENT_SECRET", "").strip()
+    if not (client_id and client_secret):
+        return None
+
+    seed: dict[str, Any] = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "card_template_id": os.getenv("DINGTALK_CARD_TEMPLATE_ID")
+        or OFFICIAL_CARD_TEMPLATE_ID,
+    }
+
+    robot_code = os.getenv("DINGTALK_ROBOT_CODE", "").strip()
+    if robot_code:
+        seed["robot_code"] = robot_code
+
+    account_id = os.getenv("DINGTALK_ACCOUNT_ID", "").strip()
+    if account_id:
+        seed["account_id"] = account_id
+
+    bot_mentions = os.getenv("DINGTALK_BOT_MENTIONS", "").strip()
+    if bot_mentions:
+        seed["bot_mentions"] = _load_jsonish(bot_mentions)
+
+    home_channel = os.getenv("DINGTALK_HOME_CHANNEL", "").strip()
+    if home_channel:
+        seed["home_channel"] = {
+            "chat_id": home_channel,
+            "name": os.getenv("DINGTALK_HOME_CHANNEL_NAME", "Home"),
+            "thread_id": os.getenv("DINGTALK_HOME_CHANNEL_THREAD_ID") or None,
+        }
+    return seed
+
+
+def _apply_yaml_config(_yaml_cfg: dict[str, Any], platform_cfg: dict[str, Any]) -> dict[str, Any]:
+    """Allow concise top-level DingTalk YAML to carry official card options."""
+    extra: dict[str, Any] = {}
+    for key in (
+        "account_id",
+        "accountId",
+        "card_template_id",
+        "robot_code",
+        "bot_mentions",
+        "botMentions",
+        "accounts",
+        "bindings",
+    ):
+        value = platform_cfg.get(key)
+        if value:
+            extra[key] = value
+    extra.setdefault("card_template_id", OFFICIAL_CARD_TEMPLATE_ID)
+    return extra
+
+
+def _register_skills(ctx: Any) -> None:
+    skill_path = Path(__file__).parent / "skills" / "dingtalk-dws" / "SKILL.md"
+    ctx.register_skill(
+        "dingtalk-dws",
+        skill_path,
+        "Operate DingTalk product features from Hermes through the dws CLI.",
+    )
+
+
+def _tool_credentials() -> tuple[str, str]:
+    return (
+        os.getenv("DINGTALK_CLIENT_ID", "").strip(),
+        os.getenv("DINGTALK_CLIENT_SECRET", "").strip(),
+    )
+
+
+def _send_tool_requirements() -> bool:
+    client_id, client_secret = _tool_credentials()
+    if not (client_id and client_secret):
+        return False
+    try:
+        import httpx  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _attachment_kind(file_path: str, requested: str | None) -> str:
+    normalized = str(requested or "auto").strip().lower()
+    if normalized in {"image", "file"}:
+        return normalized
+    return "image" if Path(file_path).suffix.lower() in IMAGE_EXTENSIONS else "file"
+
+
+def _content_kind(content: str, requested: str | None) -> str:
+    normalized = str(requested or "auto").strip().lower()
+    if normalized in {"text", "markdown"}:
+        return normalized
+    return "markdown" if _looks_like_markdown(content) else "text"
+
+
+async def _handle_dingtalk_official_send(args: dict[str, Any], **_kwargs: Any) -> str:
+    from tools.registry import tool_error, tool_result
+
+    client_id, client_secret = _tool_credentials()
+    if not (client_id and client_secret):
+        return tool_error("Set DINGTALK_CLIENT_ID and DINGTALK_CLIENT_SECRET first.")
+
+    target_type = str(args.get("target_type") or "").strip().lower()
+    target_id = str(args.get("target_id") or "").strip()
+    if target_type not in {"user", "group"} or not target_id:
+        return tool_error("target_type must be user or group, and target_id is required.")
+
+    content = str(args.get("content") or "")
+    file_path = str(args.get("file_path") or "").strip()
+    if not content.strip() and not file_path:
+        return tool_error("Provide content, file_path, or both.")
+
+    prepared_mentions = _prepare_multi_bot_mentions(
+        content,
+        at_accounts=args.get("at_accounts"),
+        at_dingtalk_ids=args.get("at_dingtalk_ids"),
+    )
+    if prepared_mentions["missing_accounts"]:
+        return tool_error(
+            "Unknown DingTalk bot mention accounts or aliases: "
+            + ", ".join(prepared_mentions["missing_accounts"])
+            + ". Configure DINGTALK_BOT_MENTIONS first."
+        )
+    content = _append_visible_mentions(
+        prepared_mentions["content"],
+        at_dingtalk_ids=prepared_mentions["at_dingtalk_ids"],
+        at_user_ids=args.get("at_user_ids"),
+        at_all=_truthy(args.get("at_all")),
+    )
+
+    try:
+        import httpx
+    except Exception:
+        return tool_error("httpx is required for DingTalk official proactive sends.")
+
+    target = {"type": target_type, "id": target_id}
+    sent: list[dict[str, Any]] = []
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as http_client:
+            if content.strip():
+                content_kind = _content_kind(content, args.get("format"))
+                data = await _send_proactive_payload(
+                    http_client,
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    robot_code=os.getenv("DINGTALK_ROBOT_CODE", "").strip() or client_id,
+                    target=target,
+                    payload=_build_message_payload(
+                        content_kind,
+                        content,
+                        title=str(args.get("title") or "") or None,
+                    ),
+                )
+                sent.append(
+                    {
+                        "kind": content_kind,
+                        "processQueryKey": data.get("processQueryKey"),
+                    }
+                )
+            if file_path:
+                file_kind = _attachment_kind(file_path, args.get("file_kind"))
+                uploaded = await _upload_local_media(
+                    http_client,
+                    client_id,
+                    client_secret,
+                    file_path,
+                    file_kind,
+                )
+                data = await _send_proactive_payload(
+                    http_client,
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    robot_code=os.getenv("DINGTALK_ROBOT_CODE", "").strip() or client_id,
+                    target=target,
+                    payload=_build_message_payload(
+                        file_kind,
+                        uploaded["media_id"],
+                        file_name=uploaded["file_name"],
+                    ),
+                )
+                sent.append(
+                    {
+                        "kind": file_kind,
+                        "fileName": uploaded["file_name"],
+                        "processQueryKey": data.get("processQueryKey"),
+                    }
+                )
+    except Exception as exc:
+        return tool_error(str(exc))
+
+    return tool_result({"success": True, "target": target, "sent": sent})
+
+
+def _handle_dingtalk_official_mentions(_args: dict[str, Any] | None = None, **_kwargs: Any) -> str:
+    from tools.registry import tool_result
+
+    return tool_result(_bot_mentions_report())
+
+
+def register(ctx: Any) -> None:
+    """Register the official DingTalk platform surface with Hermes."""
+    ctx.register_platform(
+        name=PLATFORM_NAME,
+        label="DingTalk Official",
+        adapter_factory=_adapter_factory,
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=["DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET"],
+        install_hint='pip install "hermes-agent[dingtalk]"',
+        env_enablement_fn=_env_enablement,
+        apply_yaml_config_fn=_apply_yaml_config,
+        cron_deliver_env_var="DINGTALK_HOME_CHANNEL",
+        allowed_users_env="DINGTALK_ALLOWED_USERS",
+        allow_all_env="DINGTALK_ALLOW_ALL_USERS",
+        max_message_length=20000,
+        pii_safe=False,
+        allow_update_command=True,
+        platform_hint=(
+            "You are chatting through DingTalk. DingTalk renders Markdown and "
+            "the official connector enables AI Card streaming by default when "
+            "the DingTalk card SDK is available. Keep group replies concise "
+            "and respect DingTalk user and chat allowlists. If configured "
+            "DingTalk bot mention aliases are available, write @alias to call "
+            "another bot; the plugin resolves it to a real DingTalk bot @."
+        ),
+    )
+    _register_skills(ctx)
+    ctx.register_tool(
+        name="dingtalk_official_send",
+        toolset="dingtalk_official",
+        schema=DINGTALK_OFFICIAL_SEND_SCHEMA,
+        handler=_handle_dingtalk_official_send,
+        check_fn=_send_tool_requirements,
+        is_async=True,
+    )
+    ctx.register_tool(
+        name="dingtalk_official_mentions",
+        toolset="dingtalk_official",
+        schema=DINGTALK_OFFICIAL_MENTIONS_SCHEMA,
+        handler=_handle_dingtalk_official_mentions,
+        check_fn=lambda: True,
+        is_async=False,
+    )

--- a/hermes-plugin/plugin.yaml
+++ b/hermes-plugin/plugin.yaml
@@ -1,0 +1,72 @@
+name: dingtalk-official
+label: DingTalk Official
+kind: platform
+version: 0.1.0
+description: >
+  Hermes Agent platform plugin entrypoint for the DingTalk official connector.
+  It registers Hermes' DingTalk Stream adapter with the official AI Card
+  template enabled by default, proactive robot sends, local media upload, and
+  a DingTalk dws skill.
+author: DingTalk Real AI / Hermes conversion
+requires_env:
+  - name: DINGTALK_CLIENT_ID
+    description: "DingTalk AppKey / Client ID for the robot application"
+    prompt: "DingTalk client ID"
+    password: false
+  - name: DINGTALK_CLIENT_SECRET
+    description: "DingTalk AppSecret / Client Secret for the robot application"
+    prompt: "DingTalk client secret"
+    password: true
+optional_env:
+  - name: DINGTALK_CARD_TEMPLATE_ID
+    description: "AI Card template ID; defaults to the official connector template"
+    prompt: "DingTalk AI Card template ID"
+    password: false
+  - name: DINGTALK_ROBOT_CODE
+    description: "Robot code for AI Card delivery; defaults to the client ID"
+    prompt: "DingTalk robot code"
+    password: false
+  - name: DINGTALK_ACCOUNT_ID
+    description: "Friendly local bot/account ID used in BotIdentity logs"
+    prompt: "DingTalk account ID"
+    password: false
+  - name: DINGTALK_BOT_MENTIONS
+    description: "JSON bot mention map/list used to resolve @agent aliases to chatbotUserId"
+    prompt: "DingTalk bot mention aliases"
+    password: false
+  - name: DINGTALK_SUPPRESS_INTERMEDIATE
+    description: "Suppress tool progress, terminal activity, and interim assistant messages (default true)"
+    prompt: "Suppress DingTalk intermediate activity"
+    password: false
+  - name: DINGTALK_SHOW_ACTIVITY
+    description: "Set true to show debug/tool-progress activity messages in DingTalk"
+    prompt: "Show DingTalk activity messages"
+    password: false
+  - name: DINGTALK_REQUIRE_MENTION
+    description: "Require a bot mention in group chats (true/false)"
+    prompt: "Require group mention"
+    password: false
+  - name: DINGTALK_ALLOWED_USERS
+    description: "Comma-separated DingTalk sender/staff IDs allowed to use the bot"
+    prompt: "Allowed DingTalk users"
+    password: false
+  - name: DINGTALK_ALLOW_ALL_USERS
+    description: "Allow all DingTalk users through Hermes gateway authorization"
+    prompt: "Allow all DingTalk users"
+    password: false
+  - name: DINGTALK_ALLOWED_CHATS
+    description: "Comma-separated group conversation IDs allowed to trigger the bot"
+    prompt: "Allowed DingTalk chats"
+    password: false
+  - name: DINGTALK_FREE_RESPONSE_CHATS
+    description: "Comma-separated group conversation IDs that do not require a mention"
+    prompt: "Free-response DingTalk chats"
+    password: false
+  - name: DINGTALK_MENTION_PATTERNS
+    description: "JSON list, newline list, or comma list of group wake-word regexes"
+    prompt: "DingTalk mention patterns"
+    password: false
+  - name: DINGTALK_HOME_CHANNEL
+    description: "Default conversation ID for Hermes cron delivery"
+    prompt: "DingTalk home channel"
+    password: false

--- a/hermes-plugin/skills/dingtalk-dws/SKILL.md
+++ b/hermes-plugin/skills/dingtalk-dws/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: dingtalk-dws
+description: |
+  Use DingTalk product capabilities from a Hermes DingTalk conversation with
+  the dws CLI: docs, AI tables, calendar, todo, reports, DING, chat, contacts,
+  approvals, attendance, and workbench operations.
+---
+
+# DingTalk DWS
+
+Use this skill when a Hermes DingTalk user asks for a DingTalk business
+operation that is not ordinary chat reply delivery.
+
+## Boundary
+
+The Hermes platform adapter handles DingTalk chat transport: inbound messages,
+session replies, DingTalk Markdown, media intake, allowlists, and AI Cards.
+The `dingtalk_official_send` tool handles proactive user/group delivery and
+local image/file upload when that is a robot-message transport task. Use the
+`dws` CLI for DingTalk product APIs such as docs, calendars, tables, todos,
+reports, DING messages, contacts, group operations, approvals, attendance,
+and workbench administration.
+
+## Before Running
+
+1. Check `dws --version`; use a current `dingtalk-workspace-cli` version.
+2. Check `dws auth status`; if it is not authorized, ask the user to run
+   `dws auth login` and complete DingTalk authorization.
+3. Use the Hermes terminal approval flow for any command that changes data or
+   sends a high-impact notification.
+
+Hermes does not copy the platform client secret into shell subprocesses. Do
+not print or export DingTalk secrets to make a `dws` command work; use the
+normal `dws` auth flow instead.
+
+## Command Rules
+
+- Prefer `dws` over ad hoc HTTP calls or browser automation for supported
+  DingTalk business operations.
+- Add `--format json` whenever the command supports it.
+- Query first instead of guessing DingTalk IDs, UUIDs, field names, or record
+  shapes.
+- Keep a batch action to 30 records or fewer unless the user explicitly asks
+  for a controlled larger batch.
+- Summarize the intended target and impact before destructive actions such as
+  deleting tables, records, calendar events, participants, group members, or
+  todos.
+
+## Routing Hints
+
+| User intent | `dws` area |
+| --- | --- |
+| DingTalk docs and document search | `doc` |
+| AI tables, records, fields, data rows | `aitable` |
+| Calendar, meeting, busy/free, room | `calendar` |
+| Todo and task reminders | `todo` |
+| Daily report, weekly report, log history | `report` |
+| DING and urgent reminders | `ding` |
+| Contacts, colleagues, departments | `contact` |
+| Chat groups and robot-sent messages | `chat` |
+| Approval, attendance, workbench | matching product command |
+
+When a `dws` command fails, retry once with its verbose/debug option if one is
+available, then report the concrete error instead of inventing a fallback API.

--- a/hermes-plugin/tests/test_adapter.py
+++ b/hermes-plugin/tests/test_adapter.py
@@ -1,0 +1,587 @@
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "dingtalk_official_hermes_adapter", PLUGIN_ROOT / "adapter.py"
+)
+adapter = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(adapter)
+
+
+class Config:
+    def __init__(self, extra=None):
+        self.extra = extra or {}
+
+
+class FakeContext:
+    def __init__(self):
+        self.platforms = []
+        self.skills = []
+        self.tools = []
+
+    def register_platform(self, **kwargs):
+        self.platforms.append(kwargs)
+
+    def register_skill(self, name, path, description=""):
+        self.skills.append((name, path, description))
+
+    def register_tool(self, **kwargs):
+        self.tools.append(kwargs)
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+        self.text = str(payload)
+
+    def json(self):
+        return self.payload
+
+
+class FakeHTTPClient:
+    def __init__(self):
+        self.get_calls = []
+        self.post_calls = []
+
+    async def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return FakeResponse({"errcode": 0, "access_token": "oapi-token"})
+
+    async def post(self, url, **kwargs):
+        self.post_calls.append((url, kwargs))
+        if url.endswith("/v1.0/oauth2/accessToken"):
+            return FakeResponse({"accessToken": "api-token"})
+        if url.endswith("/media/upload"):
+            return FakeResponse({"media_id": "@media-id"})
+        return FakeResponse({"processQueryKey": "sent-key"})
+
+
+class BaseReplyAdapter:
+    MAX_MESSAGE_LENGTH = 20000
+
+    async def send(
+        self,
+        chat_id,
+        content,
+        reply_to=None,
+        metadata=None,
+    ):
+        self.base_send_calls.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SimpleNamespace(success=True, message_id="text-reply")
+
+    async def send_image(
+        self,
+        chat_id,
+        image_url,
+        caption=None,
+        reply_to=None,
+        metadata=None,
+    ):
+        self.base_image_calls.append(
+            {
+                "chat_id": chat_id,
+                "image_url": image_url,
+                "caption": caption,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SimpleNamespace(success=True, message_id="image-reply")
+
+
+class ReplyImageAdapter(adapter._OfficialDingTalkMixin, BaseReplyAdapter):
+    def __init__(self):
+        self.base_send_calls = []
+        self.base_image_calls = []
+        self._http_client = FakeHTTPClient()
+        self._client_id = "ding-client"
+        self._client_secret = "ding-secret"
+        self._message_contexts = {
+            "cid-group": SimpleNamespace(conversation_type="2", conversation_id="cid-group")
+        }
+        self._session_webhooks = {
+            "cid-group": ("https://api.dingtalk.com/robot/sendBySession", 0)
+        }
+
+    def _get_valid_webhook(self, chat_id):
+        return self._session_webhooks.get(chat_id)
+
+    async def _official_upload(self, file_path, media_type):
+        return {
+            "media_id": "@media-id",
+            "download_url": "https://down.dingtalk.com/media/media-id",
+            "file_name": "plot.png",
+        }
+
+    async def _official_send_payload(self, target, payload):
+        raise AssertionError(f"unexpected proactive send: {target} {payload}")
+
+
+class ReplyDocumentAdapter(adapter._OfficialDingTalkMixin, BaseReplyAdapter):
+    def __init__(self):
+        self.base_send_calls = []
+        self.base_image_calls = []
+        self._http_client = FakeHTTPClient()
+        self._client_id = "ding-client"
+        self._client_secret = "ding-secret"
+        self._message_contexts = {
+            "cid-group": SimpleNamespace(conversation_type="2", conversation_id="cid-group")
+        }
+        self._session_webhooks = {
+            "cid-group": ("https://api.dingtalk.com/robot/sendBySession", 0)
+        }
+
+    def _get_valid_webhook(self, chat_id):
+        return self._session_webhooks.get(chat_id)
+
+    async def _official_upload(self, file_path, media_type):
+        return {
+            "media_id": "@file-media",
+            "download_url": "https://down.dingtalk.com/media/file-media",
+            "file_name": "report.pdf",
+        }
+
+    async def _official_send_payload(self, target, payload):
+        raise AssertionError(f"unexpected proactive send: {target} {payload}")
+
+
+class MentionReplyAdapter(adapter._OfficialDingTalkMixin, BaseReplyAdapter):
+    def __init__(self):
+        self.base_send_calls = []
+        self.base_image_calls = []
+        self._http_client = FakeHTTPClient()
+        self._client_id = "ding-client"
+        self._client_secret = "ding-secret"
+        self.config = Config(
+            {
+                "bot_mentions": [
+                    {
+                        "account_id": "dev-bot",
+                        "name": "开发助手",
+                        "agent_ids": ["dev-agent"],
+                        "aliases": ["dev"],
+                        "chatbot_user_id": "$:LWCP_v1:$devbot",
+                    }
+                ]
+            }
+        )
+        self._message_contexts = {
+            "cid-group": SimpleNamespace(conversation_type="2", conversation_id="cid-group")
+        }
+        self._session_webhooks = {
+            "cid-group": ("https://api.dingtalk.com/robot/sendBySession", 0)
+        }
+        self.done_calls = []
+
+    def _get_valid_webhook(self, chat_id):
+        return self._session_webhooks.get(chat_id)
+
+    def _normalize_markdown(self, content):
+        return content
+
+    def _fire_done_reaction(self, chat_id):
+        self.done_calls.append(chat_id)
+
+    async def _official_send_payload(self, target, payload):
+        raise AssertionError(f"unexpected proactive send: {target} {payload}")
+
+
+class IdentityAdapter(adapter._OfficialDingTalkMixin):
+    def __init__(self):
+        self.config = Config({"account_id": "main-bot"})
+        self.messages = []
+
+    async def _on_message_super(self, message):
+        self.messages.append(message)
+
+
+class QuietActivityAdapter(adapter._OfficialDingTalkMixin, BaseReplyAdapter):
+    def __init__(self):
+        self.config = Config({})
+        self.base_send_calls = []
+        self.base_image_calls = []
+        self._message_contexts = {}
+        self._http_client = FakeHTTPClient()
+        self._client_id = "ding-client"
+        self._client_secret = "ding-secret"
+        self.proactive_calls = []
+
+    async def _official_send_payload(self, target, payload):
+        self.proactive_calls.append((target, payload))
+        return SimpleNamespace(success=True, message_id="proactive-sent")
+
+
+class AdapterDefaultsTests(unittest.TestCase):
+    def test_env_enablement_seeds_official_card_template(self):
+        env = {
+            "DINGTALK_CLIENT_ID": "ding-client",
+            "DINGTALK_CLIENT_SECRET": "ding-secret",
+            "DINGTALK_HOME_CHANNEL": "cid-home",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            seeded = adapter._env_enablement()
+
+        self.assertEqual(seeded["client_id"], "ding-client")
+        self.assertEqual(seeded["client_secret"], "ding-secret")
+        self.assertEqual(seeded["card_template_id"], adapter.OFFICIAL_CARD_TEMPLATE_ID)
+        self.assertEqual(seeded["home_channel"]["chat_id"], "cid-home")
+
+    def test_explicit_card_template_survives_defaults(self):
+        config = Config(
+            {
+                "client_id": "ding-client",
+                "card_template_id": "custom-template",
+            }
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            adapter._apply_official_defaults(config)
+
+        self.assertEqual(config.extra["card_template_id"], "custom-template")
+        self.assertEqual(config.extra["robot_code"], "ding-client")
+
+    def test_register_overrides_dingtalk_platform_and_bundles_skill(self):
+        ctx = FakeContext()
+        adapter.register(ctx)
+
+        self.assertEqual(len(ctx.platforms), 1)
+        self.assertEqual(ctx.platforms[0]["name"], "dingtalk")
+        self.assertEqual(ctx.platforms[0]["allowed_users_env"], "DINGTALK_ALLOWED_USERS")
+        self.assertEqual(ctx.skills[0][0], "dingtalk-dws")
+        self.assertTrue(ctx.skills[0][1].exists())
+        self.assertEqual(ctx.tools[0]["name"], "dingtalk_official_send")
+        self.assertTrue(ctx.tools[0]["is_async"])
+        props = ctx.tools[0]["schema"]["parameters"]["properties"]
+        self.assertIn("at_accounts", props)
+        self.assertIn("at_dingtalk_ids", props)
+        self.assertIn("at_user_ids", props)
+        self.assertIn("at_all", props)
+        self.assertEqual(ctx.tools[1]["name"], "dingtalk_official_mentions")
+
+
+class ProactivePayloadTests(unittest.TestCase):
+    def test_parse_explicit_proactive_targets(self):
+        self.assertEqual(
+            adapter._parse_proactive_target("user:alice"),
+            {"type": "user", "id": "alice"},
+        )
+        self.assertEqual(
+            adapter._parse_proactive_target("group:cid-1"),
+            {"type": "group", "id": "cid-1"},
+        )
+        self.assertIsNone(adapter._parse_proactive_target("cid-1"))
+
+    def test_context_target_uses_group_conversation_or_dm_staff_id(self):
+        group_message = SimpleNamespace(conversation_type="2", conversation_id="cid-group")
+        dm_message = SimpleNamespace(conversation_type="1", sender_staff_id="staff-alice")
+
+        self.assertEqual(
+            adapter._message_context_target(group_message, "fallback"),
+            {"type": "group", "id": "cid-group"},
+        )
+        self.assertEqual(
+            adapter._message_context_target(dm_message, "fallback"),
+            {"type": "user", "id": "staff-alice"},
+        )
+
+    def test_file_payload_keeps_media_id_and_file_metadata(self):
+        payload = adapter._build_message_payload("file", "@media-id", file_name="report.pdf")
+
+        self.assertEqual(payload["msgKey"], "sampleFile")
+        self.assertIn('"mediaId": "@media-id"', payload["msgParam"])
+        self.assertIn('"fileType": "pdf"', payload["msgParam"])
+
+    def test_proactive_errors_explain_identity_mismatches(self):
+        staff_error = adapter._proactive_send_error(
+            FakeResponse({"code": "staffId.notExisted", "message": "staff missing"}, status_code=400)
+        )
+        robot_error = adapter._proactive_send_error(
+            FakeResponse({"code": "resource.not.found", "message": "robot does not exist"}, status_code=404)
+        )
+
+        self.assertIn("staff_id", staff_error)
+        self.assertIn("sender_id", staff_error)
+        self.assertIn("DINGTALK_ROBOT_CODE", robot_error)
+
+
+class MultiBotMentionTests(unittest.TestCase):
+    def test_openclaw_accounts_and_bindings_resolve_bot_aliases(self):
+        cfg = {
+            "accounts": {
+                "dev-bot": {
+                    "name": "开发助手",
+                    "chatbotUserId": "$:LWCP_v1:$devbot",
+                    "aliases": ["dev"],
+                }
+            },
+            "bindings": [
+                {
+                    "agentId": "dev-agent",
+                    "match": {"channel": "dingtalk-connector", "accountId": "dev-bot"},
+                }
+            ],
+        }
+
+        content, ids = adapter._substitute_bot_mentions("请 @dev-agent 看一下", cfg)
+
+        self.assertEqual(content, "请 @$:LWCP_v1:$devbot 看一下")
+        self.assertEqual(ids, ["$:LWCP_v1:$devbot"])
+
+    def test_explicit_at_accounts_append_real_chatbot_id(self):
+        cfg = {
+            "bot_mentions": [
+                {
+                    "account_id": "dev-bot",
+                    "agent_ids": ["dev-agent"],
+                    "chatbot_user_id": "$:LWCP_v1:$devbot",
+                }
+            ]
+        }
+
+        prepared = adapter._prepare_multi_bot_mentions(
+            "请处理",
+            config_or_extra=cfg,
+            at_accounts=["dev-agent"],
+        )
+
+        self.assertEqual(prepared["content"], "请处理 @$:LWCP_v1:$devbot")
+        self.assertEqual(prepared["at_dingtalk_ids"], ["$:LWCP_v1:$devbot"])
+        self.assertEqual(prepared["missing_accounts"], [])
+
+    def test_mentions_report_shows_ready_and_missing_accounts(self):
+        report = adapter._bot_mentions_report(
+            {
+                "accounts": {
+                    "ready-bot": {"chatbotUserId": "$:LWCP_v1:$ready"},
+                    "missing-bot": {"name": "未配置"},
+                }
+            }
+        )
+
+        self.assertFalse(report["ready"])
+        self.assertEqual(report["readyAccounts"], 1)
+        self.assertEqual(report["missingChatbotUserId"], ["missing-bot"])
+        self.assertIn("ready-bot", report["report"])
+
+    def test_record_bot_identity_keeps_latest_identity(self):
+        identity_adapter = IdentityAdapter()
+        message = SimpleNamespace(
+            chatbot_user_id="$:LWCP_v1:$main",
+            chatbot_corp_id="corp-main",
+        )
+
+        with patch("builtins.print") as printed:
+            identity_adapter._record_bot_identity(message)
+
+        self.assertEqual(
+            identity_adapter._official_last_bot_identity,
+            {
+                "accountId": "main-bot",
+                "chatbotUserId": "$:LWCP_v1:$main",
+                "chatbotCorpId": "corp-main",
+            },
+        )
+        printed.assert_called_once()
+
+    def test_visible_mentions_append_user_ids_and_all_once(self):
+        content = adapter._append_visible_mentions(
+            "请处理 @staff-a",
+            at_dingtalk_ids=["$:LWCP_v1:$devbot"],
+            at_user_ids=["staff-a", "staff-b"],
+            at_all=True,
+        )
+
+        self.assertEqual(
+            content,
+            "请处理 @staff-a @$:LWCP_v1:$devbot @staff-b @all",
+        )
+
+
+class QuietActivityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_intermediate_activity_is_suppressed_by_default(self):
+        quiet_adapter = QuietActivityAdapter()
+
+        result = await quiet_adapter.send(
+            "cid-group",
+            '💻 terminal: "grep DINGTALK_CLIENT_ID ..."',
+        )
+
+        self.assertTrue(result.success)
+        self.assertIsNone(result.message_id)
+        self.assertEqual(quiet_adapter.base_send_calls, [])
+        self.assertFalse(quiet_adapter.SUPPORTS_MESSAGE_EDITING)
+
+    async def test_final_reply_still_sends(self):
+        quiet_adapter = QuietActivityAdapter()
+
+        result = await quiet_adapter.send(
+            "cid-group",
+            "这是最终回复",
+            reply_to="msg-1",
+            metadata={"notify": True},
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(quiet_adapter.base_send_calls[0]["content"], "这是最终回复")
+
+    async def test_activity_can_be_enabled_for_debugging(self):
+        quiet_adapter = QuietActivityAdapter()
+
+        with patch.dict(os.environ, {"DINGTALK_SHOW_ACTIVITY": "true"}):
+            result = await quiet_adapter.send("cid-group", "调试进度")
+
+        self.assertTrue(result.success)
+        self.assertEqual(quiet_adapter.base_send_calls[0]["content"], "调试进度")
+        with patch.dict(os.environ, {"DINGTALK_SHOW_ACTIVITY": "true"}):
+            self.assertTrue(quiet_adapter.SUPPORTS_MESSAGE_EDITING)
+
+    async def test_explicit_proactive_targets_are_not_suppressed(self):
+        quiet_adapter = QuietActivityAdapter()
+
+        result = await quiet_adapter.send("group:cid-home", "主动发送")
+
+        self.assertTrue(result.success)
+        self.assertEqual(quiet_adapter.proactive_calls[0][0], {"type": "group", "id": "cid-home"})
+
+
+class OfficialRequestTests(unittest.IsolatedAsyncioTestCase):
+    async def test_proactive_group_send_uses_robot_openapi_template(self):
+        client = FakeHTTPClient()
+
+        result = await adapter._send_proactive_payload(
+            client,
+            client_id="ding-client",
+            client_secret="ding-secret",
+            robot_code="ding-robot",
+            target={"type": "group", "id": "cid-group"},
+            payload=adapter._build_message_payload("markdown", "# Hello"),
+        )
+
+        self.assertEqual(result["processQueryKey"], "sent-key")
+        self.assertEqual(client.post_calls[0][0], f"{adapter.DINGTALK_API}/v1.0/oauth2/accessToken")
+        send_url, send_kwargs = client.post_calls[1]
+        self.assertEqual(send_url, f"{adapter.DINGTALK_API}/v1.0/robot/groupMessages/send")
+        self.assertEqual(send_kwargs["json"]["openConversationId"], "cid-group")
+        self.assertEqual(send_kwargs["json"]["robotCode"], "ding-robot")
+        self.assertEqual(send_kwargs["json"]["msgKey"], "sampleMarkdown")
+        self.assertEqual(
+            send_kwargs["headers"]["x-acs-dingtalk-access-token"],
+            "api-token",
+        )
+
+    async def test_media_upload_uses_oapi_and_returns_original_media_id(self):
+        client = FakeHTTPClient()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            image_path = Path(temp_dir) / "plot.png"
+            image_path.write_bytes(b"png-bytes")
+
+            uploaded = await adapter._upload_local_media(
+                client,
+                "ding-client",
+                "ding-secret",
+                str(image_path),
+                "image",
+            )
+
+        self.assertEqual(uploaded["media_id"], "@media-id")
+        self.assertEqual(uploaded["download_url"], "https://down.dingtalk.com/media/media-id")
+        self.assertEqual(client.get_calls[0][0], f"{adapter.DINGTALK_OAPI}/gettoken")
+        upload_url, upload_kwargs = client.post_calls[0]
+        self.assertEqual(upload_url, f"{adapter.DINGTALK_OAPI}/media/upload")
+        self.assertEqual(upload_kwargs["params"]["access_token"], "oapi-token")
+        self.assertEqual(upload_kwargs["params"]["type"], "image")
+
+    async def test_current_context_local_image_uses_session_markdown_media_id(self):
+        reply_adapter = ReplyImageAdapter()
+
+        result = await reply_adapter.send_image_file(
+            "cid-group",
+            "/tmp/plot.png",
+            caption="plot",
+            reply_to="msg-1",
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(reply_adapter.base_send_calls, [])
+        self.assertEqual(reply_adapter._http_client.post_calls[0][0], f"{adapter.DINGTALK_API}/v1.0/oauth2/accessToken")
+        send_url, send_kwargs = reply_adapter._http_client.post_calls[1]
+        self.assertEqual(send_url, "https://api.dingtalk.com/robot/sendBySession")
+        self.assertEqual(send_kwargs["json"]["msgtype"], "markdown")
+        self.assertEqual(
+            send_kwargs["json"]["markdown"]["text"],
+            "plot\n\n![image](@media-id)",
+        )
+
+    async def test_current_context_document_uses_session_file_message(self):
+        reply_adapter = ReplyDocumentAdapter()
+
+        result = await reply_adapter.send_document(
+            "cid-group",
+            "/tmp/report.pdf",
+            file_name="report.pdf",
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(reply_adapter._http_client.post_calls[0][0], f"{adapter.DINGTALK_API}/v1.0/oauth2/accessToken")
+        send_url, send_kwargs = reply_adapter._http_client.post_calls[1]
+        self.assertEqual(send_url, "https://api.dingtalk.com/robot/sendBySession")
+        self.assertEqual(send_kwargs["json"]["msgtype"], "file")
+        self.assertEqual(send_kwargs["json"]["file"]["media_id"], "@file-media")
+        self.assertEqual(send_kwargs["json"]["file"]["fileName"], "report.pdf")
+        self.assertEqual(send_kwargs["json"]["file"]["fileType"], "pdf")
+
+    async def test_session_text_with_bot_alias_uses_dingtalk_at_field(self):
+        reply_adapter = MentionReplyAdapter()
+
+        result = await reply_adapter.send(
+            "cid-group",
+            "请 @dev-agent 看一下",
+            reply_to="msg-1",
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(reply_adapter.base_send_calls, [])
+        self.assertEqual(reply_adapter._http_client.post_calls[0][0], f"{adapter.DINGTALK_API}/v1.0/oauth2/accessToken")
+        send_url, send_kwargs = reply_adapter._http_client.post_calls[1]
+        self.assertEqual(send_url, "https://api.dingtalk.com/robot/sendBySession")
+        self.assertEqual(send_kwargs["json"]["markdown"]["text"], "请 @$:LWCP_v1:$devbot 看一下")
+        self.assertEqual(
+            send_kwargs["json"]["at"]["atDingtalkIds"],
+            ["$:LWCP_v1:$devbot"],
+        )
+        self.assertEqual(reply_adapter.done_calls, ["cid-group"])
+
+    async def test_session_text_metadata_can_at_user_and_all(self):
+        reply_adapter = MentionReplyAdapter()
+
+        result = await reply_adapter.send(
+            "cid-group",
+            "请大家看一下",
+            reply_to="msg-1",
+            metadata={"at_user_ids": ["staff-a"], "at_all": True},
+        )
+
+        self.assertTrue(result.success)
+        _send_url, send_kwargs = reply_adapter._http_client.post_calls[1]
+        self.assertEqual(send_kwargs["json"]["markdown"]["text"], "请大家看一下 @staff-a @all")
+        self.assertEqual(send_kwargs["json"]["at"]["atUserIds"], ["staff-a"])
+        self.assertTrue(send_kwargs["json"]["at"]["isAtAll"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -95,7 +95,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
   const log = createLoggerFromConfig(account.config, `DingTalk:${accountId}`);
 
   // AI Card 状态管理
-  let currentCardTarget: AICardTarget | null = null;
+  let currentCardTarget: AICardInstance | null = null;
   let accumulatedText = "";
   const deliveredFinalTexts = new Set<string>();
 
@@ -247,7 +247,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       // 这样用户看到的是同一条消息从 ACK 文案更新为最终结果，而不是多出一条消息
       if (preCreatedCard) {
         log.info(`[DingTalk][startStreaming] 复用预创建 AI Card，cardInstanceId=${preCreatedCard.cardInstanceId}`);
-        currentCardTarget = preCreatedCard as any;
+        currentCardTarget = preCreatedCard;
         accumulatedText = "";
         outboundUserVisibleThisTurn = true;
         return;
@@ -267,7 +267,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
           target,
           log
         );
-        currentCardTarget = card as any;
+        currentCardTarget = card;
         accumulatedText = "";
 
         if (card) {
@@ -288,6 +288,12 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
   };
 
   const closeStreaming: () => Promise<void> = async () => {
+    const pendingCardCreation = cardCreationPromise;
+    if (!currentCardTarget && pendingCardCreation) {
+      log.info(`[DingTalk][closeStreaming] AI Card 仍在创建中，等待创建完成后再关闭`);
+      await pendingCardCreation;
+    }
+
     // 立即捕获并清空，防止并发调用重复执行（竞争条件保护）
     // closeStreaming 可能被 onIdle 和 onError 同时触发，若不在此处清空，
     // 第一次调用的 finally 块会将 currentCardTarget 置 null，
@@ -418,7 +424,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       log.info(`[DingTalk][closeStreaming] 准备调用 finishAICard，文本长度=${finalText.length}`);
       log.debug(`[DingTalk][closeStreaming] 最终发送内容长度=${finalText.length}`);
       await finishAICard(
-        cardSnapshot as any,
+        cardSnapshot,
         finalText,
         account.config as DingtalkConfig,
         log
@@ -613,7 +619,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
               lastUpdateTime = now;
               try {
                 await streamAICard(
-                  currentCardTarget as any,
+                  currentCardTarget,
                   text,
                   false,
                   account.config as DingtalkConfig,
@@ -775,7 +781,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
             lastUpdateTime = now;
             try {
               await streamAICard(
-                currentCardTarget as any,
+                currentCardTarget,
                 displayContent,
                 false,
                 account.config as DingtalkConfig,

--- a/tests/reply-dispatcher/reply-dispatcher.test.ts
+++ b/tests/reply-dispatcher/reply-dispatcher.test.ts
@@ -158,6 +158,51 @@ describe("reply-dispatcher", () => {
     expect(typeof result.getAsyncModeResponse()).toBe("string");
   });
 
+  it("waits for pending AI Card creation before closing on idle", async () => {
+    const { createDingtalkReplyDispatcher } = await import("../../src/reply-dispatcher");
+    const runtime = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    let resolveCard!: (card: any) => void;
+    const pendingCard = new Promise<any>((resolve) => {
+      resolveCard = resolve;
+    });
+    mockCreateAICardForTarget.mockReturnValueOnce(pendingCard);
+
+    createDingtalkReplyDispatcher({
+      cfg: {} as any,
+      agentId: "a1",
+      runtime: runtime as any,
+      conversationId: "conv-1",
+      senderId: "user-1",
+      isDirect: true,
+      sessionWebhook: "http://webhook",
+    });
+
+    const args = (globalThis as any).__dispatcherArgs;
+    args.onReplyStart();
+
+    const idlePromise = args.onIdle();
+    await Promise.resolve();
+
+    expect(mockFinishAICard).not.toHaveBeenCalled();
+
+    resolveCard({
+      cardInstanceId: "slow-card",
+      accessToken: "tk",
+      inputingStarted: false,
+    });
+    await idlePromise;
+
+    expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+    expect(mockFinishAICard.mock.calls[0]?.[0]?.cardInstanceId).toBe("slow-card");
+  });
+
   it("asyncMode accumulates final response without streaming", async () => {
     const { createDingtalkReplyDispatcher } = await import("../../src/reply-dispatcher");
     const runtime = {


### PR DESCRIPTION
## What changed
- add a Hermes platform plugin entrypoint for the DingTalk official connector delta
- document install and configuration for AI cards, proactive sends, quiet chat mode, current-session media replies, bot mentions, and dws usage
- cover adapter behavior with focused unit tests

## Why
The official connector targets OpenClaw, while Hermes users need a packaged bridge that keeps Hermes' DingTalk adapter and ports the official connector features that are useful in Hermes.

## Impact
Hermes users can install the plugin from this repository, use the official AI Card default, send proactive user or group messages with media upload, keep DingTalk chats quiet during tool activity, and configure cross-bot mention aliases.

## Root cause
The OpenClaw connector runtime and Hermes platform plugin runtime are different, so the connector features were not available as a Hermes-installable plugin before this change.

## Checks
- `PYTHONPATH=/Users/johnliu/Code/钉钉/hermes-agent /Users/johnliu/Code/钉钉/hermes-agent/.venv/bin/python -m unittest discover -s hermes-plugin/tests`
- `git diff --cached --check`