### PR TITLE
fix: ensure AI Card is finalized on error/settle-missing/hang turns (supersedes #645)

### DIFF
--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -1465,7 +1465,7 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
     } as any);
 
     // 创建 reply dispatcher，使用解析后的 agentId
-    const { dispatcher, replyOptions, markDispatchIdle, getAsyncModeResponse } = createDingtalkReplyDispatcher({
+    const { dispatcher, replyOptions, markDispatchIdle, markRunComplete, getAsyncModeResponse } = createDingtalkReplyDispatcher({
       cfg,
       agentId: matchedAgentId,  // ✅ 使用手动匹配的 agentId
       runtime: runtime as RuntimeEnv,
@@ -1506,6 +1506,10 @@ export async function handleDingTalkMessageInternal(params: HandleMessageParams)
     const dispatchResult = await core.channel.reply.withReplyDispatcher({
       dispatcher,
       onSettled: () => {
+        // 2026.7.x 通道契约：settle 时成对调用 markRunComplete + markDispatchIdle
+        //（typing 控制器需要两个信号齐全才会 cleanup/seal，缺 markRunComplete
+        // 会导致 typing keepalive 无法收口，见 openclaw typing.ts:189-197）。
+        markRunComplete?.();
         markDispatchIdle();
       },
       run: async () => {

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -295,7 +295,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       return Promise.resolve();
     }
 
-    cardCreationPromise = (async () => {
+    const creation = (async () => {
       // 异步模式下禁用流式 AI Card
       if (asyncMode) {
         log.info(`[DingTalk][startStreaming] 异步模式，跳过 AI Card 创建`);
@@ -345,13 +345,20 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       } catch (error: any) {
         log.error(`[DingTalk][startStreaming] ❌ AI Card 创建失败：${error?.message || String(error)}，静默降级到普通消息模式`);
         currentCardTarget = null;
-      } finally {
-        // 创建完成后清空 Promise，允许下次重新创建
-        cardCreationPromise = null;
       }
     })();
 
-    return cardCreationPromise;
+    cardCreationPromise = creation;
+    // 在 Promise settle 后清空 gate，覆盖所有路径（含 asyncMode /
+    // !streamingEnabled / preCreatedCard 的 early return——它们不进入
+    // 内部 try/finally，旧实现只在内部 finally 清空，导致这三条路径
+    // 的 cardCreationPromise 永远指向已 settle 的 stale Promise，后续
+    // startStreaming 调用会复用 stale Promise 而非走 currentCardTarget
+    // 快捷路径或重新创建）。
+    creation.finally(() => {
+      if (cardCreationPromise === creation) cardCreationPromise = null;
+    });
+    return creation;
   };
 
   const closeStreaming: () => Promise<void> = async () => {
@@ -616,8 +623,12 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         outboundUserVisibleThisTurn = false;
         idleConfigNudgeSent = false;
         if (streamingEnabled) {
-          // fire-and-forget：提前创建 AI Card，onPartialReply 会等待创建完成
-          void startStreaming();
+          // fire-and-forget：提前创建 AI Card，onPartialReply 会等待创建完成。
+          // 加 .catch() 防止 IIFE early-return 路径（preCreatedCard 里
+          // armCardWatchdog 等）抛出时成为 unhandledRejection。
+          void startStreaming().catch(err =>
+            log.error(`[DingTalk][onReplyStart] startStreaming error: ${err?.message || err}`)
+          );
         }
         typingCallbacks.onActive?.();
       },

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -221,8 +221,71 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
   const streamingEnabled = !isTextMode && (account.config as any)?.streaming !== false;
   // 用 Promise 保存 AI Card 的创建过程，避免 final 消息到达时轮询等待
   let cardCreationPromise: Promise<void> | null = null;
+  // 回合 settle（onIdle）后置 true。openclaw 2026.5.x+ 存在 settle 之后仍会送达的
+  // 迟到回调（typing keepalive 触发的 onReplyStart、steer/followup 认领回合经旧
+  // dispatcher 投递的 block 等，见 openclaw typing.ts 的 sealed 机制注释）。
+  // 密封后不再创建新卡片——settle 后创建的卡片没有任何收口方，必然孤儿转圈。
+  let streamingSealed = false;
+
+  // ===== 卡片守护超时（watchdog）=====
+  // settle 可能永远不来：上游 run 挂死、openclaw dispatch 不返回、或收口链中
+  // 无超时的调用挂住——此时 onIdle 收口路径整体失效，卡片将永久转圈。
+  // watchdog 是最后防线：卡片创建后计时，流式更新/命令输出会刷新计时；
+  // 到期仍未收口则强制 finishAICard 并密封本轮，之后迟到的 final/block
+  // 走密封降级路径以普通消息发出，内容不丢失。
+  const CARD_WATCHDOG_TIMEOUT_MS = 10 * 60 * 1000;
+  let cardWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
+  let watchdogCard: AICardInstance | null = null;
+
+  const clearCardWatchdog = () => {
+    if (cardWatchdogTimer) {
+      clearTimeout(cardWatchdogTimer);
+      cardWatchdogTimer = null;
+    }
+    watchdogCard = null;
+  };
+
+  const forceFinishStaleCard = async () => {
+    const staleCard = watchdogCard;
+    cardWatchdogTimer = null;
+    watchdogCard = null;
+    if (!staleCard) return;
+    // 本轮已不可信：密封防止迟到回调再建卡；清空引用防止收口路径二次 finish
+    streamingSealed = true;
+    if (currentCardTarget === (staleCard as any)) {
+      currentCardTarget = null;
+    }
+    const timeoutText = accumulatedText.trim() || pickEmptyReplyFallbackText(!isDirect);
+    log.warn(
+      `[DingTalk][cardWatchdog] 卡片超过 ${CARD_WATCHDOG_TIMEOUT_MS / 60000} 分钟未收口（settle 未到达），强制结束以避免永久转圈`,
+    );
+    try {
+      await finishAICard(staleCard, timeoutText, account.config as DingtalkConfig, log);
+      outboundUserVisibleThisTurn = true;
+      log.info(`[DingTalk][cardWatchdog] ✅ 强制收口成功`);
+    } catch (err: any) {
+      log.error(`[DingTalk][cardWatchdog] ❌ 强制收口失败：${err?.message || String(err)}`);
+    } finally {
+      accumulatedText = "";
+    }
+  };
+
+  const armCardWatchdog = () => {
+    if (cardWatchdogTimer) {
+      clearTimeout(cardWatchdogTimer);
+    }
+    cardWatchdogTimer = setTimeout(() => {
+      void forceFinishStaleCard();
+    }, CARD_WATCHDOG_TIMEOUT_MS);
+    (cardWatchdogTimer as any).unref?.();
+  };
 
   const startStreaming = (): Promise<void> => {
+    // 回合已 settle：迟到回调不得再创建 AI Card
+    if (streamingSealed) {
+      log.debug(`[DingTalk][startStreaming] 回合已 settle（sealed），跳过 AI Card 创建`);
+      return Promise.resolve();
+    }
     // 如果已经有创建中的 Promise，直接复用，避免并发创建
     if (cardCreationPromise) {
       return cardCreationPromise;
@@ -250,6 +313,8 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         currentCardTarget = preCreatedCard as any;
         accumulatedText = "";
         outboundUserVisibleThisTurn = true;
+        watchdogCard = preCreatedCard;
+        armCardWatchdog();
         return;
       }
 
@@ -271,6 +336,8 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         accumulatedText = "";
 
         if (card) {
+          watchdogCard = card;
+          armCardWatchdog();
           log.info(`[DingTalk][startStreaming] ✅ AI Card 创建成功`);
         } else {
           log.warn(`[DingTalk][startStreaming] AI Card 创建返回 null，静默降级到普通消息模式`);
@@ -288,6 +355,18 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
   };
 
   const closeStreaming: () => Promise<void> = async () => {
+    // ✅ 先等待仍在途的卡片创建完成再快照。final 被上游抑制的回合
+    // （openclaw 2026.5.x+ 的 message_tool_only / steer 认领，final 永远不会
+    // 经 deliver 到达）里 onIdle → closeStreaming 是唯一收口；若此刻创建
+    // HTTP 尚未返回，直接快照会拿到 null 而跳过关闭，卡片随后创建成功后
+    // 将永远停留在 INPUTING（转圈）状态。
+    if (cardCreationPromise) {
+      try {
+        await cardCreationPromise;
+      } catch {
+        // 创建失败已在 startStreaming 内部降级处理，此处继续走快照逻辑即可
+      }
+    }
     // 立即捕获并清空，防止并发调用重复执行（竞争条件保护）
     // closeStreaming 可能被 onIdle 和 onError 同时触发，若不在此处清空，
     // 第一次调用的 finally 块会将 currentCardTarget 置 null，
@@ -450,7 +529,9 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         }
       }
     } finally {
-      // currentCardTarget 已在函数开头清空，此处只需重置累积文本
+      // currentCardTarget 已在函数开头清空，此处只需重置累积文本；
+      // 正常收口完成，解除守护计时（若 watchdog 已先行触发则此处为幂等清理）
+      clearCardWatchdog();
       accumulatedText = "";
     }
   };
@@ -516,7 +597,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
     }
   };
 
-  const { dispatcher, replyOptions, markDispatchIdle } =
+  const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
     core.channel.reply.createReplyDispatcherWithTyping({
       ...prefixOptions,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
@@ -601,6 +682,37 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
             log.info(`[DingTalk][deliver] block 消息，流式未启用，丢弃`);
             return;
           }
+          // 回合已 settle：这可能是 steer/followup 认领回合经本 dispatcher 送达的
+          // 实际回复（openclaw 2026.5.x+ 对认领回合从不投递 final，只以 block 形式
+          // 经原回合 dispatcher 送达）。降级为普通消息发出——既保住回复内容，
+          // 也不会创建一张无人收口的孤儿卡片。
+          if (streamingSealed) {
+            log.info(`[DingTalk][deliver] block 晚于 settle 到达，降级为普通消息发送，文本长度=${text.length}`);
+            try {
+              for (const chunk of core.channel.text.chunkTextWithMode(
+                text,
+                textChunkLimit,
+                chunkMode
+              )) {
+                await sendMessage(
+                  account.config as DingtalkConfig,
+                  sessionWebhook,
+                  chunk,
+                  {
+                    useMarkdown: true,
+                    log: params.runtime.log,
+                    cfg,
+                    detectBareAliases: true,
+                  }
+                );
+              }
+              outboundUserVisibleThisTurn = true;
+              log.info(`[DingTalk][deliver] ✅ 迟到 block 降级发送成功`);
+            } catch (lateErr: any) {
+              log.error(`[DingTalk][deliver] ❌ 迟到 block 降级发送失败：${lateErr.message}`);
+            }
+            return;
+          }
           log.info(`[DingTalk][deliver] block 消息，追加到流式 AI Card，文本长度=${text.length}`);
           // 确保 AI Card 已创建（startStreaming 内部会复用已有的 cardCreationPromise）
           await startStreaming();
@@ -620,6 +732,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
                   log
                 );
                 outboundUserVisibleThisTurn = true;
+                if (watchdogCard) armCardWatchdog();
                 log.info(`[DingTalk][deliver] ✅ block 更新到 AI Card 成功`);
               } catch (streamErr: any) {
                 log.error(`[DingTalk][deliver] ❌ block 更新 AI Card 失败：${streamErr.message}`);
@@ -717,6 +830,10 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       onIdle: async () => {
         log.info(`[DingTalk][onIdle] 回复空闲，关闭 AI Card`);
         typingCallbacks.onIdle?.();
+        // 先密封再收口：onIdle 意味着本轮 dispatcher 已 settle
+        //（reservation 语义保证 onIdle 只在 markComplete 之后触发），
+        // 此后任何迟到回调都不允许再创建新卡片。
+        streamingSealed = true;
         await closeStreaming();
         await maybeSendGroupVisibleRepliesIdleNudge();
       },
@@ -782,6 +899,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
                 log
               );
               outboundUserVisibleThisTurn = true;
+              if (watchdogCard) armCardWatchdog();
               log.debug(`[DingTalk][onPartialReply] ✅ AI Card 更新成功`);
             } catch (err: any) {
               // QPS 限流是瞬时错误：streamAICard 内部已自动退避+重试，
@@ -820,6 +938,8 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         durationMs?: number;
         cwd?: string;
       }) => {
+        // 命令仍在执行说明本轮存活：刷新卡片守护计时，避免长任务被误判为挂死
+        if (watchdogCard) armCardWatchdog();
         const commandText = payload.title || payload.name || '';
         const dwsMatch = commandText.match(DWS_PRODUCT_PATTERN) || payload.output?.match(DWS_PRODUCT_PATTERN);
         if (dwsMatch) {
@@ -836,6 +956,10 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       },
     },
     markDispatchIdle,
