### PR TITLE
fix: 保证 AI Card 在 final/settle 缺失与挂死回合下必然收口（fixes #644）

### DIFF
--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -1465,7 +1465,7 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
     } as any);
 
     // 创建 reply dispatcher，使用解析后的 agentId
-    const { dispatcher, replyOptions, markDispatchIdle, getAsyncModeResponse } = createDingtalkReplyDispatcher({
+    const { dispatcher, replyOptions, markDispatchIdle, markRunComplete, getAsyncModeResponse } = createDingtalkReplyDispatcher({
       cfg,
       agentId: matchedAgentId,  // ✅ 使用手动匹配的 agentId
       runtime: runtime as RuntimeEnv,
@@ -1506,6 +1506,10 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
     const dispatchResult = await core.channel.reply.withReplyDispatcher({
       dispatcher,
       onSettled: () => {
+        // 2026.7.x 通道契约：settle 时成对调用 markRunComplete + markDispatchIdle
+        //（typing 控制器需要两个信号齐全才会 cleanup/seal，缺 markRunComplete
+        // 会导致 typing keepalive 无法收口，见 openclaw typing.ts:189-197）。
+        markRunComplete?.();
         markDispatchIdle();
       },
       run: async () => {

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -221,8 +221,71 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
   const streamingEnabled = !isTextMode && (account.config as any)?.streaming !== false;
   // 用 Promise 保存 AI Card 的创建过程，避免 final 消息到达时轮询等待
   let cardCreationPromise: Promise<void> | null = null;
+  // 回合 settle（onIdle）后置 true。openclaw 2026.5.x+ 存在 settle 之后仍会送达的
+  // 迟到回调（typing keepalive 触发的 onReplyStart、steer/followup 认领回合经旧
+  // dispatcher 投递的 block 等，见 openclaw typing.ts 的 sealed 机制注释）。
+  // 密封后不再创建新卡片——settle 后创建的卡片没有任何收口方，必然孤儿转圈。
+  let streamingSealed = false;
+
+  // ===== 卡片守护超时（watchdog）=====
+  // settle 可能永远不来：上游 run 挂死、openclaw dispatch 不返回、或收口链中
+  // 无超时的调用挂住——此时 onIdle 收口路径整体失效，卡片将永久转圈。
+  // watchdog 是最后防线：卡片创建后计时，流式更新/命令输出会刷新计时；
+  // 到期仍未收口则强制 finishAICard 并密封本轮，之后迟到的 final/block
+  // 走密封降级路径以普通消息发出，内容不丢失。
+  const CARD_WATCHDOG_TIMEOUT_MS = 10 * 60 * 1000;
+  let cardWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
+  let watchdogCard: AICardInstance | null = null;
+
+  const clearCardWatchdog = () => {
+    if (cardWatchdogTimer) {
+      clearTimeout(cardWatchdogTimer);
+      cardWatchdogTimer = null;
+    }
+    watchdogCard = null;
+  };
+
+  const forceFinishStaleCard = async () => {
+    const staleCard = watchdogCard;
+    cardWatchdogTimer = null;
+    watchdogCard = null;
+    if (!staleCard) return;
+    // 本轮已不可信：密封防止迟到回调再建卡；清空引用防止收口路径二次 finish
+    streamingSealed = true;
+    if (currentCardTarget === (staleCard as any)) {
+      currentCardTarget = null;
+    }
+    const timeoutText = accumulatedText.trim() || pickEmptyReplyFallbackText(!isDirect);
+    log.warn(
+      `[DingTalk][cardWatchdog] 卡片超过 ${CARD_WATCHDOG_TIMEOUT_MS / 60000} 分钟未收口（settle 未到达），强制结束以避免永久转圈`,
+    );
+    try {
+      await finishAICard(staleCard, timeoutText, account.config as DingtalkConfig, log);
+      outboundUserVisibleThisTurn = true;
+      log.info(`[DingTalk][cardWatchdog] ✅ 强制收口成功`);
+    } catch (err: any) {
+      log.error(`[DingTalk][cardWatchdog] ❌ 强制收口失败：${err?.message || String(err)}`);
+    } finally {
+      accumulatedText = "";
+    }
+  };
+
+  const armCardWatchdog = () => {
+    if (cardWatchdogTimer) {
+      clearTimeout(cardWatchdogTimer);
+    }
+    cardWatchdogTimer = setTimeout(() => {
+      void forceFinishStaleCard();
+    }, CARD_WATCHDOG_TIMEOUT_MS);
+    (cardWatchdogTimer as any).unref?.();
+  };
 
   const startStreaming = (): Promise<void> => {
+    // 回合已 settle：迟到回调不得再创建 AI Card
+    if (streamingSealed) {
+      log.debug(`[DingTalk][startStreaming] 回合已 settle（sealed），跳过 AI Card 创建`);
+      return Promise.resolve();
+    }
     // 如果已经有创建中的 Promise，直接复用，避免并发创建
     if (cardCreationPromise) {
       return cardCreationPromise;
@@ -250,6 +313,8 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         currentCardTarget = preCreatedCard as any;
         accumulatedText = "";
         outboundUserVisibleThisTurn = true;
+        watchdogCard = preCreatedCard;
+        armCardWatchdog();
         return;
       }
 
@@ -271,6 +336,8 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         accumulatedText = "";
 
         if (card) {
+          watchdogCard = card;
+          armCardWatchdog();
           log.info(`[DingTalk][startStreaming] ✅ AI Card 创建成功`);
         } else {
           log.warn(`[DingTalk][startStreaming] AI Card 创建返回 null，静默降级到普通消息模式`);
@@ -288,6 +355,18 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
   };
 
   const closeStreaming: () => Promise<void> = async () => {
+    // ✅ 先等待仍在途的卡片创建完成再快照。final 被上游抑制的回合
+    // （openclaw 2026.5.x+ 的 message_tool_only / steer 认领，final 永远不会
+    // 经 deliver 到达）里 onIdle → closeStreaming 是唯一收口；若此刻创建
+    // HTTP 尚未返回，直接快照会拿到 null 而跳过关闭，卡片随后创建成功后
+    // 将永远停留在 INPUTING（转圈）状态。
+    if (cardCreationPromise) {
+      try {
+        await cardCreationPromise;
+      } catch {
+        // 创建失败已在 startStreaming 内部降级处理，此处继续走快照逻辑即可
+      }
+    }
     // 立即捕获并清空，防止并发调用重复执行（竞争条件保护）
     // closeStreaming 可能被 onIdle 和 onError 同时触发，若不在此处清空，
     // 第一次调用的 finally 块会将 currentCardTarget 置 null，
@@ -450,7 +529,9 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         }
       }
     } finally {
-      // currentCardTarget 已在函数开头清空，此处只需重置累积文本
+      // currentCardTarget 已在函数开头清空，此处只需重置累积文本；
+      // 正常收口完成，解除守护计时（若 watchdog 已先行触发则此处为幂等清理）
+      clearCardWatchdog();
       accumulatedText = "";
     }
   };
@@ -516,7 +597,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
     }
   };
 
-  const { dispatcher, replyOptions, markDispatchIdle } =
+  const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
     core.channel.reply.createReplyDispatcherWithTyping({
       ...prefixOptions,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
@@ -601,6 +682,37 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
             log.info(`[DingTalk][deliver] block 消息，流式未启用，丢弃`);
             return;
           }
+          // 回合已 settle：这可能是 steer/followup 认领回合经本 dispatcher 送达的
+          // 实际回复（openclaw 2026.5.x+ 对认领回合从不投递 final，只以 block 形式
+          // 经原回合 dispatcher 送达）。降级为普通消息发出——既保住回复内容，
+          // 也不会创建一张无人收口的孤儿卡片。
+          if (streamingSealed) {
+            log.info(`[DingTalk][deliver] block 晚于 settle 到达，降级为普通消息发送，文本长度=${text.length}`);
+            try {
+              for (const chunk of core.channel.text.chunkTextWithMode(
+                text,
+                textChunkLimit,
+                chunkMode
+              )) {
+                await sendMessage(
+                  account.config as DingtalkConfig,
+                  sessionWebhook,
+                  chunk,
+                  {
+                    useMarkdown: true,
+                    log: params.runtime.log,
+                    cfg,
+                    detectBareAliases: true,
+                  }
+                );
+              }
+              outboundUserVisibleThisTurn = true;
+              log.info(`[DingTalk][deliver] ✅ 迟到 block 降级发送成功`);
+            } catch (lateErr: any) {
+              log.error(`[DingTalk][deliver] ❌ 迟到 block 降级发送失败：${lateErr.message}`);
+            }
+            return;
+          }
           log.info(`[DingTalk][deliver] block 消息，追加到流式 AI Card，文本长度=${text.length}`);
           // 确保 AI Card 已创建（startStreaming 内部会复用已有的 cardCreationPromise）
           await startStreaming();
@@ -620,6 +732,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
                   log
                 );
                 outboundUserVisibleThisTurn = true;
+                if (watchdogCard) armCardWatchdog();
                 log.info(`[DingTalk][deliver] ✅ block 更新到 AI Card 成功`);
               } catch (streamErr: any) {
                 log.error(`[DingTalk][deliver] ❌ block 更新 AI Card 失败：${streamErr.message}`);
@@ -717,6 +830,10 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       onIdle: async () => {
         log.info(`[DingTalk][onIdle] 回复空闲，关闭 AI Card`);
         typingCallbacks.onIdle?.();
+        // 先密封再收口：onIdle 意味着本轮 dispatcher 已 settle
+        //（reservation 语义保证 onIdle 只在 markComplete 之后触发），
+        // 此后任何迟到回调都不允许再创建新卡片。
+        streamingSealed = true;
         await closeStreaming();
         await maybeSendGroupVisibleRepliesIdleNudge();
       },
@@ -782,6 +899,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
                 log
               );
               outboundUserVisibleThisTurn = true;
+              if (watchdogCard) armCardWatchdog();
               log.debug(`[DingTalk][onPartialReply] ✅ AI Card 更新成功`);
             } catch (err: any) {
               // QPS 限流是瞬时错误：streamAICard 内部已自动退避+重试，
@@ -820,6 +938,8 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         durationMs?: number;
         cwd?: string;
       }) => {
+        // 命令仍在执行说明本轮存活：刷新卡片守护计时，避免长任务被误判为挂死
+        if (watchdogCard) armCardWatchdog();
         const commandText = payload.title || payload.name || '';
         const dwsMatch = commandText.match(DWS_PRODUCT_PATTERN) || payload.output?.match(DWS_PRODUCT_PATTERN);
         if (dwsMatch) {
@@ -836,6 +956,10 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       },
     },
     markDispatchIdle,
