### PR TITLE
fix: undefined promptSingleChannelSecretInput on existing-config path + toSorted runtime compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.24] - 2026-06-18
+
+### Fixed
+
+- **onboarding**: fix `ReferenceError: promptSingleChannelSecretInput is not defined` on the existing-config manual-input path. The static import was removed in #527 but one call site (the "update existing account" secret prompt) was missed; it now uses the same dynamic `import("openclaw/plugin-sdk/setup")` as the other call site.
+- **accounts**: replace `Array.prototype.toSorted` with `sort()` on a spread copy in `listDingtalkAccountIds`. `toSorted` is ES2023 / Node 20+ and threw on older runtimes hosting the plugin.
+
+### Changed
+
+- **connection**: expose a structured `DingtalkWsClient` type for the `DWClient` instance instead of a bare `as any`, documenting the private `socket` member the custom heartbeat / reconnect logic relies on.
+
 ## [0.8.23] - 2026-05-26 / [0.8.22] - 2026-05-24
 
 > `0.8.23` 为 `0.8.22` 的重发版本，内容沿用自 `0.8.22` / `0.8.22-beta.0`，建议直接安装 `0.8.23`（[#609](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/609)）。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "type": "module",
   "exports": {

--- a/src/config/accounts.ts
+++ b/src/config/accounts.ts
@@ -28,7 +28,9 @@ export function listDingtalkAccountIds(cfg: ClawdbotConfig): string[] {
     // Backward compatibility: no accounts configured, use default
     return [DEFAULT_ACCOUNT_ID];
   }
-  return [...ids].toSorted((a, b) => a.localeCompare(b));
+  // Use sort() on a spread copy instead of toSorted() — toSorted is ES2023 / Node 20+,
+  // and this plugin may run on older runtimes where it would throw at runtime.
+  return [...ids].sort((a, b) => a.localeCompare(b));
 }
 
 /**

--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -29,6 +29,21 @@ export type DingtalkReactionCreatedEvent = {
   emoji: string;
 };
 
+/**
+ * Structured view of DWClient: exposes the members this connection layer uses.
+ * The SDK declares the underlying WebSocket (socket) as private, but the custom
+ * heartbeat / reconnect logic needs to operate on it directly, so socket and the
+ * public methods used here are listed explicitly.
+ */
+type DingtalkWsClient = {
+  socket?: any;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  on(event: string, listener: (...args: any[]) => void): void;
+  registerCallbackListener(topic: string, listener: (...args: any[]) => void): void;
+  socketCallBackResponse(messageId: string, data: any): void;
+};
+
 // 消息处理器函数类型
 export type MessageHandler = (params: {
   accountId: string;
@@ -187,6 +202,8 @@ export async function monitorSingleAccount(
   }
 
   // 配置 DWClient：禁用 SDK 内置的 keepAlive 和 autoReconnect，使用自定义实现
+  // 注：DWClient.socket 为私有成员，但本连接层需直接访问底层 WebSocket 以实现
+  //     自定义心跳与重连，故用结构化类型暴露本层用到的成员（含 socket）。
   const client = new DWClient({
     clientId: account.clientId,
     clientSecret: account.clientSecret,
@@ -195,7 +212,7 @@ export async function monitorSingleAccount(
     endpoint: account.config.endpoint || "https://api.dingtalk.com",
     autoReconnect: false, // ❌ 禁用 SDK 自动重连
     keepAlive: false, // ❌ 禁用 SDK 心跳检测
-  } as any);
+  } as any) as unknown as DingtalkWsClient;
 
   // ============ 连接状态管理 ============
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -406,7 +406,8 @@ export const dingtalkOnboardingAdapter: ChannelSetupWizardAdapter = {
                 normalizeString(dingtalkCfg?.clientId) ?? normalizeString(_env.DINGTALK_CLIENT_ID),
             });
 
-            const clientSecretResult = await promptSingleChannelSecretInput({
+            const { promptSingleChannelSecretInput: promptSecret } = await import("openclaw/plugin-sdk/setup");
+            const clientSecretResult = await promptSecret({
               cfg: next,
               prompter,
               providerHint: "dingtalk",


### PR DESCRIPTION
## Summary

Three fixes found while integrating `@dingtalk-real-ai/dingtalk-connector` into a downstream app. Two are real runtime bugs in `0.8.23`; one is a type-safety cleanup.

### 🐛 `onboarding.ts` — `ReferenceError: promptSingleChannelSecretInput is not defined`

The static import of `promptSingleChannelSecretInput` was removed in #527 (the symbol is now dynamically imported at call sites), but **one call site was missed**: the existing-config → manual-input → Client Secret prompt still referenced the no-longer-imported `promptSingleChannelSecretInput` directly.

As a result, re-configuring an already-configured DingTalk account and falling through to manual secret entry throws `ReferenceError: promptSingleChannelSecretInput is not defined` at runtime. (`tsdown` strips types and doesn't catch the undefined value reference, so the build stays green.)

This converts that call site to the same `const { promptSingleChannelSecretInput: promptSecret } = await import("openclaw/plugin-sdk/setup")` pattern already used by the other call site.

### 🐛 `config/accounts.ts` — `toSorted` throws on older runtimes

`listDingtalkAccountIds` used `Array.prototype.toSorted`, which is ES2023 / Node 20+. On older runtimes hosting the plugin this throws `TypeError: [...].toSorted is not a function`. Switched to `sort()` on the existing spread copy (`[...ids].sort(...)`), which is non-mutating and behaves identically.

### 🧹 `core/connection.ts` — structured type for `DWClient`

The connection layer accesses `client.socket?.` throughout for its custom heartbeat / reconnect, but the instance was a bare `as any`. Added a small structured `DingtalkWsClient` type that documents the private `socket` member and the public methods this layer relies on, replacing the bare `as any` with an explicit cast.

## Validation

- `npm run build` passes; both onboarding call sites compile to dynamic `import("openclaw/plugin-sdk/setup")`.
- Version bumped `0.8.23 → 0.8.24` with a CHANGELOG entry.

Happy to adjust the version bump / CHANGELOG to fit your release process.
