### PR TITLE
release: v0.8.25-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.25-beta.0] - 2026-08-19
+
+> **社区验证版本** — 修复 AI Card 在 error、缺失 settle/final 或上游挂死时可能无法结束的问题。该版本先发布到 npm `beta` 标签；经社区验证后再晋升为正式版 `v0.8.25`。详见 [Release Notes](docs/RELEASE_NOTES_V0.8.25-beta.0.md)。
+> **Community validation release** — fixes AI Cards that could remain unfinished when error, missing settle/final, or upstream hangs occur. This version is published under npm's `beta` tag before promotion to GA `v0.8.25`.
+
+### 修复 / Fixed
+
+- 🐛 **AI Card 生命周期可靠性 ([#644](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/644) / [#647](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/647))** — 收口时等待在途卡片创建完成；在 idle/error 收口前密封流式入口，迟到回调不再生成无人收口的卡片；补充 10 分钟 watchdog 覆盖上游挂死；并通过单飞保护避免 watchdog 与正常收口重复结束同一张卡片。对早返回创建路径的 promise gate 也完成清理，避免后续回合错误复用已完成的 promise。
+  **AI Card lifecycle reliability** — waits for in-flight card creation during close; seals streaming before idle/error close so late callbacks cannot create orphan cards; adds a 10-minute watchdog for upstream hangs; and single-flights card finalization to prevent watchdog/normal-close double finishes. The creation-promise gate is also cleared for early-return paths.
+
+### 升级 / Upgrade
+
+```bash
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.25-beta.0
+openclaw gateway restart
+```
+
 ## [0.8.24] - 2026-07-24
 
 晋升自 `0.8.24-beta.0` 的 GA 版本，与 beta.0 内容完全一致，经过社区验证后正式发布。详见 [Release Notes](docs/RELEASE_NOTES_V0.8.24.md)。  

--- a/docs/RELEASE_NOTES_V0.8.25-beta.0.md
+++ b/docs/RELEASE_NOTES_V0.8.25-beta.0.md
@@ -1,0 +1,47 @@
+# Release Notes - v0.8.25-beta.0
+
+> **社区验证版本** — 本版本聚焦 AI Card 异常收口可靠性，先发布到 npm `beta` 标签，不会替换稳定用户使用的 `latest`（`0.8.24`）。计划在社区验证完成后，以完全相同的源码晋升为正式版 `v0.8.25`。
+> **Community validation release** — This release focuses on reliable AI Card completion. It is published under npm's `beta` tag and does not replace the stable `latest` (`0.8.24`). After community validation, the exact same source will be promoted to GA `v0.8.25`.
+
+## 🎯 修复的问题 / What is fixed
+
+当上游没有按预期发送 `final` 或 `settle`，或者回合在创建卡片期间发生 error/hang 时，AI Card 过去可能保持在输入中，或在极端竞态下被重复结束。本版本修复这些生命周期窗口。
+
+When upstream omits `final` or `settle`, or a turn errors/hangs while a card is being created, an AI Card could previously remain in its input state or, in edge races, be finalized twice. This release closes those lifecycle windows.
+
+## 🐛 修复详情 / Fixes
+
+### AI Card 生命周期收口 ([#644](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/644) / [#647](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/647))
+
+- `closeStreaming()` 会等待在途卡片创建完成后再取快照并收口，消除创建与收口的竞态。
+- `onIdle` 与 `onError` 会先密封流式入口；迟到的回调不会再生成没有关闭方的孤儿卡片。
+- 新增默认 10 分钟的卡片 watchdog；上游挂死或永不 settle 时，卡片会被强制结束并密封。
+- 用单飞保护统一 watchdog 与正常收口路径，确保同一张卡只会调用一次 `finishAICard`。
+- 所有 `startStreaming` 早返回路径都会释放创建 promise gate，避免后续回合误复用已完成的 promise。
+- 收口时会调用可选的 `markRunComplete`，对齐较新的 OpenClaw channel 生命周期契约，同时保持旧版兼容。
+
+## 🧪 验证 / Verification
+
+- 覆盖回复分发器与 AI Card 的回归测试：error 收口密封、watchdog 与正常收口并发、早返回 promise 清理、快速 settle 等场景。
+- 发布前会执行 TypeScript 类型检查、全部 Vitest 测试、构建与 npm 打包产物检查。
+- 尚未进行真实钉钉环境的端到端验证；因此本版本先作为 beta 发布。
+
+## 📦 安装与反馈 / Install and feedback
+
+```bash
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.25-beta.0
+openclaw gateway restart
+```
+
+遇到问题请在 [Issues](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues) 报告，并附上 connector 与 OpenClaw 版本、场景、以及脱敏后的相关日志。
+
+## ⏭️ 后续节奏 / Next steps
+
+1. 由受影响场景的用户安装 beta，验证错误、长任务和上游无 final/settle 时卡片都能正常结束。
+2. 观察期内无阻塞回归后，将不改源码地把版本晋升为 `0.8.25`，并把 npm `latest` 指向正式版。
+
+## 🔗 相关链接 / Related links
+
+- [PR #647](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/647)
+- [Issue #644](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/644)
+- [完整变更日志 / Full changelog](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/CHANGELOG.md)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.8.24",
+  "version": "0.8.25-beta.0",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "author": "DingTalk Real Team",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.8.24",
+  "version": "0.8.25-beta.0",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## 发布内容\n\n发布 #647 的 AI Card 生命周期可靠性修复为 npm beta：error/idle 收口密封、缺失 settle/final 的 watchdog、结束单飞保护，以及创建 promise gate 清理。\n\n## 版本与渠道\n\n- npm 包：@dingtalk-real-ai/dingtalk-connector@0.8.25-beta.0\n- npm 标签：beta（不改变 latest 的 0.8.24）\n- 完成社区验证后，再以相同源码晋升 v0.8.25。\n\n## 验证\n\n- Node v24.19.0：npm run type-check\n- Node v24.19.0：npm run test:all\n- Node v24.19.0：npm run build\n- Node v24.19.0：npm pack --dry-run --json\n- git diff --check\n\n## 风险与回滚\n\n- 未做真机钉钉 E2E，因此只发布 beta。\n- 如发现阻塞问题，停止 beta 推广；npm 已发布的版本不可覆盖，需发布一个新的 beta 修复版本。\n\nRefs #644 #647