+    // 2026.7.x 通道契约要求 settle 时成对调用 markRunComplete + markDispatchIdle
+    //（参照 openclaw core dispatch.ts 与 Feishu 插件 comment-handler）；
+    // 旧版 SDK（2026.4.9）同样返回该方法，可选调用保证向后兼容。
+    markRunComplete: () => markRunComplete?.(),
     getAsyncModeResponse: () => asyncModeFullResponse,
   };
 }

--- a/tests/reply-dispatcher/card-lifecycle.test.ts
+++ b/tests/reply-dispatcher/card-lifecycle.test.ts
@@ -1,0 +1,298 @@
+/**
+ * AI Card 生命周期回归测试（openclaw >=2026.5.x 兼容性）
+ *
+ * 背景：openclaw 2026.5.x 引入 source-reply delivery mode（message_tool_only）
+ * 与 steer/followup 认领机制后，存在大量「deliver(kind:"final") 永远不会到达」
+ * 的回合。此时唯一的关卡路径是 onIdle → closeStreaming：
+ *
+ * 1. closeStreaming 必须等待仍在途的 AI Card 创建完成，否则快照为 null 直接
+ *    跳过，卡片随后才创建成功，永远停在 INPUTING（转圈）状态；
+ * 2. 回合 settle（onIdle）之后到达的迟到回调（partial / block）不得再创建
+ *    新卡片——新卡片没有任何收口方，必然变成孤儿转圈卡；
+ * 3. 迟到 block 携带的文本（steer/followup 认领回合的实际回复）应降级为
+ *    普通消息发出，而不是丢弃或写进孤儿卡片；
+ * 4. wrapper 需向 message-handler 透传 SDK 的 markRunComplete，以满足
+ *    2026.7.x 的通道契约（markRunComplete + markDispatchIdle 成对调用）。
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateReplyDispatcherWithTyping = vi.hoisted(() => vi.fn());
+const mockResolveDingtalkAccount = vi.hoisted(() => vi.fn());
+const mockGetDingtalkRuntime = vi.hoisted(() => vi.fn());
+const mockCreateAICardForTarget = vi.hoisted(() => vi.fn());
+const mockStreamAICard = vi.hoisted(() => vi.fn());
+const mockFinishAICard = vi.hoisted(() => vi.fn());
+const mockIsQpsLimitError = vi.hoisted(() => vi.fn());
+const mockSendMessage = vi.hoisted(() => vi.fn());
+const mockSendTextMessage = vi.hoisted(() => vi.fn());
+const mockSendMarkdownMessage = vi.hoisted(() => vi.fn());
+const mockGetOapiAccessToken = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  createReplyPrefixOptions: vi.fn(() => ({
+    onModelSelected: vi.fn(),
+  })),
+  createTypingCallbacks: vi.fn(() => ({
+    onActive: vi.fn(),
+    onIdle: vi.fn(),
+    onCleanup: vi.fn(),
+  })),
+  logTypingFailure: vi.fn(),
+}));
+
+vi.mock("../../src/config/accounts.ts", () => ({
+  resolveDingtalkAccount: mockResolveDingtalkAccount,
+}));
+
+vi.mock("../../src/runtime.ts", () => ({
+  getDingtalkRuntime: mockGetDingtalkRuntime,
+}));
+
+vi.mock("../../src/services/messaging/card.ts", () => ({
+  createAICardForTarget: mockCreateAICardForTarget,
+  streamAICard: mockStreamAICard,
+  finishAICard: mockFinishAICard,
+  isQpsLimitError: mockIsQpsLimitError,
+}));
+
+vi.mock("../../src/services/messaging.ts", () => ({
+  sendMessage: mockSendMessage,
+  sendTextMessage: mockSendTextMessage,
+  sendMarkdownMessage: mockSendMarkdownMessage,
+}));
+
+vi.mock("../../src/services/media/image.ts", () => ({
+  processLocalImages: vi.fn(async (s: string) => s),
+}));
+
+vi.mock("../../src/services/media/video.ts", () => ({
+  processVideoMarkers: vi.fn(async (s: string) => s),
+}));
+
+vi.mock("../../src/services/media/audio.ts", () => ({
+  processAudioMarkers: vi.fn(async (s: string) => s),
+}));
+
+vi.mock("../../src/services/media/file.ts", () => ({
+  uploadAndReplaceFileMarkers: vi.fn(async (s: string) => s),
+}));
+
+vi.mock("../../src/utils/token.ts", () => ({
+  getAccessToken: vi.fn(),
+  getOapiAccessToken: mockGetOapiAccessToken,
+}));
+
+const CARD = {
+  cardInstanceId: "card-1",
+  accessToken: "tk",
+  inputingStarted: false,
+};
+
+function makeRuntime() {
+  return {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+async function makeDispatcher(overrides: Record<string, unknown> = {}) {
+  const { createDingtalkReplyDispatcher } = await import("../../src/reply-dispatcher");
+  const result = createDingtalkReplyDispatcher({
+    cfg: {} as any,
+    agentId: "a1",
+    runtime: makeRuntime() as any,
+    conversationId: "conv-1",
+    senderId: "user-1",
+    isDirect: true,
+    sessionWebhook: "http://webhook",
+    ...overrides,
+  } as any);
+  const args = (globalThis as any).__dispatcherArgs;
+  return { result, args };
+}
+
+describe("reply-dispatcher AI card lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveDingtalkAccount.mockReturnValue({
+      accountId: "acc-1",
+      config: { debug: false, streaming: true },
+    });
+    mockGetOapiAccessToken.mockResolvedValue(null);
+    mockCreateAICardForTarget.mockResolvedValue(CARD);
+    mockStreamAICard.mockResolvedValue(undefined);
+    mockFinishAICard.mockResolvedValue(undefined);
+    mockSendMessage.mockResolvedValue({ ok: true });
+    mockSendTextMessage.mockResolvedValue({ ok: true });
+    mockSendMarkdownMessage.mockResolvedValue({ ok: true });
+    mockIsQpsLimitError.mockReturnValue(false);
+    mockCreateReplyDispatcherWithTyping.mockImplementation((args: any) => {
+      (globalThis as any).__dispatcherArgs = args;
+      return {
+        dispatcher: {},
+        replyOptions: {},
+        markDispatchIdle: vi.fn(),
+        markRunComplete: vi.fn(),
+      };
+    });
+    mockGetDingtalkRuntime.mockReturnValue({
+      channel: {
+        text: {
+          resolveTextChunkLimit: () => 4000,
+          resolveChunkMode: () => "markdown",
+          chunkTextWithMode: (text: string) => [text],
+        },
+        reply: {
+          resolveHumanDelayConfig: () => ({ enabled: false }),
+          createReplyDispatcherWithTyping: mockCreateReplyDispatcherWithTyping,
+        },
+      },
+    });
+  });
+
+  // 竞态修复：final 被上游抑制（message_tool_only / steer 认领）时，
+  // onIdle 是唯一收口。若 onIdle 在 AI Card 创建 HTTP 返回前执行，
+  // 旧实现快照 currentCardTarget 为 null 直接跳过 → 卡片永远转圈。
+  it("closes the AI card even when onIdle fires before card creation completes", async () => {
+    let resolveCard!: (card: typeof CARD) => void;
+    mockCreateAICardForTarget.mockImplementation(
+      () => new Promise((resolve) => {
+        resolveCard = resolve;
+      }),
+    );
+
+    const { args } = await makeDispatcher();
+
+    // onReplyStart 触发 fire-and-forget 的卡片创建（HTTP 仍在途）
+    args.onReplyStart();
+    expect(mockCreateAICardForTarget).toHaveBeenCalledTimes(1);
+
+    // final 被上游抑制，onIdle 先于创建完成到达
+    const idlePromise = args.onIdle();
+
+    // 给 closeStreaming 一个 tick 抵达它的快照/等待点，再让创建完成
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    resolveCard(CARD);
+
+    await idlePromise;
+    // 允许收口用的微任务全部落地
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // 卡片必须被 finishAICard 收口，不能留在 INPUTING 转圈状态
+    expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+  });
+
+  // 密封修复：settle 后到达的迟到 onPartialReply 不得再创建新卡片。
+  // 新卡片没有任何收口方（本轮 dispatcher 已 settle），必然孤儿转圈。
+  it("does not create a new AI card when onPartialReply arrives after the turn settled", async () => {
+    const { result, args } = await makeDispatcher();
+
+    args.onReplyStart();
+    await args.deliver({ text: "final-1" }, { kind: "final" });
+    await args.onIdle();
+
+    mockCreateAICardForTarget.mockClear();
+    mockStreamAICard.mockClear();
+
+    await result.replyOptions.onPartialReply?.({ text: "late-partial" });
+
+    expect(mockCreateAICardForTarget).not.toHaveBeenCalled();
+    expect(mockStreamAICard).not.toHaveBeenCalled();
+  });
+
+  // 密封修复 + 内容保全：settle 后经旧 dispatcher 送达的 block
+  // （steer/followup 认领回合的实际回复）应降级为普通消息，
+  // 而不是写进一张永远不会被关闭的新卡片。
+  it("delivers a late block as a plain message instead of opening a new card", async () => {
+    const { args } = await makeDispatcher();
+
+    args.onReplyStart();
+    await args.deliver({ text: "final-1" }, { kind: "final" });
+    await args.onIdle();
+
+    mockCreateAICardForTarget.mockClear();
+
+    await args.deliver({ text: "late-followup-reply" }, { kind: "block" });
+
+    expect(mockCreateAICardForTarget).not.toHaveBeenCalled();
+    expect(mockSendMessage).toHaveBeenCalled();
+    const sentText = mockSendMessage.mock.calls.at(-1)?.[2];
+    expect(String(sentText)).toContain("late-followup-reply");
+  });
+
+  // 守护超时：settle 可能永远不来（上游 run 挂死 / 收口链中无超时的调用挂住），
+  // 此时 onIdle 收口路径完全失效。watchdog 到期必须强制 finishAICard 并密封，
+  // 之后迟到的 final 降级为普通消息发出，内容不丢失。
+  it("force-finishes a stale card via watchdog and degrades a late final to a plain message", async () => {
+    vi.useFakeTimers();
+    try {
+      const { args } = await makeDispatcher();
+
+      args.onReplyStart();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockCreateAICardForTarget).toHaveBeenCalledTimes(1);
+
+      // 模拟挂死：没有 deliver、没有 onIdle，只有时间流逝
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1000);
+
+      // watchdog 强制收口，卡片不再永久转圈
+      expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+
+      // 挂死解除后迟到的 final：不得重新开卡，降级为普通消息，内容保全
+      mockSendMessage.mockClear();
+      mockCreateAICardForTarget.mockClear();
+      await args.deliver({ text: "late-final-after-watchdog" }, { kind: "final" });
+      expect(mockCreateAICardForTarget).not.toHaveBeenCalled();
+      expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+      expect(mockSendMessage).toHaveBeenCalled();
+      const sentText = mockSendMessage.mock.calls.at(-1)?.[2];
+      expect(String(sentText)).toContain("late-final-after-watchdog");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 守护超时的边界：正常收口后 watchdog 必须被清除，不得二次 finish。
+  it("watchdog does not double-finish a card that closed normally", async () => {
+    vi.useFakeTimers();
+    try {
+      const { args } = await makeDispatcher();
+
+      args.onReplyStart();
+      await vi.advanceTimersByTimeAsync(0);
+      await args.deliver({ text: "final-1" }, { kind: "final" });
+      expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 契约修复：2026.7.x 通道契约要求在 settle 时成对调用
+  // markRunComplete() + markDispatchIdle()（参照 core dispatch.ts:695-696
+  // 与 Feishu comment-handler.ts:324-330）。wrapper 需要把 SDK 返回的
+  // markRunComplete 透传给 message-handler。
+  it("exposes markRunComplete from the underlying SDK dispatcher", async () => {
+    const sdkMarkRunComplete = vi.fn();
+    mockCreateReplyDispatcherWithTyping.mockImplementation((args: any) => {
+      (globalThis as any).__dispatcherArgs = args;
+      return {
+        dispatcher: {},
+        replyOptions: {},
+        markDispatchIdle: vi.fn(),
+        markRunComplete: sdkMarkRunComplete,
+      };
+    });
+
+    const { result } = await makeDispatcher();
+
+    expect(typeof result.markRunComplete).toBe("function");
+    result.markRunComplete();
+    expect(sdkMarkRunComplete).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 解决什么问题 / What Problem This Solves

AI Card 在部分回合永久停留在转圈（INPUTING）状态、无任何内容输出、跨天不恢复。完整的源码级根因分析（openclaw v2026.7.1 + connector 0.8.24 双侧引用行号）、报告环境实测轨迹与逐行日志判据见 #644。

一句话概括：connector 的卡片收口完全依赖「`deliver(kind:"final")` 到达」或「settle 到达后的 `onIdle` 兜底」，而 openclaw ≥2026.5.x 存在多条两者皆不到达的路径——

1. **final 从不投递**（`message_tool_only` 抑制 / steer-followup 认领 / 空 final 被 normalize 丢弃 / `beforeDeliver` 取消 / origin 路由），此时唯一收口 `onIdle → closeStreaming` 与 fire-and-forget 的卡片创建存在竞态（`closeStreaming` 快照到 `null` 直接跳过，卡片随后才创建成功 → 永久转圈）；
2. **settle 从不到达**（上游 dispatch/run 挂死，或收口链中无超时的调用挂住），此时连 `onIdle` 兜底整体失效——connector 没有任何守护超时。报告环境的实测轨迹（卡片跨天转圈、追发消息可正常回复）指向此类。

## 修复内容 / Changes

| # | 修复 | 位置 |
|---|---|---|
| 1 | `closeStreaming` 先 `await cardCreationPromise` 再快照，消除收口与创建的竞态 | `src/reply-dispatcher.ts` |
| 2 | settle（`onIdle`）时密封 `startStreaming`：迟到的 partial/`onReplyStart` 不再创建无人收口的孤儿卡片（对齐 openclaw `typing.ts` 的 sealed 思路） | `src/reply-dispatcher.ts` |
| 3 | 迟到 block 降级为普通消息发出：steer/followup 认领回合经原 dispatcher 送达的实际回复内容不丢失 | `src/reply-dispatcher.ts` |
| 4 | 新增卡片守护超时（watchdog，默认 10 分钟；流式更新 / `onCommandOutput` 命令活动刷新计时）：到期强制 `finishAICard` 并密封本轮，其后迟到的 final/block 走密封降级路径以普通消息送达——不依赖 settle，覆盖「上游挂死」场景 | `src/reply-dispatcher.ts` |
| 5 | 透传并在 `onSettled` 中调用 `markRunComplete`，对齐 openclaw 2026.7.x 通道契约（core `dispatch.ts:695-696`、Feishu 插件同款做法；2026.4.9 SDK 亦返回该方法，向后兼容） | `src/reply-dispatcher.ts`、`src/core/message-handler.ts` |

## 测试 / Evidence

- TDD：新增 `tests/reply-dispatcher/card-lifecycle.test.ts` 6 例（竞态收口 / settle 后不建卡 / 迟到 block 降级 / watchdog 强制收口并降级迟到 final / watchdog 正常收口后不二次 finish / `markRunComplete` 透传），全部先行确认 RED（修复前按预期原因失败）后转 GREEN；watchdog 用 fake timers 模拟挂死。
- 本分支（基于 `main` @ v0.8.24 GA）：`tests/reply-dispatcher/` + `tests/ai-card/` **49/49 通过**；全量套件 **511 通过 / 11 跳过 / 5 失败**——5 个失败全部位于 `tests/probe/probe.test.ts`，为**原有**失败（在未打补丁的 v0.8.24 原始代码上复现同样 5 例，与本改动无关）。
- `tsc --noEmit`：触及文件无新增错误（仓库既有的 `accounts.ts`/`connection.ts`/`pdf-parse` 报错与本 PR 无关）。
- **尚未做真机 E2E**（无真实网关/机器人凭据）：建议按 #644 的「日志判据」做打补丁前后对照——补丁前卡片永久转圈；补丁后任何回合的卡片都会在 final、settle 或 watchdog 三者最先到达时收口，且迟到内容以普通消息送达。

## 兼容性说明

- 全部改动位于 connector 侧回复分发闭包内，不改变正常回合（final 正常到达）的行为路径；
- `markRunComplete` 在 2026.4.9 era SDK 中同样存在（已核对其 npm dist），可选调用（`?.()`）保证更旧版本不受影响；
- watchdog 定时器 `unref`，不阻止进程退出。

Fixes #644