+    // 2026.7.x 通道契约要求 settle 时成对调用 markRunComplete + markDispatchIdle
+    //（参照 openclaw core dispatch.ts 与 Feishu 插件 comment-handler）；
+    // 旧版 SDK（2026.4.9）同样返回该方法，可选调用保证向后兼容。
+    markRunComplete: () => markRunComplete?.(),
     getAsyncModeResponse: () => asyncModeFullResponse,
   };
 }

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -236,6 +236,12 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
   const CARD_WATCHDOG_TIMEOUT_MS = 10 * 60 * 1000;
   let cardWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
   let watchdogCard: AICardInstance | null = null;
+  // 同一张卡片只允许一次 finish。入口 clearCardWatchdog 盖不到
+  // 「卡片创建在途 → await 返回后 IIFE 才 arm → 媒体处理超过 timeout」
+  // 的窗口（#647 review）；closeStreaming 与 forceFinishStaleCard 必须
+  // 共享单飞，否则两条路径会各调一次 finishAICard。
+  let finishInFlight: Promise<void> | null = null;
+  const finishedCardIds = new Set<string>();
 
   const clearCardWatchdog = () => {
     if (cardWatchdogTimer) {
@@ -243,6 +249,29 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       cardWatchdogTimer = null;
     }
     watchdogCard = null;
+  };
+
+  const finishCardOnce = async (card: AICardInstance, text: string): Promise<void> => {
+    const id = card.cardInstanceId;
+    if (id && finishedCardIds.has(id)) {
+      log.info(`[DingTalk][finishCardOnce] 卡片已收口，跳过重复 finish`);
+      return;
+    }
+    if (finishInFlight) {
+      log.info(`[DingTalk][finishCardOnce] 收口进行中，等待进行中的 finish`);
+      await finishInFlight;
+      return;
+    }
+    const run = (async () => {
+      await finishAICard(card, text, account.config as DingtalkConfig, log);
+      if (id) finishedCardIds.add(id);
+    })();
+    finishInFlight = run;
+    try {
+      await run;
+    } finally {
+      if (finishInFlight === run) finishInFlight = null;
+    }
   };
 
   const forceFinishStaleCard = async () => {
@@ -260,7 +289,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
       `[DingTalk][cardWatchdog] 卡片超过 ${CARD_WATCHDOG_TIMEOUT_MS / 60000} 分钟未收口（settle 未到达），强制结束以避免永久转圈`,
     );
     try {
-      await finishAICard(staleCard, timeoutText, account.config as DingtalkConfig, log);
+      await finishCardOnce(staleCard, timeoutText);
       outboundUserVisibleThisTurn = true;
       log.info(`[DingTalk][cardWatchdog] ✅ 强制收口成功`);
     } catch (err: any) {
@@ -355,9 +384,15 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
     // 的 cardCreationPromise 永远指向已 settle 的 stale Promise，后续
     // startStreaming 调用会复用 stale Promise 而非走 currentCardTarget
     // 快捷路径或重新创建）。
-    creation.finally(() => {
+    // 不用 creation.finally(...)：其派生 Promise 是独立 rejection 通道，
+    // 调用方的 creation.catch() 盖不住它。Node 22 默认
+    // --unhandled-rejections=throw，派生 Promise 被丢弃时仍会打
+    // UNHANDLED REJECTION 并退出进程（#647 review）。
+    // then(onFulfilled, onRejected) 在两个 handler 都不抛时不会再 reject。
+    const clearCreationGate = () => {
       if (cardCreationPromise === creation) cardCreationPromise = null;
-    });
+    };
+    void creation.then(clearCreationGate, clearCreationGate);
     return creation;
   };
 
