### PR TITLE
release: v0.8.22 (GA, promoted from 0.8.22-beta.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.22] - 2026-05-24
+
+晋升自 `0.8.22-beta.0` 的 GA 版本，与 beta.0 内容完全一致，经过 ~3 天社区验证（无回归反馈）后正式发布。
+GA promotion of `0.8.22-beta.0` after ~3 days of community validation with no regression; functionally identical to the beta.
+
+### 升级 / Upgrade
+
+```bash
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.22
+openclaw gateway restart
+```
+
+以下内容沿用自 `0.8.22-beta.0` 的改进 / Same improvements as `0.8.22-beta.0`：
+
 ## [0.8.22-beta.0] - 2026-05-21
 
 > **社区验证版本** — 计划 2-3 天观察期后晋升为 `v0.8.22`。详见 [Release Notes](docs/RELEASE_NOTES_V0.8.22-beta.0.md)。

--- a/docs/RELEASE_NOTES_V0.8.22.md
+++ b/docs/RELEASE_NOTES_V0.8.22.md
@@ -1,0 +1,95 @@
+# Release Notes - v0.8.22
+
+> **GA 正式版** — 晋升自 `0.8.22-beta.0`，经 ~3 天社区验证（无回归反馈）后正式发布。
+> **General Availability** — Promoted from `0.8.22-beta.0` after ~3 days of community validation with no regression.
+
+## 🎉 本次重点 / Highlights
+
+本版本聚焦 UX 文案与 dws onboarding 体验，与 `0.8.22-beta.0` 功能完全一致：
+
+1. 把单聊空回复兜底文案 `✅ 任务执行完成（无文本输出）` 换成口语化的 `好的 👌 有其他问题随时找我`，避免被用户误判为报错（[#599](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/599) / [PR #601](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/601)）
+2. 内置 dws CLI 从 `1.0.13` 升到 npm 最新 `1.0.30`，新装用户拿到正确的 `dws auth login --help` 文案
+3. onboarding 检测 SSH / 无头环境（`SSH_CLIENT` / `SSH_TTY` / `SSH_CONNECTION`），自动建议 `dws auth login --device`，避免 127.0.0.1 loopback 在远端无浏览器服务器上挂起（[#565](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/565) / [PR #598](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/598)）
+
+This release focuses on UX copy + dws onboarding experience. Functionally identical to `0.8.22-beta.0`:
+
+1. Replace direct-chat empty-reply fallback `✅ 任务执行完成（无文本输出）` with conversational `好的 👌 有其他问题随时找我`, so users no longer mistake it for an error (#599 / PR #601)
+2. Bump bundled dws CLI from `1.0.13` to npm latest `1.0.30`; new installs get the corrected `dws auth login --help` copy
+3. Detect SSH / headless env in onboarding and auto-suggest `dws auth login --device`, avoiding 127.0.0.1 loopback hangs on remote headless servers (#565 / PR #598)
+
+## ✨ 改进 / Improvements
+
+### 单聊空回复 UX 文案优化 ([#599](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/599) / [PR #601](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/601))
+
+**现象**：用户对一段说明回「知道了」后，机器人显示 `✅ 任务执行完成（无文本输出）`，被误判为报错。
+
+**根因**：私聊场景下模型可能因 ACK 类输入选择沉默（只走 thinking / tool_call、或纯输出空文本）。connector 的空回复兜底文案系统/技术味偏重。
+
+**改动**：
+
+- `src/utils/empty-reply.ts:23` — `DIRECT_FALLBACK_TEXT` 改为 `好的 👌 有其他问题随时找我`，保留"本轮已结束"信号但去掉技术味
+- 测试改成语义契约（不绑死字符串）：不出现报错感字样 / 以「好」开头 / 包含追问引导 / 与群聊文案不同
+- 群聊兜底文案与日志 hint 维持不变（仍是面向运维的可操作指引）
+
+### dws onboarding SSH 兼容 + 版本升级 ([#565](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/565) / [PR #598](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/598))
+
+**现象**：SSH / 无头服务器上首次 `dws auth login` 卡死——dws CLI 默认走 127.0.0.1 loopback 回调，本地浏览器无法访问远端 loopback。
+
+**根因**：connector pin 的 dws 是 `1.0.13`，此版本 `--help` 文案描述与实际行为相反，SSH 用户照着 help 跑必然踩坑。
+
+**改动**：
+
+- `bin/dingtalk-connector.js:401` — `DWS_NPM_PACKAGE` 从 `1.0.13` → `1.0.30`（npm latest，含上游 dws #226 文档修复）
+- 新增 `isSshSession()`：检测 `SSH_CLIENT` / `SSH_TTY` / `SSH_CONNECTION` 三个环境变量
+- 新增 `printDwsLoginHint()` 辅助：SSH 命中时把 `dws auth login` 换成 `dws auth login --device`，并附一句说明
+- 把"已安装/全新安装"两条路径的登录提示统一走 `printDwsLoginHint()`，避免分叉
+
+**根治方向（跨仓 follow-up）**：
+
+- [dws #327](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/327) — 建议 dws 自身检测 SSH 环境自动降级到 `--device`，根治后 connector 这边的兜底逻辑可以择机删除
+- 「对话框内授权」是更大的跨仓 UX 改造，需要 dws 支持非 CLI 流程或 Web flow，本版本不涉及
+
+## 🔒 兼容性 / Compatibility
+
+- **API 无变化**、配置 schema 无变化、导出符号无变化
+- 现有用户升级无需任何配置改动
+- 群聊行为完全不变（空回复兜底文案与日志 hint 未动）
+- 仅以下两类用户感知到差异：
+  - 私聊场景看到空回复兜底文案的用户 —— 文案更友好
+  - 全新安装 / 在 SSH 环境首次 `dws auth login` 的用户 —— 自动得到正确命令建议
+
+## 🧪 验证 / Verification
+
+**Beta 社区验证（2026-05-21 ~ 2026-05-24，~3 天）**：
+- npm `beta` tag 上 `0.8.22-beta.0` 稳定可用
+- 无任何针对私聊空回复文案 / dws SSH onboarding 的回归 issue
+
+**已验证组合 / Verified combo**：
+- OpenClaw Gateway `2026.5.12` (f066dd2)
+- Connector `0.8.22-beta.0`（已晋升为 `0.8.22`）
+- 平台 macOS（darwin 23.2.0）
+
+## 📥 安装升级 / Installation & Upgrade
+
+```bash
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.22
+openclaw gateway restart
+```
+
+或：
+
+```bash
+npm install @dingtalk-real-ai/dingtalk-connector@latest
+```
+
+## 🔗 相关链接 / Related Links
+
+- [完整变更日志 / Full Changelog](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/CHANGELOG.md)
+- [Beta release notes (`v0.8.22-beta.0`)](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/docs/RELEASE_NOTES_V0.8.22-beta.0.md)
+- 关联 PRs / issues：[#599](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/599) / [#601](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/601) / [#565](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/565) / [#598](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/598) / [dws #327](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/327)
+
+---
+
+**发布日期 / Release Date**：2026-05-24
+**版本号 / Version**：v0.8.22
+**兼容性 / Compatibility**：OpenClaw Gateway 2026.5.7+

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.8.22-beta.0",
+  "version": "0.8.22",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "author": "DingTalk Real Team",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.8.22-beta.0",
+  "version": "0.8.22",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

晋升 `v0.8.22-beta.0` → `v0.8.22` GA。经 ~3 天社区验证（2026-05-21 ~ 2026-05-24），**无回归反馈**：
- 期间仅 1 条新 issue [#604](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/604)（dws 多用户身份权限模型 feature request），与本次 beta 改动无关
- 无任何针对「私聊空回复文案」/「dws SSH onboarding」的回归 issue
- npm `beta` tag 上 `0.8.22-beta.0` 稳定可用

功能与 `0.8.22-beta.0` **完全一致**，覆盖：
- ✨ 单聊空回复 UX 文案优化（[#599](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/599) / [#601](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/601)）
- ✨ dws CLI 升级到 1.0.30 + onboarding SSH 兼容（[#565](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/565) / [#598](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/598)）

## 改动

- `package.json` / `openclaw.plugin.json` — 版本号 `0.8.22-beta.0` → `0.8.22`
- `CHANGELOG.md` — 新增 0.8.22 GA 段落
- `docs/RELEASE_NOTES_V0.8.22.md` — 完整双语 GA release notes

## 验证

- Beta 期间已用 OpenClaw Gateway 2026.5.12 + macOS 跑过完整路径
- 本 PR 仅版本号 + 文档，无代码改动

## 合入后步骤

合入后需要：
1. `gh release create v0.8.22 --target <sha>` 创建 GitHub release + tag
2. `npm publish` **不带 `--tag beta`**（默认进 latest tag）
3. 在置顶 #584 / #585 同步 GA 发布
4. 在 #582 / #574 评论里告知 GA 已发