### PR TITLE
release: v0.8.23 (republish of v0.8.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.22] - 2026-05-24
+## [0.8.23] - 2026-05-26 / [0.8.22] - 2026-05-24
 
-晋升自 `0.8.22-beta.0` 的 GA 版本，与 beta.0 内容完全一致，经过 ~3 天社区验证（无回归反馈）后正式发布。
-GA promotion of `0.8.22-beta.0` after ~3 days of community validation with no regression; functionally identical to the beta.
+> `0.8.23` 为 `0.8.22` 的重发版本，内容沿用自 `0.8.22` / `0.8.22-beta.0`，建议直接安装 `0.8.23`（[#609](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/609)）。
+> `0.8.23` is a republish of `0.8.22` with identical functionality; please install `0.8.23` ([#609](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/609)).
 
 ### 升级 / Upgrade
 
 ```bash
-openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.22
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.23
 openclaw gateway restart
 ```
 

--- a/docs/RELEASE_NOTES_V0.8.23.md
+++ b/docs/RELEASE_NOTES_V0.8.23.md
@@ -1,7 +1,7 @@
-# Release Notes - v0.8.22
+# Release Notes - v0.8.23 / v0.8.22
 
-> **GA 正式版** — 晋升自 `0.8.22-beta.0`，经 ~3 天社区验证（无回归反馈）后正式发布。
-> **General Availability** — Promoted from `0.8.22-beta.0` after ~3 days of community validation with no regression.
+> **v0.8.23 为 v0.8.22 的重新发布包**（[#609](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/609)），功能与 `0.8.22` 完全一致，推荐直接安装 `0.8.23`。
+> **v0.8.23 is a republish of v0.8.22** ([#609](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/609)), functionally identical to `0.8.22`; please install `0.8.23`.
 
 ## 🎉 本次重点 / Highlights
 
@@ -72,7 +72,7 @@ This release focuses on UX copy + dws onboarding experience. Functionally identi
 ## 📥 安装升级 / Installation & Upgrade
 
 ```bash
-openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.22
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.23
 openclaw gateway restart
 ```
 
@@ -86,10 +86,11 @@ npm install @dingtalk-real-ai/dingtalk-connector@latest
 
 - [完整变更日志 / Full Changelog](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/CHANGELOG.md)
 - [Beta release notes (`v0.8.22-beta.0`)](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/docs/RELEASE_NOTES_V0.8.22-beta.0.md)
-- 关联 PRs / issues：[#599](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/599) / [#601](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/601) / [#565](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/565) / [#598](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/598) / [dws #327](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/327)
+- 关联 PRs / issues：[#599](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/599) / [#601](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/601) / [#565](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/565) / [#598](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/598) / [#609](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/609) / [dws #327](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/327)
 
 ---
 
-**发布日期 / Release Date**：2026-05-24
-**版本号 / Version**：v0.8.22
+**v0.8.23 发布日期 / Release Date**：2026-05-26
+**v0.8.22 发布日期 / Release Date**：2026-05-24
+**当前推荐版本 / Recommended Version**：v0.8.23
 **兼容性 / Compatibility**：OpenClaw Gateway 2026.5.7+

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "author": "DingTalk Real Team",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

重新发布 `v0.8.22`，npm 已发布 `0.8.23` 并打 tag `v0.8.23`（[#609](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/609)）。功能与 `v0.8.22` 完全一致。

## Verification

```text
npm dist-tags: { latest: '0.8.23', beta: '0.8.22-beta.0' }
tarball: 156 files, 18 skills/ entries
shasum:  922645c1a89b18df2b6ccf27af327bc3ced7ee75
```