@@ -511,12 +546,7 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
 
       log.info(`[DingTalk][closeStreaming] 准备调用 finishAICard，文本长度=${finalText.length}`);
       log.debug(`[DingTalk][closeStreaming] 最终发送内容长度=${finalText.length}`);
-      await finishAICard(
-        cardSnapshot as any,
-        finalText,
-        account.config as DingtalkConfig,
-        log
-      );
+      await finishCardOnce(cardSnapshot as any, finalText);
       outboundUserVisibleThisTurn = true;
       log.info(`[DingTalk][closeStreaming] ✅ AI Card 关闭成功`);
     } catch (error: any) {

--- a/src/reply-dispatcher.ts
+++ b/src/reply-dispatcher.ts
@@ -355,6 +355,14 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
   };
 
   const closeStreaming: () => Promise<void> = async () => {
+    // ⚠️ 单飞入口：在任何 await 之前先解除 watchdog，防止收口与 watchdog
+    // 并发触发同一张卡片的 finishAICard。若不在入口清理，await
+    // cardCreationPromise / finishAICard 期间 watchdog 计时器仍会触发
+    // forceFinishStaleCard，两条路径会各自调一次 finishAICard，服务端
+    // 收到重复关闭请求，日志/计数与 outboundUserVisibleThisTurn 也会被
+    // 双写。closeStreaming 的正常/降级路径最终都会走到 finally 的
+    // clearCardWatchdog()，此处提前清理是幂等的。
+    clearCardWatchdog();
     // ✅ 先等待仍在途的卡片创建完成再快照。final 被上游抑制的回合
     // （openclaw 2026.5.x+ 的 message_tool_only / steer 认领，final 永远不会
     // 经 deliver 到达）里 onIdle → closeStreaming 是唯一收口；若此刻创建
@@ -823,6 +831,10 @@ export function createDingtalkReplyDispatcher(params: CreateDingtalkReplyDispatc
         params.runtime.error?.(
           `dingtalk[${account.accountId}] ${info.kind} reply failed: ${String(error)}`
         );
+        // 与 onIdle 对称：先密封再收口。onError 也是本轮的终结信号，
+        // 收口后到达的迟到 onReplyStart / partial / block 不得再创建新卡片，
+        // 否则同样会产生无人收口的孤儿卡（见 typing.ts 的 sealed 机制）。
+        streamingSealed = true;
         await closeStreaming();
         typingCallbacks.onIdle?.();
         await maybeSendGroupVisibleRepliesIdleNudge();

--- a/tests/reply-dispatcher/card-lifecycle.test.ts
+++ b/tests/reply-dispatcher/card-lifecycle.test.ts
@@ -1,0 +1,298 @@
+/**
+ * AI Card 生命周期回归测试（openclaw >=2026.5.x 兼容性）
+ *
+ * 背景：openclaw 2026.5.x 引入 source-reply delivery mode（message_tool_only）
+ * 与 steer/followup 认领机制后，存在大量「deliver(kind:"final") 永远不会到达」
+ * 的回合。此时唯一的关卡路径是 onIdle → closeStreaming：
+ *
+ * 1. closeStreaming 必须等待仍在途的 AI Card 创建完成，否则快照为 null 直接
+ *    跳过，卡片随后才创建成功，永远停在 INPUTING（转圈）状态；
+ * 2. 回合 settle（onIdle）之后到达的迟到回调（partial / block）不得再创建
+ *    新卡片——新卡片没有任何收口方，必然变成孤儿转圈卡；
+ * 3. 迟到 block 携带的文本（steer/followup 认领回合的实际回复）应降级为
+ *    普通消息发出，而不是丢弃或写进孤儿卡片；
+ * 4. wrapper 需向 message-handler 透传 SDK 的 markRunComplete，以满足
+ *    2026.7.x 的通道契约（markRunComplete + markDispatchIdle 成对调用）。
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreateReplyDispatcherWithTyping = vi.hoisted(() => vi.fn());
+const mockResolveDingtalkAccount = vi.hoisted(() => vi.fn());
+const mockGetDingtalkRuntime = vi.hoisted(() => vi.fn());
+const mockCreateAICardForTarget = vi.hoisted(() => vi.fn());
+const mockStreamAICard = vi.hoisted(() => vi.fn());
+const mockFinishAICard = vi.hoisted(() => vi.fn());
+const mockIsQpsLimitError = vi.hoisted(() => vi.fn());
+const mockSendMessage = vi.hoisted(() => vi.fn());
+const mockSendTextMessage = vi.hoisted(() => vi.fn());
+const mockSendMarkdownMessage = vi.hoisted(() => vi.fn());
+const mockGetOapiAccessToken = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  createReplyPrefixOptions: vi.fn(() => ({
+    onModelSelected: vi.fn(),
+  })),
+  createTypingCallbacks: vi.fn(() => ({
+    onActive: vi.fn(),
+    onIdle: vi.fn(),
+    onCleanup: vi.fn(),
+  })),
+  logTypingFailure: vi.fn(),
+}));
+
+vi.mock("../../src/config/accounts.ts", () => ({
+  resolveDingtalkAccount: mockResolveDingtalkAccount,
+}));
+
+vi.mock("../../src/runtime.ts", () => ({
+  getDingtalkRuntime: mockGetDingtalkRuntime,
+}));
+
+vi.mock("../../src/services/messaging/card.ts", () => ({
+  createAICardForTarget: mockCreateAICardForTarget,
+  streamAICard: mockStreamAICard,
+  finishAICard: mockFinishAICard,
+  isQpsLimitError: mockIsQpsLimitError,
+}));
+
+vi.mock("../../src/services/messaging.ts", () => ({
+  sendMessage: mockSendMessage,
+  sendTextMessage: mockSendTextMessage,
+  sendMarkdownMessage: mockSendMarkdownMessage,
+}));
+
+vi.mock("../../src/services/media/image.ts", () => ({
+  processLocalImages: vi.fn(async (s: string) => s),
+}));
+
+vi.mock("../../src/services/media/video.ts", () => ({
+  processVideoMarkers: vi.fn(async (s: string) => s),
+}));
+
+vi.mock("../../src/services/media/audio.ts", () => ({
+  processAudioMarkers: vi.fn(async (s: string) => s),
+}));
+
+vi.mock("../../src/services/media/file.ts", () => ({
+  uploadAndReplaceFileMarkers: vi.fn(async (s: string) => s),
+}));
+
+vi.mock("../../src/utils/token.ts", () => ({
+  getAccessToken: vi.fn(),
+  getOapiAccessToken: mockGetOapiAccessToken,
+}));
+
+const CARD = {
+  cardInstanceId: "card-1",
+  accessToken: "tk",
+  inputingStarted: false,
+};
+
+function makeRuntime() {
+  return {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+async function makeDispatcher(overrides: Record<string, unknown> = {}) {
+  const { createDingtalkReplyDispatcher } = await import("../../src/reply-dispatcher");
+  const result = createDingtalkReplyDispatcher({
+    cfg: {} as any,
+    agentId: "a1",
+    runtime: makeRuntime() as any,
+    conversationId: "conv-1",
+    senderId: "user-1",
+    isDirect: true,
+    sessionWebhook: "http://webhook",
+    ...overrides,
+  } as any);
+  const args = (globalThis as any).__dispatcherArgs;
+  return { result, args };
+}
+
+describe("reply-dispatcher AI card lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveDingtalkAccount.mockReturnValue({
+      accountId: "acc-1",
+      config: { debug: false, streaming: true },
+    });
+    mockGetOapiAccessToken.mockResolvedValue(null);
+    mockCreateAICardForTarget.mockResolvedValue(CARD);
+    mockStreamAICard.mockResolvedValue(undefined);
+    mockFinishAICard.mockResolvedValue(undefined);
+    mockSendMessage.mockResolvedValue({ ok: true });
+    mockSendTextMessage.mockResolvedValue({ ok: true });
+    mockSendMarkdownMessage.mockResolvedValue({ ok: true });
+    mockIsQpsLimitError.mockReturnValue(false);
+    mockCreateReplyDispatcherWithTyping.mockImplementation((args: any) => {
+      (globalThis as any).__dispatcherArgs = args;
+      return {
+        dispatcher: {},
+        replyOptions: {},
+        markDispatchIdle: vi.fn(),
+        markRunComplete: vi.fn(),
+      };
+    });
+    mockGetDingtalkRuntime.mockReturnValue({
+      channel: {
+        text: {
+          resolveTextChunkLimit: () => 4000,
+          resolveChunkMode: () => "markdown",
+          chunkTextWithMode: (text: string) => [text],
+        },
+        reply: {
+          resolveHumanDelayConfig: () => ({ enabled: false }),
+          createReplyDispatcherWithTyping: mockCreateReplyDispatcherWithTyping,
+        },
+      },
+    });
+  });
+
+  // 竞态修复：final 被上游抑制（message_tool_only / steer 认领）时，
+  // onIdle 是唯一收口。若 onIdle 在 AI Card 创建 HTTP 返回前执行，
+  // 旧实现快照 currentCardTarget 为 null 直接跳过 → 卡片永远转圈。
+  it("closes the AI card even when onIdle fires before card creation completes", async () => {
+    let resolveCard!: (card: typeof CARD) => void;
+    mockCreateAICardForTarget.mockImplementation(
+      () => new Promise((resolve) => {
+        resolveCard = resolve;
+      }),
+    );
+
+    const { args } = await makeDispatcher();
+
+    // onReplyStart 触发 fire-and-forget 的卡片创建（HTTP 仍在途）
+    args.onReplyStart();
+    expect(mockCreateAICardForTarget).toHaveBeenCalledTimes(1);
+
+    // final 被上游抑制，onIdle 先于创建完成到达
+    const idlePromise = args.onIdle();
+
+    // 给 closeStreaming 一个 tick 抵达它的快照/等待点，再让创建完成
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    resolveCard(CARD);
+
+    await idlePromise;
+    // 允许收口用的微任务全部落地
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // 卡片必须被 finishAICard 收口，不能留在 INPUTING 转圈状态
+    expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+  });
+
+  // 密封修复：settle 后到达的迟到 onPartialReply 不得再创建新卡片。
+  // 新卡片没有任何收口方（本轮 dispatcher 已 settle），必然孤儿转圈。
+  it("does not create a new AI card when onPartialReply arrives after the turn settled", async () => {
+    const { result, args } = await makeDispatcher();
+
+    args.onReplyStart();
+    await args.deliver({ text: "final-1" }, { kind: "final" });
+    await args.onIdle();
+
+    mockCreateAICardForTarget.mockClear();
+    mockStreamAICard.mockClear();
+
+    await result.replyOptions.onPartialReply?.({ text: "late-partial" });
+
+    expect(mockCreateAICardForTarget).not.toHaveBeenCalled();
+    expect(mockStreamAICard).not.toHaveBeenCalled();
+  });
+
+  // 密封修复 + 内容保全：settle 后经旧 dispatcher 送达的 block
+  // （steer/followup 认领回合的实际回复）应降级为普通消息，
+  // 而不是写进一张永远不会被关闭的新卡片。
+  it("delivers a late block as a plain message instead of opening a new card", async () => {
+    const { args } = await makeDispatcher();
+
+    args.onReplyStart();
+    await args.deliver({ text: "final-1" }, { kind: "final" });
+    await args.onIdle();
+
+    mockCreateAICardForTarget.mockClear();
+
+    await args.deliver({ text: "late-followup-reply" }, { kind: "block" });
+
+    expect(mockCreateAICardForTarget).not.toHaveBeenCalled();
+    expect(mockSendMessage).toHaveBeenCalled();
+    const sentText = mockSendMessage.mock.calls.at(-1)?.[2];
+    expect(String(sentText)).toContain("late-followup-reply");
+  });
+
+  // 守护超时：settle 可能永远不来（上游 run 挂死 / 收口链中无超时的调用挂住），
+  // 此时 onIdle 收口路径完全失效。watchdog 到期必须强制 finishAICard 并密封，
+  // 之后迟到的 final 降级为普通消息发出，内容不丢失。
+  it("force-finishes a stale card via watchdog and degrades a late final to a plain message", async () => {
+    vi.useFakeTimers();
+    try {
+      const { args } = await makeDispatcher();
+
+      args.onReplyStart();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockCreateAICardForTarget).toHaveBeenCalledTimes(1);
+
+      // 模拟挂死：没有 deliver、没有 onIdle，只有时间流逝
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1000);
+
+      // watchdog 强制收口，卡片不再永久转圈
+      expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+
+      // 挂死解除后迟到的 final：不得重新开卡，降级为普通消息，内容保全
+      mockSendMessage.mockClear();
+      mockCreateAICardForTarget.mockClear();
+      await args.deliver({ text: "late-final-after-watchdog" }, { kind: "final" });
+      expect(mockCreateAICardForTarget).not.toHaveBeenCalled();
+      expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+      expect(mockSendMessage).toHaveBeenCalled();
+      const sentText = mockSendMessage.mock.calls.at(-1)?.[2];
+      expect(String(sentText)).toContain("late-final-after-watchdog");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 守护超时的边界：正常收口后 watchdog 必须被清除，不得二次 finish。
+  it("watchdog does not double-finish a card that closed normally", async () => {
+    vi.useFakeTimers();
+    try {
+      const { args } = await makeDispatcher();
+
+      args.onReplyStart();
+      await vi.advanceTimersByTimeAsync(0);
+      await args.deliver({ text: "final-1" }, { kind: "final" });
+      expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // 契约修复：2026.7.x 通道契约要求在 settle 时成对调用
+  // markRunComplete() + markDispatchIdle()（参照 core dispatch.ts:695-696
+  // 与 Feishu comment-handler.ts:324-330）。wrapper 需要把 SDK 返回的
+  // markRunComplete 透传给 message-handler。
+  it("exposes markRunComplete from the underlying SDK dispatcher", async () => {
+    const sdkMarkRunComplete = vi.fn();
+    mockCreateReplyDispatcherWithTyping.mockImplementation((args: any) => {
+      (globalThis as any).__dispatcherArgs = args;
+      return {
+        dispatcher: {},
+        replyOptions: {},
+        markDispatchIdle: vi.fn(),
+        markRunComplete: sdkMarkRunComplete,
+      };
+    });
+
+    const { result } = await makeDispatcher();
+
+    expect(typeof result.markRunComplete).toBe("function");
+    result.markRunComplete();
+    expect(sdkMarkRunComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/reply-dispatcher/card-lifecycle.test.ts
+++ b/tests/reply-dispatcher/card-lifecycle.test.ts
@@ -27,6 +27,7 @@ const mockSendMessage = vi.hoisted(() => vi.fn());
 const mockSendTextMessage = vi.hoisted(() => vi.fn());
 const mockSendMarkdownMessage = vi.hoisted(() => vi.fn());
 const mockGetOapiAccessToken = vi.hoisted(() => vi.fn());
+const mockProcessLocalImages = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk", () => ({
   createReplyPrefixOptions: vi.fn(() => ({
@@ -62,7 +63,14 @@ vi.mock("../../src/services/messaging.ts", () => ({
 }));
 
 vi.mock("../../src/services/media/image.ts", () => ({
-  processLocalImages: vi.fn(async (s: string) => s),
+  processLocalImages: mockProcessLocalImages,
+}));
+
+vi.mock("../../src/services/media/index.ts", () => ({
+  processLocalImages: mockProcessLocalImages,
+  processVideoMarkers: vi.fn(async (s: string) => s),
+  processAudioMarkers: vi.fn(async (s: string) => s),
+  uploadAndReplaceFileMarkers: vi.fn(async (s: string) => s),
 }));
 
 vi.mock("../../src/services/media/video.ts", () => ({
@@ -75,6 +83,10 @@ vi.mock("../../src/services/media/audio.ts", () => ({
 
 vi.mock("../../src/services/media/file.ts", () => ({
   uploadAndReplaceFileMarkers: vi.fn(async (s: string) => s),
+}));
+
+vi.mock("../../src/services/media.ts", () => ({
+  processRawMediaPaths: vi.fn(async (s: string) => s),
 }));
 
 vi.mock("../../src/utils/token.ts", () => ({
@@ -122,6 +134,7 @@ describe("reply-dispatcher AI card lifecycle", () => {
       config: { debug: false, streaming: true },
     });
     mockGetOapiAccessToken.mockResolvedValue(null);
+    mockProcessLocalImages.mockImplementation(async (s: string) => s);
     mockCreateAICardForTarget.mockResolvedValue(CARD);
     mockStreamAICard.mockResolvedValue(undefined);
     mockFinishAICard.mockResolvedValue(undefined);
@@ -300,11 +313,15 @@ describe("reply-dispatcher AI card lifecycle", () => {
     expect(sentTexts.some((t) => t.includes("late-block"))).toBe(true);
   });
 
-  // Blocking-2（reviewer #645）：watchdog 与 closeStreaming 不能双 finish。
-  // 让卡片创建 HTTP 慢返回，onIdle 触发 closeStreaming 进入 await
-  // cardCreationPromise 的等待窗口；同时把 watchdog 到期时间推过——
-  // 若入口未清理 watchdog，就会看到两次 finishAICard 调用。
-  it("does not double-finish when watchdog fires while closeStreaming is awaiting card creation", async () => {
+  // Blocking-2（#647 review）：入口 clearCardWatchdog 盖不到目标窗口。
+  // 卡片创建在途时 watchdog 尚未装上，入口清理是空操作；await 返回后
+  // IIFE 才 arm，随后 closeStreaming 还要走完 getOapiAccessToken /
+  // processLocalImages 等媒体链路。该链路超过 CARD_WATCHDOG_TIMEOUT_MS
+  // 时 watchdog 与 closeStreaming 会各调一次 finishAICard。
+  // 旧用例在推进时钟之后才 resolveCard，推进期间 timer 未装上，对
+  // 「入口清理有/无」不敏感。此处按 review 复刻：创建在途 → onIdle →
+  // resolve 后媒体处理挂住 → 再拨过 watchdog。
+  it("does not double-finish when watchdog fires while closeStreaming is processing media", async () => {
     vi.useFakeTimers();
     try {
       let resolveCard!: (card: typeof CARD) => void;
@@ -314,28 +331,41 @@ describe("reply-dispatcher AI card lifecycle", () => {
         }),
       );
 
+      let releaseMedia!: (s: string) => void;
+      mockGetOapiAccessToken.mockResolvedValue("oapi-token");
+      mockProcessLocalImages.mockImplementation(
+        (s: string) => new Promise((resolve) => {
+          releaseMedia = () => resolve(s);
+        }),
+      );
+
       const { args } = await makeDispatcher();
 
       args.onReplyStart();
-      // 让 startStreaming 里的 armCardWatchdog 拿到 preCreatedCard 之外的路径
-      // （即真实创建路径）。这里 card 创建 Promise 尚未 resolve。
       await vi.advanceTimersByTimeAsync(0);
       expect(mockCreateAICardForTarget).toHaveBeenCalledTimes(1);
 
-      // onIdle 进入 closeStreaming：应先 clearCardWatchdog，再 await 创建完成
+      // 创建仍在途：入口 clearCardWatchdog 此时是空操作
       const idlePromise = args.onIdle();
+      await vi.advanceTimersByTimeAsync(0);
 
-      // 推过 watchdog 的到期时间；若入口没清理 timer，此时 timer 会触发
-      // forceFinishStaleCard，与稍后的 closeStreaming 各调一次 finishAICard。
-      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1000);
-
-      // 让 card 创建完成，closeStreaming 继续执行 finishAICard
+      // 创建完成 → IIFE 重新 arm watchdog → closeStreaming 进入媒体处理并挂住。
+      // 入口 clear 是空操作，必须靠 finish 单飞闭合双 finish。
       resolveCard(CARD);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockProcessLocalImages).toHaveBeenCalled();
+      expect(mockFinishAICard).not.toHaveBeenCalled();
+
+      // 媒体仍在途时拨过 watchdog：forceFinishStaleCard 先 finish 一次
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1000);
+      expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+
+      // closeStreaming 随后也会走 finish；单飞后仍只能是一次
+      releaseMedia("partial-text");
       await vi.advanceTimersByTimeAsync(0);
       await idlePromise;
       await vi.advanceTimersByTimeAsync(0);
 
-      // 只允许一次 finish：入口 clearCardWatchdog 生效
       expect(mockFinishAICard).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();

--- a/tests/reply-dispatcher/card-lifecycle.test.ts
+++ b/tests/reply-dispatcher/card-lifecycle.test.ts
@@ -342,6 +342,47 @@ describe("reply-dispatcher AI card lifecycle", () => {
     }
   });
 
+  // M1 回归：cardCreationPromise 生命周期。
+  // 旧实现只在内部 try/finally 清空 cardCreationPromise，但 asyncMode /
+  // !streamingEnabled / preCreatedCard 三条 early-return 路径不进入 try，
+  // 导致 cardCreationPromise 永远指向 stale Promise。此处用 preCreatedCard
+  // 路径验证：IIFE settle 后 gate 被清空，第二次 startStreaming 调用
+  // 走 currentCardTarget 快捷路径而非复用 stale Promise。
+  it("clears cardCreationPromise after preCreatedCard early return so next startStreaming uses currentCardTarget shortcut", async () => {
+    const preCreated = { ...CARD, cardInstanceId: "pre-created" };
+    const { args } = await makeDispatcher({ preCreatedCard: preCreated });
+
+    // onReplyStart → startStreaming → preCreatedCard early return
+    args.onReplyStart();
+    // 让 IIFE 完全 settle（.finally() 清空 gate）
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockCreateAICardForTarget).not.toHaveBeenCalled();
+
+    // closeStreaming 收口
+    await args.deliver({ text: "final-1" }, { kind: "final" });
+    await args.onIdle();
+    expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+  });
+
+  // M1 回归：card 创建同步成功（quick settle）后 closeStreaming 仍能收口。
+  // 旧实现 finally 在 IIFE settle 前清空了 cardCreationPromise，但
+  // currentCardTarget 在 finally 之前已设好，所以快路径也能过。
+  // 此测试确认 .finally() 重构后快路径不被破坏。
+  it("closes the AI card when card creation settles before onIdle (quick settle)", async () => {
+    mockCreateAICardForTarget.mockResolvedValue(CARD);
+
+    const { args } = await makeDispatcher();
+
+    args.onReplyStart();
+    // 让 card 创建 IIFE 完全 settle（mockResolvedValue 同步 resolve）
+    await new Promise((r) => setTimeout(r, 0));
+
+    // 此时 cardCreationPromise 已被 .finally() 清空，currentCardTarget 已设好
+    await args.onIdle();
+
+    expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+  });
+
   // 契约修复：2026.7.x 通道契约要求在 settle 时成对调用
   // markRunComplete() + markDispatchIdle()（参照 core dispatch.ts:695-696
   // 与 Feishu comment-handler.ts:324-330）。wrapper 需要把 SDK 返回的

--- a/tests/reply-dispatcher/card-lifecycle.test.ts
+++ b/tests/reply-dispatcher/card-lifecycle.test.ts
@@ -273,6 +273,75 @@ describe("reply-dispatcher AI card lifecycle", () => {
     }
   });
 
+  // Blocking-1（reviewer #645）：onError 必须与 onIdle 对称先密封再收口。
+  // 若只 close 不 seal，错误收口后到达的迟到 onReplyStart / onPartialReply
+  // 仍会走 startStreaming 创建一张新的孤儿卡片，永远转圈。
+  it("seals streaming on onError so late callbacks cannot create an orphan card", async () => {
+    const { result, args } = await makeDispatcher();
+
+    args.onReplyStart();
+    await args.deliver({ text: "partial-1" }, { kind: "block" });
+
+    // 触发一次错误收口
+    await args.onError(new Error("boom"), { kind: "final" });
+
+    mockCreateAICardForTarget.mockClear();
+    mockStreamAICard.mockClear();
+
+    // 错误收口之后，模拟上游继续送达的迟到回调
+    args.onReplyStart();
+    await result.replyOptions.onPartialReply?.({ text: "late-partial" });
+    await args.deliver({ text: "late-block" }, { kind: "block" });
+
+    expect(mockCreateAICardForTarget).not.toHaveBeenCalled();
+    expect(mockStreamAICard).not.toHaveBeenCalled();
+    // 迟到 block 的内容仍以普通消息送达，不丢失
+    const sentTexts = mockSendMessage.mock.calls.map((c) => String(c[2] ?? ""));
+    expect(sentTexts.some((t) => t.includes("late-block"))).toBe(true);
+  });
+
+  // Blocking-2（reviewer #645）：watchdog 与 closeStreaming 不能双 finish。
+  // 让卡片创建 HTTP 慢返回，onIdle 触发 closeStreaming 进入 await
+  // cardCreationPromise 的等待窗口；同时把 watchdog 到期时间推过——
+  // 若入口未清理 watchdog，就会看到两次 finishAICard 调用。
+  it("does not double-finish when watchdog fires while closeStreaming is awaiting card creation", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveCard!: (card: typeof CARD) => void;
+      mockCreateAICardForTarget.mockImplementation(
+        () => new Promise((resolve) => {
+          resolveCard = resolve;
+        }),
+      );
+
+      const { args } = await makeDispatcher();
+
+      args.onReplyStart();
+      // 让 startStreaming 里的 armCardWatchdog 拿到 preCreatedCard 之外的路径
+      // （即真实创建路径）。这里 card 创建 Promise 尚未 resolve。
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockCreateAICardForTarget).toHaveBeenCalledTimes(1);
+
+      // onIdle 进入 closeStreaming：应先 clearCardWatchdog，再 await 创建完成
+      const idlePromise = args.onIdle();
+
+      // 推过 watchdog 的到期时间；若入口没清理 timer，此时 timer 会触发
+      // forceFinishStaleCard，与稍后的 closeStreaming 各调一次 finishAICard。
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1000);
+
+      // 让 card 创建完成，closeStreaming 继续执行 finishAICard
+      resolveCard(CARD);
+      await vi.advanceTimersByTimeAsync(0);
+      await idlePromise;
+      await vi.advanceTimersByTimeAsync(0);
+
+      // 只允许一次 finish：入口 clearCardWatchdog 生效
+      expect(mockFinishAICard).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // 契约修复：2026.7.x 通道契约要求在 settle 时成对调用
   // markRunComplete() + markDispatchIdle()（参照 core dispatch.ts:695-696
   // 与 Feishu comment-handler.ts:324-330）。wrapper 需要把 SDK 返回的


### PR DESCRIPTION
## 解决什么问题 / What Problem This Solves

本 PR 是 #645 的 **替代提交（superset）**：包含 #645 的全部修复（AI Card final/settle 缺失与挂死收口）+ 采纳 @typefield 在 #645 review 中提出的两处 **Blocking** 修复。

- 基础上下文 / 根因分析：详见 #644
- 前序 PR：#645（review 已提出两处 Blocking，改到本 PR 一并合入更清爽）

## #645 已覆盖内容（保留）

| # | 修复 | 位置 |
|---|---|---|
| 1 | `closeStreaming` 先 `await cardCreationPromise` 再快照，消除收口与创建的竞态 | `src/reply-dispatcher.ts` |
| 2 | settle（`onIdle`）时密封 `startStreaming`：迟到 partial/`onReplyStart` 不再创建孤儿卡片 | `src/reply-dispatcher.ts` |
| 3 | 迟到 block 降级为普通消息发出，steer/followup 认领回合内容不丢失 | `src/reply-dispatcher.ts` |
| 4 | 新增卡片守护超时（watchdog，默认 10 分钟）：到期强制 `finishAICard` 并密封，覆盖上游挂死 | `src/reply-dispatcher.ts` |
| 5 | 透传并在 `onSettled` 调用 `markRunComplete`，对齐 openclaw 2026.7.x 通道契约 | `src/reply-dispatcher.ts`、`src/core/message-handler.ts` |

## 本 PR 新增（回应 #645 review Blocking）

### Blocking-1：`onError` 未 seal，错误收口后仍会开孤儿卡

`onIdle` 已在 close 前 `streamingSealed = true`，而 `onError` 只 `await closeStreaming()`。错误收口后到达的迟到 `onReplyStart` / `onPartialReply` / `block` 会重新进入 `startStreaming`，创建一张无收口方的孤儿 AI Card。

**Fix**：`onError` 与 `onIdle` 对称——先 seal 再 close。

```ts
onError: async (error, info) => {
  log.error(...);
  params.runtime.error?.(...);
  // 与 onIdle 对称：先密封再收口。
  streamingSealed = true;
  await closeStreaming();
  typingCallbacks.onIdle?.();
  await maybeSendGroupVisibleRepliesIdleNudge();
},
```

### Blocking-2：`watchdog` 与 `closeStreaming` 可能双 finish

`clearCardWatchdog()` 只在 `closeStreaming` 的 `finally`。`closeStreaming` 内部 `await cardCreationPromise` 与 `await finishAICard(...)` 期间，watchdog 计时器仍可能到期触发 `forceFinishStaleCard`，与随后的 `finishAICard` 各调一次，服务端收到重复关闭请求。

**Fix**：在 `closeStreaming` 入口、任何 `await` 之前立即 `clearCardWatchdog()`。`finally` 里的清理保留，入口清理是幂等的。

```ts
const closeStreaming: () => Promise<void> = async () => {
  // 单飞入口：在任何 await 之前先解除 watchdog。
  clearCardWatchdog();
  if (cardCreationPromise) {
    try { await cardCreationPromise; } catch { /* startStreaming 已降级 */ }
  }
  ...
};
```

## 测试 / Tests

`tests/reply-dispatcher/card-lifecycle.test.ts` 在 #645 的 6 例基础上再加 2 例并发/迟到窗口回归（原实现下 RED，补丁后 GREEN）：

- `seals streaming on onError so late callbacks cannot create an orphan card`
- `does not double-finish when watchdog fires while closeStreaming is awaiting card creation`

**结果**：
- `tests/reply-dispatcher/` + `tests/ai-card/` **51/51 通过**（#645 的 49 例 + 新增 2 例）
- `tsc --noEmit`：触及文件无新增错误（仓库既有 `accounts.ts` / `connection.ts` / `pdf-parse` 报错与本 PR 无关）
- 尚未做真机 E2E（同 #645）

## Non-blocking（留 follow-up）

来自 #645 review，本 PR 未处理，可另开 issue/PR 收敛：

- 迟到 final 隐式降级改显式分支/日志（便于运维对照 #644 判据）
- 降级 `sessionWebhook` 失败时打醒目 warn
- `CARD_WATCHDOG_TIMEOUT_MS` 可配置
- peerDep/文档同步至 openclaw >= 2026.5.x 契约

## 兼容性

- 全部改动位于 connector 侧回复分发闭包内；不改变正常回合（final 正常到达）的行为路径
- `markRunComplete` 可选调用（`?.()`），旧版 SDK 不受影响
- watchdog 定时器 `unref`，不阻止进程退出

Supersedes #645. Fixes #644.
